### PR TITLE
Adding print_tree method to FlowGraph

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -269,6 +269,24 @@ class FlowGraph:
         settings_str = "  -" + '\n  -'.join(f"{k}: {v}" for k, v in self.flow_settings)
         return f"FlowGraph(\nNodes: {self._node_db}\n\nSettings:\n{settings_str}"
 
+    def print_tree(self):
+        """
+        Print flow_graph as a tree.
+        """
+
+        str_repr = result.flow_graph._node_db
+        last_key = len(str_repr.keys())
+        tree= ""
+
+        for k, v in str_repr.items():
+            operation = str(v).split("(")[1][:-1].replace("_", " ").title()
+            tree += str(operation) + " (id=" + str(k) + "):" 
+            # This is still missing the operation type. Need to check how to access FlowFile object
+            if k < last_key:
+                tree += "\n" + "# " + "\t"*(k-1) + "|___ "
+
+        return print(tree)
+        
     def get_nodes_overview(self):
         output = []
         for v in self._node_db.values():


### PR DESCRIPTION
Adding `print_tree` method to FlowGraph class.

Couple of notes :

1. Is there anyway I can access `FlowFile`attributes? Not sure if having FlowGraph inheriting from FlowFile would help here. Basically this is what is stopping me from accessing the operation type at each node (e.g: Filter, Select etc.)

2. I couldn't find the symbols that would match what was described on the issue yet... 