### PR TITLE
Fix if the right select is not selected but renamed

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
@@ -1500,12 +1500,10 @@ class FlowDataEngine:
         verify_join_select_integrity(join_input, left_columns=self.columns, right_columns=other.columns)
         if not verify_join_map_integrity(join_input, left_columns=self.schema, right_columns=other.schema):
             raise Exception('Join is not valid by the data fields')
-
         if auto_generate_selection:
             join_input.auto_rename()
         left = self.data_frame.select(get_select_columns(join_input.left_select.renames)).rename(join_input.left_select.rename_table)
         right = other.data_frame.select(get_select_columns(join_input.right_select.renames)).rename(join_input.right_select.rename_table)
-
         if verify_integrity and join_input.how != 'right':
             n_records = get_join_count(left, right, left_on_keys=join_input.left_join_keys,
                                        right_on_keys=join_input.right_join_keys, how=join_input.how)

--- a/flowfile_core/flowfile_core/schemas/transform_schema.py
+++ b/flowfile_core/flowfile_core/schemas/transform_schema.py
@@ -134,7 +134,7 @@ class SelectInputs:
 
     @property
     def rename_table(self):
-        return {v.old_name: v.new_name for v in self.renames if v.is_available}
+        return {v.old_name: v.new_name for v in self.renames if v.is_available and (v.keep or v.join_key)}
 
     def get_select_cols(self, include_join_key: bool = True):
         return [v.old_name for v in self.renames if v.keep or (v.join_key and include_join_key)]

--- a/flowfile_core/tests/flowfile/flowfile_table/test_flow_data_engine.py
+++ b/flowfile_core/tests/flowfile/flowfile_table/test_flow_data_engine.py
@@ -363,9 +363,6 @@ def test_join_input_overlapping_columns():
     output = left_data.join(other=right_data, join_input=join_input, auto_generate_selection=True, verify_integrity=False)
 
 
-
-
-
 def test_join_no_selection(join_df: FlowDataEngine):
     join_input = transform_schema.JoinInput(
         join_mapping='id',
@@ -408,6 +405,21 @@ def test_join_non_selecting_join_keys_right(join_df: FlowDataEngine):
     expected = FlowDataEngine({'category': 'A',
                                'category_right': 'A'})
     result.assert_equal(expected)
+
+
+def test_join_non_selecting_renamed_keys_right(join_df: FlowDataEngine):
+    join_input = transform_schema.JoinInput(
+        join_mapping='id',
+        left_select=[transform_schema.SelectInput(old_name='id', keep=False),
+                     transform_schema.SelectInput('category')],
+        right_select=[transform_schema.SelectInput(old_name='id', keep=False, new_name="id_right"),
+                      transform_schema.SelectInput('category', keep=False, new_name="category_right")],
+        how='left'
+    )
+    right_df = join_df.get_sample(1)
+    result = join_df.join(other=right_df, join_input=join_input, auto_generate_selection=True,
+                          verify_integrity=False)
+    result.assert_equal(join_df.select_columns("category"))
 
 
 def test_join_select_join_key_right(join_df: FlowDataEngine):


### PR DESCRIPTION
This pull request improves the handling of column renaming and selection during join operations, ensuring that only relevant columns are renamed and tested. The changes also add a new test to verify correct behavior when join keys are renamed but not selected.

Enhancements to join column renaming and selection:

* Updated the `rename_table` property in `transform_schema.py` to only include columns that are either kept or are join keys, preventing unnecessary renaming of columns that are not part of the output.
* Cleaned up whitespace and removed redundant blank lines in the `join` method implementation for better readability.

Testing improvements:

* Added a new test, `test_join_non_selecting_renamed_keys_right`, to ensure correct handling when join keys are renamed but not selected, improving test coverage for edge cases in join operations.
* Removed unnecessary blank lines in the test file to improve code clarity.