### PR TITLE
adding build step for node app

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,9 @@ jobs:
 
   test-web:
     runs-on: ubuntu-latest
-    needs: test
+    defaults:
+      run:
+        working-directory: flowfile_frontend
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,7 +68,7 @@ jobs:
           # Start the preview server in the background
           npm run preview:web &
           # Wait for the server to fully start
-          sleep 5
+          sleep 10
           # Verify that the server responds with a 200 OK on port 4173
           if ! curl -sI http://localhost:4173 | grep -q "200 OK"; then
             echo "Port 4173 is not available or did not return 200 OK"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,6 @@ jobs:
           - python-version: "3.11"
           - python-version: "3.12"
             allow_failure: true
-
     steps:
       - uses: actions/checkout@v4
 
@@ -44,3 +43,32 @@ jobs:
 
       - name: Run pytest for flowfile_core
         run: poetry run pytest flowfile_core/tests --disable-warnings
+
+  test-web:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Node Dependencies
+        run: npm ci
+
+      - name: Build Web Version
+        run: npm run build:web
+
+      - name: Run Vite Preview and Check Port Availability
+        run: |
+          # Start the preview server in the background
+          npm run preview:web &
+          # Wait for the server to fully start
+          sleep 5
+          # Verify that the server responds with a 200 OK on port 4173
+          if ! curl -sI http://localhost:4173 | grep -q "200 OK"; then
+            echo "Port 4173 is not available or did not return 200 OK"
+            exit 1
+          fi


### PR DESCRIPTION
This MR updates the CI pipeline by adding a new job called **test-web**. The job:

- Builds the frontend with `npm run build:web`.
- Starts the Vite preview server using `npm run preview:web`.
- Waits briefly and checks that the preview server on port 4173 returns a "200 OK" response.

This verifies that the web build is successful and the preview server is accessible.
