### PR TITLE
Fix ref in links html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -383,7 +383,7 @@
                 Build data pipelines visually, transform data using powerful nodes, and analyze results - all without writing code.
             </p>
             <div class="hero-buttons fade-in">
-                <a href="quickstart/" class="hero-button hero-button-primary">
+                <a href="quickstart.html" class="hero-button hero-button-primary">
                     <span>Get Started</span>
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
@@ -410,7 +410,7 @@
         <p class="section-subtitle">Build powerful data pipelines without writing code, powered by the speed of Polars</p>
 
         <div class="features-grid">
-            <a href="flows/building/" class="feature-card fade-in feature-link">
+            <a href="flows/building.html" class="feature-card fade-in feature-link">
                 <div class="feature-icon">🎨</div>
                 <h3 class="feature-title">Visual Pipeline Design</h3>
                 <p class="feature-description">
@@ -420,7 +420,7 @@
                 <span class="feature-arrow">→</span>
             </a>
 
-            <a href="guides/technical_architecture" class="feature-card fade-in feature-link">
+            <a href="guides/technical_architecture.html" class="feature-card fade-in feature-link">
                 <div class="feature-icon">⚡</div>
                 <h3 class="feature-title">Blazing Fast Performance</h3>
                 <p class="feature-description">
@@ -430,7 +430,7 @@
                 <span class="feature-arrow">→</span>
             </a>
 
-            <a href="guides/code_generator/" class="feature-card fade-in feature-link">
+            <a href="guides/code_generator.html" class="feature-card fade-in feature-link">
                 <div class="feature-icon">🔄</div>
                 <h3 class="feature-title">Flow to Code</h3>
                 <p class="feature-description">
@@ -440,7 +440,7 @@
                 <span class="feature-arrow">→</span>
             </a>
 
-            <a href="guides/database_connectivity/" class="feature-card fade-in feature-link">
+            <a href="guides/database_connectivity.html" class="feature-card fade-in feature-link">
                 <div class="feature-icon">🔌</div>
                 <h3 class="feature-title">Database Integration</h3>
                 <p class="feature-description">
@@ -450,7 +450,7 @@
                 <span class="feature-arrow">→</span>
             </a>
 
-            <a href="guides/flowfile_frame_api/" class="feature-card fade-in feature-link">
+            <a href="guides/flowfile_frame_api.html" class="feature-card fade-in feature-link">
                 <div class="feature-icon">🐍</div>
                 <h3 class="feature-title">Code to Flow</h3>
                 <p class="feature-description">
@@ -507,7 +507,7 @@ open_graph_in_editor(result.flow_graph)</code></pre>
     <section style="text-align: center; padding: 4rem 2rem; background: var(--md-code-bg-color);">
         <h2 class="section-title">Ready to Transform Your Data Workflow?</h2>
         <div class="hero-buttons" style="margin-top: 2rem;">
-            <a href="quickstart/" class="hero-button hero-button-primary" style="background: var(--md-primary-fg-color); color: white;">
+            <a href="quickstart.html" class="hero-button hero-button-primary" style="background: var(--md-primary-fg-color); color: white;">
                 Start Building
             </a>
             <a href="guides/" class="hero-button hero-button-secondary" style="border-color: var(--md-primary-fg-color); color: var(--md-primary-fg-color);">


### PR DESCRIPTION
This pull request updates the documentation links in `docs/index.html` to ensure consistency by appending `.html` to all relative URLs. This change improves the reliability of navigation within the documentation.

### Documentation Link Updates:

* Updated the "Get Started" button link from `quickstart/` to `quickstart.html` in the hero section.
* Updated feature card links to include `.html`:
  - Changed `flows/building/` to `flows/building.html` for "Visual Pipeline Design."
  - Changed `guides/technical_architecture` to `guides/technical_architecture.html` for "Blazing Fast Performance."
  - Changed `guides/code_generator/` to `guides/code_generator.html` for "Flow to Code."
  - Changed `guides/database_connectivity/` to `guides/database_connectivity.html` for "Database Integration."
  - Changed `guides/flowfile_frame_api/` to `guides/flowfile_frame_api.html` for "Code to Flow."
* Updated the "Start Building" button link in the "Ready to Transform Your Data Workflow?" section from `quickstart/` to `quickstart.html`.