### PR TITLE
Bugfix/db connection schedule in docker model

### DIFF
--- a/flowfile/flowfile/__main__.py
+++ b/flowfile/flowfile/__main__.py
@@ -39,8 +39,12 @@ def run_flow(flow_path: str, param_overrides: list[str] | None = None, run_id: i
 
     try:
         from flowfile_core.auth.utils import get_local_user_id
+        from shared.run_completion import get_run_user_id
 
-        flow = open_flow(path, user_id=get_local_user_id())
+        user_id = get_run_user_id(run_id) if run_id is not None else None
+        if user_id is None:
+            user_id = get_local_user_id()
+        flow = open_flow(path, user_id=user_id)
     except Exception as e:
         print(f"Error loading flow: {e}", file=sys.stderr)
         _complete_run_if_needed(run_id, success=False, nodes_completed=0)

--- a/flowfile_core/Dockerfile
+++ b/flowfile_core/Dockerfile
@@ -27,6 +27,7 @@ COPY pyproject.toml poetry.lock* ./
 
 # Install dependencies AND strip in the same layer (in builder)
 RUN poetry install --only=main --no-root && \
+    pip install --no-cache-dir psycopg2-binary==2.9.9 pymysql==1.1.0 && \
     rm -rf $POETRY_CACHE_DIR && \
     # Strip debug symbols from compiled libraries
     find /usr/local/lib/python3.12/site-packages -name "*.so" -exec strip --strip-debug {} \; 2>/dev/null || true && \

--- a/flowfile_core/flowfile_core/alembic/versions/006_normalize_run_type.py
+++ b/flowfile_core/flowfile_core/alembic/versions/006_normalize_run_type.py
@@ -1,0 +1,33 @@
+"""Normalize legacy flow_runs.run_type values.
+
+Early versions persisted the flow-engine's run kind (``fetch_one``,
+``full_run``, ``init``) into the catalog ``flow_runs.run_type`` column,
+which is meant for provenance (``in_designer_run``, ``scheduled``,
+``manual``, ``on_demand``). Those stale rows now fail Pydantic validation
+on ``GET /catalog/runs``. Remap them to ``in_designer_run``, which is the
+only context in which the leak occurred.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-04-21
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE flow_runs SET run_type = 'in_designer_run' "
+        "WHERE run_type IN ('full_run', 'fetch_one', 'init')"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/flowfile_core/flowfile_core/catalog/repository.py
+++ b/flowfile_core/flowfile_core/catalog/repository.py
@@ -21,6 +21,7 @@ from flowfile_core.database.models import (
     FlowRun,
     FlowSchedule,
     GlobalArtifact,
+    RunType,
     ScheduleTriggerTable,
     TableFavorite,
 )
@@ -100,7 +101,7 @@ class CatalogRepository(Protocol):
         self,
         registration_id: int | None = None,
         schedule_id: int | None = None,
-        run_type: str | None = None,
+        run_type: RunType | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[FlowRun]: ...
@@ -113,14 +114,14 @@ class CatalogRepository(Protocol):
         self,
         registration_id: int | None = None,
         schedule_id: int | None = None,
-        run_type: str | None = None,
+        run_type: RunType | None = None,
     ) -> int: ...
 
     def count_runs_by_status(
         self,
         registration_id: int | None = None,
         schedule_id: int | None = None,
-        run_type: str | None = None,
+        run_type: RunType | None = None,
     ) -> dict[str, int]: ...
 
     # -- Favorites -----------------------------------------------------------
@@ -433,7 +434,7 @@ class SQLAlchemyCatalogRepository:
         self,
         registration_id: int | None = None,
         schedule_id: int | None = None,
-        run_type: str | None = None,
+        run_type: RunType | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[FlowRun]:
@@ -461,7 +462,7 @@ class SQLAlchemyCatalogRepository:
         self,
         registration_id: int | None = None,
         schedule_id: int | None = None,
-        run_type: str | None = None,
+        run_type: RunType | None = None,
     ) -> int:
         q = self._db.query(FlowRun)
         if registration_id is not None:
@@ -476,7 +477,7 @@ class SQLAlchemyCatalogRepository:
         self,
         registration_id: int | None = None,
         schedule_id: int | None = None,
-        run_type: str | None = None,
+        run_type: RunType | None = None,
     ) -> dict[str, int]:
         from sqlalchemy import case, func
 

--- a/flowfile_core/flowfile_core/catalog/service.py
+++ b/flowfile_core/flowfile_core/catalog/service.py
@@ -61,6 +61,7 @@ from flowfile_core.database.models import (
     FlowRun,
     FlowSchedule,
     GlobalArtifact,
+    RunType,
     TableFavorite,
 )
 from flowfile_core.flowfile.flow_data_engine.subprocess_operations.subprocess_operations import (
@@ -836,7 +837,7 @@ class CatalogService:
         self,
         registration_id: int | None = None,
         schedule_id: int | None = None,
-        run_type: str | None = None,
+        run_type: RunType | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> PaginatedFlowRuns:
@@ -906,7 +907,7 @@ class CatalogService:
         flow_path: str | None,
         user_id: int,
         number_of_nodes: int,
-        run_type: str = "in_designer_run",
+        run_type: RunType,
         flow_snapshot: str | None = None,
     ) -> FlowRun:
         """Record a new flow run start."""
@@ -967,7 +968,7 @@ class CatalogService:
         success: bool,
         nodes_completed: int,
         number_of_nodes: int,
-        run_type: str = "in_designer_run",
+        run_type: RunType,
         node_results_json: str | None = None,
         flow_snapshot: str | None = None,
     ) -> FlowRun:
@@ -2619,7 +2620,7 @@ class CatalogService:
         self,
         flow: FlowRegistration,
         user_id: int,
-        run_type: str,
+        run_type: RunType,
         schedule_id: int | None = None,
     ) -> FlowRun:
         """Create a FlowRun record and spawn the subprocess.

--- a/flowfile_core/flowfile_core/database/migration.py
+++ b/flowfile_core/flowfile_core/database/migration.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.engine import Engine
 
@@ -54,9 +56,48 @@ def _catalog_db_exists() -> bool:
     return False
 
 
+def _ensure_known_revision(cfg: Config) -> None:
+    """Re-stamp the catalog DB to the local head if it points at an unknown revision.
+
+    A DB stamped at a revision missing from the local migration scripts (e.g.
+    after switching back to an older branch) would crash ``command.upgrade``.
+    Schema artifacts from the unknown revision are not reverted — only the
+    ``alembic_version`` pointer is corrected so startup can proceed.
+    """
+    engine = create_engine(cfg.get_main_option("sqlalchemy.url"))
+    try:
+        if not inspect(engine).has_table("alembic_version"):
+            return
+        with engine.connect() as conn:
+            current = MigrationContext.configure(conn).get_current_revision()
+        if current is None:
+            return
+
+        script = ScriptDirectory.from_config(cfg)
+        try:
+            script.get_revision(current)
+            return
+        except Exception:
+            pass
+
+        head = script.get_current_head()
+        logger.warning(
+            "Catalog DB stamped at unknown revision '%s' (not in local migration "
+            "scripts). Rolling back stamp to last known head '%s'. Schema changes "
+            "from the unknown revision are NOT reverted; manual cleanup may be "
+            "required if columns/tables conflict.",
+            current,
+            head,
+        )
+        command.stamp(cfg, head, purge=True)
+    finally:
+        engine.dispose()
+
+
 def run_alembic_upgrade() -> None:
     """Run all pending Alembic migrations up to *head*."""
     cfg = _get_alembic_config()
+    _ensure_known_revision(cfg)
     command.upgrade(cfg, "head")
     logger.info("Alembic migrations applied successfully")
 

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -2714,6 +2714,9 @@ class FlowGraph:
                 fields=node_database_reader.fields,
             )
 
