### PR TITLE
Feature/improve stability join

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
@@ -110,7 +110,7 @@ class FlowDataEngine:
     # flow_id: int = None  # TODO: Implement flow_id
 
     def __init__(self,
-                 raw_data: Union[List[Dict], List[Any], 'ParquetFile', pl.DataFrame, pl.LazyFrame, input_schema.RawData] = None,
+                 raw_data: Union[List[Dict], List[Any], Dict[str, Any], 'ParquetFile', pl.DataFrame, pl.LazyFrame, input_schema.RawData] = None,
                  path_ref: str = None,
                  name: str = None,
                  optimize_memory: bool = True,
@@ -187,12 +187,13 @@ class FlowDataEngine:
             self.initialize_empty_fl()
         lengths = [len(v) if isinstance(v, (list, tuple)) else 1 for v in data.values()]
 
-        if len(set(lengths)) == 1 and lengths[0]>1:
+        if len(set(lengths)) == 1 and lengths[0] > 1:
             self.number_of_records = lengths[0]
             self.data_frame = pl.DataFrame(data)
         else:
             self.number_of_records = 1
             self.data_frame = pl.DataFrame([data])
+        self.lazy = True
 
     def _handle_raw_data_format(self, raw_data: input_schema.RawData):
         """Create a FlowDataEngine from a RawData object."""
@@ -481,7 +482,10 @@ class FlowDataEngine:
         return self.data_frame.to_dicts()
 
     def to_dict(self) -> Dict[str, List]:
-        return self.data_frame.collect(engine="streaming" if self._streamable else "auto").to_dict(as_series=False)
+        if self.lazy:
+            return self.data_frame.collect(engine="streaming" if self._streamable else "auto").to_dict(as_series=False)
+        else:
+            return self.data_frame.to_dict(as_series=False)
 
     @classmethod
     def create_from_external_source(cls, external_source: ExternalDataSource) -> "FlowDataEngine":

--- a/flowfile_core/flowfile_core/schemas/transform_schema.py
+++ b/flowfile_core/flowfile_core/schemas/transform_schema.py
@@ -126,6 +126,11 @@ class SelectInputs:
     def remove_select_input(self, old_key: str):
         self.renames = [rename for rename in self.renames if rename.old_name != old_key]
 
+    def unselect_field(self, old_key: str):
+        for rename in self.renames:
+            if old_key == rename.old_name:
+                rename.keep = False
+
     @classmethod
     def create_from_list(cls, col_list: str):
         return cls([SelectInput(c) for c in col_list])


### PR DESCRIPTION
This pull request introduces significant enhancements to the `FlowDataEngine` class and its associated schema handling in the `flowfile_core` module. The changes focus on improving join operations, adding support for more flexible schema transformations, and refining data handling logic. Key updates include the addition of helper functions for join key manipulation, improvements to lazy evaluation, and the introduction of new schema constructs like `JoinInputs` and `FullJoinKeyResponse`.

### Enhancements to join operations:

* Added helper functions `_rename_df_table_for_join`, `get_undo_rename_mapping_join`, and `_handle_duplication_join_keys` to streamline join key renaming and duplication handling in the `FlowDataEngine` class. These functions ensure proper mapping and cleanup of join keys during operations. (`flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py`, [[1]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR55-R91) [[2]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR1119-R1149)
* Modified the `join` method in `FlowDataEngine` to incorporate new helper functions, handle semi/anti joins, and improve column cleanup logic after join operations. (`flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py`, [[1]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aL1054-L1060) [[2]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR1119-R1149)

### Improvements to schema handling:

* Introduced new constructs `JoinInputs`, `JoinKeyRenameResponse`, and `FullJoinKeyResponse` in `transform_schema.py` to better manage join-related schema transformations. These additions provide a structured approach to handling join key renames and mappings. (`flowfile_core/flowfile_core/schemas/transform_schema.py`, [[1]](diffhunk://#diff-00bdc9357ec0617a3eb0b84361ea9585c7adaa10bc178a849f5b82020e9f8771R25-R48) [[2]](diffhunk://#diff-00bdc9357ec0617a3eb0b84361ea9585c7adaa10bc178a849f5b82020e9f8771R165-R195)
* Added methods like `unselect_field` and `get_join_key_renames` to `SelectInputs` and `JoinInputs` classes, enabling more granular control over schema selection and join key manipulation. (`flowfile_core/flowfile_core/schemas/transform_schema.py`, [[1]](diffhunk://#diff-00bdc9357ec0617a3eb0b84361ea9585c7adaa10bc178a849f5b82020e9f8771R151-R155) [[2]](diffhunk://#diff-00bdc9357ec0617a3eb0b84361ea9585c7adaa10bc178a849f5b82020e9f8771L271-R338)

### Enhancements to lazy evaluation:

* Updated the `_handle_dict_input` method in `FlowDataEngine` to set the `lazy` attribute to `True`, ensuring lazy evaluation for dictionary-based inputs. (`flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py`, [flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.pyR233](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR233))
* Refined the `to_dict` method to handle lazy data frames differently, using the appropriate collection engine based on the `lazy` attribute. (`flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py`, [flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.pyR522-R525](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR522-R525))

### Test additions:

* Added a new pytest fixture `join_df` to facilitate testing of join operations on sample data frames. (`flowfile_core/tests/flowfile/flowfile_table/test_flowfilePolars.py`, [flowfile_core/tests/flowfile/flowfile_table/test_flowfilePolars.pyR64-R68](diffhunk://#diff-e584b0152c061b8554e75c3f82c884b9c579d7baf8a4cb74fa3e94234f0efb8cR64-R68))