### PR TITLE
fixate version duckdb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ fastapi = "~0.115.2"
 uvicorn = "~0.32.0"
 pydantic = "~2.9.2"
 databases = "~0.9.0"
+duckdb = [
+    { version = "1.3.0", markers = "sys_platform == 'win32'" },
+    { version = ">=1.3.0", markers = "sys_platform != 'win32'" }
+]
 passlib = "~1.7.4"
 pyarrow = "^18.0.0"
 python-multipart = "~0.0.12"


### PR DESCRIPTION
This pull request updates the `pyproject.toml` file to include platform-specific dependencies for `duckdb`. The change ensures compatibility by specifying different versions of `duckdb` based on the operating system.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R27-R30): Added `duckdb` dependency with version `1.3.0` for Windows (`sys_platform == 'win32'`) and version `>=1.3.0` for non-Windows platforms (`sys_platform != 'win32'`).