+            # TODO: centralize this local SQL read with flowfile_worker's
+            # /store_database_read_result path — both call pl.read_database_uri
+            # and have drifted in shape (see schema_callback below too).
             if self.execution_location == "local":
                 local_source = SqlSource(
                     connection_string=sql_utils.construct_sql_uri(
@@ -2724,7 +2727,7 @@ class FlowGraph:
                         username=database_connection.username,
                         password=decrypt_secret(encrypted_password) if encrypted_password else None,
                     ),
-                    query=sql_source.query,
+                    query=None if database_settings.query_mode == "table" else database_settings.query,
                     table_name=database_settings.table_name,
                     schema_name=database_settings.schema_name,
                     fields=node_database_reader.fields,

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -2733,6 +2733,7 @@ class FlowGraph:
                     fields=node_database_reader.fields,
                 )
                 fl = FlowDataEngine(local_source.get_pl_df())
+                fl.lazy = True
                 node_database_reader.fields = [c.get_minimal_field_info() for c in fl.schema]
                 return fl
 

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -2713,6 +2713,26 @@ class FlowGraph:
                 schema_name=database_settings.schema_name,
                 fields=node_database_reader.fields,
             )
+
+            if self.execution_location == "local":
+                local_source = SqlSource(
+                    connection_string=sql_utils.construct_sql_uri(
+                        database_type=database_connection.database_type,
+                        host=database_connection.host,
+                        port=database_connection.port,
+                        database=database_connection.database,
+                        username=database_connection.username,
+                        password=decrypt_secret(encrypted_password) if encrypted_password else None,
+                    ),
+                    query=sql_source.query,
+                    table_name=database_settings.table_name,
+                    schema_name=database_settings.schema_name,
+                    fields=node_database_reader.fields,
+                )
+                fl = FlowDataEngine(local_source.get_pl_df())
+                node_database_reader.fields = [c.get_minimal_field_info() for c in fl.schema]
+                return fl
+
             database_external_read_settings = (
                 sql_models.DatabaseExternalReadSettings.create_from_from_node_database_reader(
                     node_database_reader=node_database_reader,

--- a/flowfile_core/flowfile_core/main.py
+++ b/flowfile_core/flowfile_core/main.py
@@ -248,8 +248,12 @@ def _run_flow_cli(flow_path: str, run_id: int) -> int:
     _cli_logger.debug("Loading flow from: %s", flow_path)
     try:
         from flowfile_core.auth.utils import get_local_user_id
+        from shared.run_completion import get_run_user_id
 
-        flow = open_flow(path, user_id=get_local_user_id())
+        user_id = get_run_user_id(run_id) if run_id is not None else None
+        if user_id is None:
+            user_id = get_local_user_id()
+        flow = open_flow(path, user_id=user_id)
     except Exception as e:
         _cli_logger.exception("Error loading flow: %s", e)
         _complete_run(run_id, success=False, nodes_completed=0)

--- a/flowfile_core/flowfile_core/routes/catalog.py
+++ b/flowfile_core/flowfile_core/routes/catalog.py
@@ -42,7 +42,7 @@ from flowfile_core.catalog import (
     TableNotFoundError,
 )
 from flowfile_core.database.connection import get_db
-from flowfile_core.database.models import SchedulerLock
+from flowfile_core.database.models import RunType, SchedulerLock
 from flowfile_core.fileExplorer import validate_path_under_cwd
 from flowfile_core.flowfile.utils import create_unique_id
 from flowfile_core.scheduler import FlowScheduler, get_scheduler, set_scheduler
@@ -313,7 +313,7 @@ def list_flow_artifacts(
 def list_runs(
     registration_id: int | None = None,
     schedule_id: int | None = None,
-    run_type: str | None = None,
+    run_type: RunType | None = None,
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
     service: CatalogService = Depends(get_catalog_service),

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -341,7 +341,7 @@ def _run_and_track(flow, user_id: int | None):
                     success=run_info.success,
                     nodes_completed=run_info.nodes_completed,
                     number_of_nodes=run_info.number_of_nodes,
-                    run_type=run_info.run_type,
+                    run_type="in_designer_run",
                     node_results_json=node_results,
                     flow_snapshot=snapshot_yaml,
                 )

--- a/flowfile_core/tests/test_migration.py
+++ b/flowfile_core/tests/test_migration.py
@@ -485,3 +485,49 @@ class TestTopologicalSort:
         tables = {"catalog_namespaces"}
         order = _compute_table_order(inspector, tables)
         assert order == ["catalog_namespaces"]
+
+
+# Unknown-revision rollback
+
+
+class TestUnknownRevisionRollback:
+    def test_unknown_revision_rolled_back_to_head(self, tmp_path, monkeypatch, capsys):
+        """DB stamped at a revision unknown to local scripts should be re-stamped to head."""
+        db_path = tmp_path / "catalog.db"
+        _run_migration(db_path, monkeypatch)
+
+        engine = create_engine(f"sqlite:///{db_path}")
+        with engine.connect() as conn:
+            conn.execute(text("UPDATE alembic_version SET version_num = '999fakeXYZ'"))
+            conn.commit()
+        engine.dispose()
+
+        _run_migration(db_path, monkeypatch)
+        captured = capsys.readouterr()
+
+        from alembic.script import ScriptDirectory
+
+        from flowfile_core.database.migration import _get_alembic_config
+
+        head = ScriptDirectory.from_config(_get_alembic_config()).get_current_head()
+
+        engine = create_engine(f"sqlite:///{db_path}")
+        with engine.connect() as conn:
+            ver = conn.execute(text("SELECT version_num FROM alembic_version")).scalar()
+        engine.dispose()
+
+        assert ver == head
+        assert "999fakeXYZ" in captured.err
+
+    def test_no_alembic_version_table_is_noop(self, tmp_path, monkeypatch):
+        """DB file exists but lacks alembic_version → upgrade runs from base, no crash."""
+        db_path = tmp_path / "catalog.db"
+        engine = create_engine(f"sqlite:///{db_path}")
+        with engine.connect() as conn:
+            conn.execute(text("CREATE TABLE marker (id INTEGER)"))
+            conn.commit()
+        engine.dispose()
+
+        _run_migration(db_path, monkeypatch)
+
+        assert "alembic_version" in _get_tables(db_path)

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -853,7 +853,7 @@ async function handleRunNowFromDetail(scheduleId: number) {
 async function handleRunFlow(flowId: number) {
   try {
     await CatalogApi.runFlow(flowId);
-    await Promise.all([catalogStore.loadActiveRuns(), catalogStore.loadRuns()]);
+    await Promise.all([catalogStore.loadActiveRuns(), catalogStore.loadRuns(flowId)]);
   } catch (e: any) {
     ElMessage.error(e?.response?.data?.detail ?? "Failed to trigger run");
   }
@@ -867,7 +867,7 @@ async function handleCancelFlowRun(flowId: number) {
     }
     await Promise.all([
       catalogStore.loadActiveRuns(),
-      catalogStore.loadRuns(),
+      catalogStore.loadRuns(flowId),
       catalogStore.loadStats(),
     ]);
     ElMessage.success("Run cancelled");

--- a/flowfile_worker/Dockerfile
+++ b/flowfile_worker/Dockerfile
@@ -28,6 +28,7 @@ COPY pyproject.toml poetry.lock* ./
 # Install dependencies AND strip in the same layer (in builder)
 RUN poetry install --only=main --no-root && \
     rm -rf $POETRY_CACHE_DIR && \
+    pip install --no-cache-dir psycopg2-binary==2.9.9 pymysql==1.1.0 && \
     # Strip debug symbols from compiled libraries
     find /usr/local/lib/python3.12/site-packages -name "*.so" -exec strip --strip-debug {} \; 2>/dev/null || true && \
     # Remove unnecessary files

--- a/shared/run_completion.py
+++ b/shared/run_completion.py
@@ -19,6 +19,22 @@ from shared.storage_config import get_database_url
 logger = logging.getLogger("flowfile.run_completion")
 
 
+def get_run_user_id(run_id: int) -> int | None:
+    """Return the FlowRun's ``user_id``, or ``None`` if the run row is missing.
+
+    Used by subprocess CLI entrypoints to resolve the owning user for a
+    pre-created run record, so the flow is loaded against the right
+    user's connections/secrets.
+    """
+    url = get_database_url()
+    connect_args = {"check_same_thread": False} if "sqlite" in url else {}
+    engine = create_engine(url, connect_args=connect_args)
+
+    with Session(engine) as session:
+        run = session.get(FlowRun, run_id)
+        return run.user_id if run else None
+
+
 def complete_run(
     run_id: int,
     success: bool,


### PR DESCRIPTION
This pull request introduces several important improvements and fixes across the backend and frontend codebases, primarily focused on standardizing the use of the `RunType` enum, improving database migration robustness, and enhancing flow run user resolution. It also addresses a legacy data normalization issue and improves the reliability of flow run tracking in the UI.

**Database and Migration Improvements**
* Added a new Alembic migration (`006_normalize_run_type.py`) to normalize legacy `flow_runs.run_type` values, remapping invalid engine kinds to a valid provenance type to prevent Pydantic validation failures.
* Enhanced migration logic to automatically detect and recover from unknown Alembic revision states by re-stamping the database to the latest known head, with tests to verify correct behavior. [[1]](diffhunk://#diff-00d8faeb34812ecf962424484e4478b2dece67a79a13e223de0dce0a57f45a4bR59-R100) [[2]](diffhunk://#diff-c3f2fcda0fe2d895c2d6941657dfc5b937d3d333ed75103832e5f4ce91a97492R488-R533)

**Backend API and Model Consistency**
* Refactored all places where `run_type` was a `str` to use the `RunType` enum instead, including function signatures and FastAPI route parameters, for improved type safety and consistency. [[1]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L103-R104) [[2]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L116-R124) [[3]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L436-R437) [[4]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L464-R465) [[5]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L479-R480) [[6]](diffhunk://#diff-e4b511850b309cf90a86ea7825ffc5e8174282e0b507a03cc826ba21b6d6e7c0L839-R840) [[7]](diffhunk://#diff-e4b511850b309cf90a86ea7825ffc5e8174282e0b507a03cc826ba21b6d6e7c0L909-R910) [[8]](diffhunk://#diff-e4b511850b309cf90a86ea7825ffc5e8174282e0b507a03cc826ba21b6d6e7c0L970-R971) [[9]](diffhunk://#diff-e4b511850b309cf90a86ea7825ffc5e8174282e0b507a03cc826ba21b6d6e7c0L2622-R2623) [[10]](diffhunk://#diff-e9ddf272831bf4d4fcf3f345bb41102129bbbfddf4b148f19dd4b24340be7f7eL316-R316)

**Flow Run User Resolution**
* Added a new utility function `get_run_user_id` in `shared/run_completion.py` and updated flow CLI entrypoints to resolve and use the correct user ID for a given run, ensuring flows are loaded with the appropriate user's context. [[1]](diffhunk://#diff-84e88be16f106767bdbf8a6d209a943593399fbc62595e4e42e1a643890a54f9R22-R37) [[2]](diffhunk://#diff-5fe12c1b0bf3e23653aae1f425dfa1b2f0c5d64a11cb60ad52f5742799333515R42-R47) [[3]](diffhunk://#diff-309affc0fd27159e801a224ccd970b6ada99aba85443d8067f22e21c14846a1bR251-R256)

**Frontend Reliability**
* Updated the Catalog UI to ensure that after triggering or cancelling a run, the run list for the specific flow is reloaded, improving UI accuracy and responsiveness. [[1]](diffhunk://#diff-28f97ff2d8ee94dc7e78eb64c0ad9c6f3025b0f357f17c9c8a37a09e0defb991L856-R856) [[2]](diffhunk://#diff-28f97ff2d8ee94dc7e78eb64c0ad9c6f3025b0f357f17c9c8a37a09e0defb991L870-R870)

**Dependency Updates**
* Updated Dockerfiles to explicitly install required database driver dependencies (`psycopg2-binary` and `pymysql`) for both core and worker images, improving out-of-the-box compatibility. [[1]](diffhunk://#diff-f8e71b446578b35aab6ea042c19a4d4d1c5a9b814d821dd15c4aec02b74d6f72R30) [[2]](diffhunk://#diff-c52a0a17f44531c9528edcbaa68b07b33bf56cada8ca30bfa058ef7a7a79577bR31)