### PR TITLE
Fix path/file parameter in write/sink methods

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/utils.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/utils.py
@@ -103,9 +103,9 @@ def execute_write_method(
         logger.info("Writing as csv file")
         if write_mode == "append":
             with open(path, "ab") as f:
-                write_method(path=f, separator=delimiter, quote_style="always")
+                write_method(file=f, separator=delimiter, quote_style="always")
         else:
-            write_method(path=path, separator=delimiter, quote_style="always")
+            write_method(file=path, separator=delimiter, quote_style="always")
     elif data_type == "parquet":
         logger.info("Writing as parquet file")
         write_method(path)

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/utils.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/utils.py
@@ -103,9 +103,9 @@ def execute_write_method(
         logger.info("Writing as csv file")
         if write_mode == "append":
             with open(path, "ab") as f:
-                write_method(file=f, separator=delimiter, quote_style="always")
+                write_method(f, separator=delimiter, quote_style="always")
         else:
-            write_method(file=path, separator=delimiter, quote_style="always")
+            write_method(path, separator=delimiter, quote_style="always")
     elif data_type == "parquet":
         logger.info("Writing as parquet file")
         write_method(path)


### PR DESCRIPTION
#406 shows issues with opening a file that was produced in version 0.7.3 in 0.8.1. Part of the problems can be explained by the parameter changes caused by the new Polars version used in 0.8.1.

When writing falls back to the collect().write_{} methods in the `local` mode, it uses an unsupported parameter `path`. This should be fixed for the write methods to `file`. 