### PR TITLE
various improvements in frontend and rename functionality from first …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ test-embed
 /expr_transformer/
 /.opencode/
 
+# Local remote-image compose setup
+/docker-remote/
+

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
@@ -61,6 +61,7 @@ from flowfile_core.flowfile.flow_data_engine.subprocess_operations.subprocess_op
     fetch_unique_values,
 )
 from flowfile_core.flowfile.flow_data_engine.threaded_processes import write_threaded
+from flowfile_core.utils.arrow_reader import read as arrow_read
 from flowfile_core.flowfile.sources.external_sources.base_class import ExternalDataSource
 from flowfile_core.schemas import cloud_storage_schemas, input_schema
 from flowfile_core.schemas import transform_schema as transform_schemas
@@ -2264,6 +2265,7 @@ class FlowDataEngine:
     def _compute_renamed_names(
         targets: list[str],
         settings: transform_schemas.DynamicRenameInput,
+        first_row_values: dict[str, Any] | None = None,
     ) -> list[str]:
         """Return new names aligned 1:1 with `targets` for the configured rename mode.
 
@@ -2276,17 +2278,24 @@ class FlowDataEngine:
         a no-op (returns `targets` unchanged). Non-string formula results are
         coerced to `str`.
 
+        For `"first_row"` mode the new names come from `first_row_values` (a dict
+        keyed by original column name). When called without `first_row_values`
+        (schema-only preview) the function returns `targets` unchanged.
+
         Args:
             targets: Column names the rename rule applies to.
             settings: The dynamic rename configuration.
+            first_row_values: First-row values keyed by original column name, used
+                only in `"first_row"` mode.
 
         Returns:
             New names aligned 1:1 with `targets`.
 
         Raises:
-            ValueError: If a formula yields a null, or changes cardinality in a way
+            ValueError: If a formula yields a null, changes cardinality in a way
                 that cannot be broadcast (e.g. an aggregation collapsing N rows to
-                a different N).
+                a different N), or — in `"first_row"` mode — a first-row value is
+                null or empty.
         """
         if not targets:
             return []
@@ -2295,6 +2304,16 @@ class FlowDataEngine:
             return [f"{settings.prefix}{n}" for n in targets]
         if mode == "suffix":
             return [f"{n}{settings.suffix}" for n in targets]
+        if mode == "first_row":
+            if first_row_values is None:
+                return list(targets)
+            new = [first_row_values.get(name) for name in targets]
+            for original, v in zip(targets, new, strict=True):
+                if v is None or (isinstance(v, str) and v.strip() == ""):
+                    raise ValueError(
+                        f"Dynamic rename (first_row) got a null/empty value for column '{original}'."
+                    )
+            return [str(v) for v in new]
         if mode == "formula":
             if not settings.formula.strip():
                 return list(targets)
@@ -2351,6 +2370,7 @@ class FlowDataEngine:
     def resolve_dynamic_rename_map(
         columns: list[tuple[str, str]],
         settings: transform_schemas.DynamicRenameInput,
+        first_row_values: dict[str, Any] | None = None,
     ) -> dict[str, str]:
         """Compute the `{old_name: new_name}` map for a dynamic-rename operation.
 
@@ -2362,22 +2382,64 @@ class FlowDataEngine:
         Args:
             columns: Incoming schema as `(column_name, data_type_group)` tuples, in order.
             settings: The dynamic rename configuration.
+            first_row_values: First-row values keyed by original column name. Required
+                for `"first_row"` mode to produce a real rename map; when omitted in
+                `"first_row"` mode the result is an empty map (schema-only preview).
 
         Returns:
             A dict mapping original column name to new column name. No-op renames are
             omitted, so the result is safe to pass directly to `pl.DataFrame.rename`.
         """
         targets = FlowDataEngine._select_rename_targets(columns, settings)
-        new_names = FlowDataEngine._compute_renamed_names(targets, settings)
+        new_names = FlowDataEngine._compute_renamed_names(
+            targets, settings, first_row_values=first_row_values
+        )
         rename_map = {old: new for old, new in zip(targets, new_names, strict=True) if old != new}
         FlowDataEngine._assert_rename_has_no_duplicates(rename_map, columns)
         return rename_map
 
+    def _peek_first_row_as_dict(self) -> dict[str, Any]:
+        """Return the first row of the underlying frame keyed by column name.
+
+        Runs on the external worker via `ExternalDfFetcher` to keep the heavy
+        compute out of the core process (same pattern as `fetch_unique_values`
+        used by `do_pivot`). Falls back to an in-core collect only if the
+        external fetcher is unavailable. Raises `ValueError` if the frame is
+        empty.
+        """
+        df = self.data_frame
+        lf = df.lazy() if isinstance(df, pl.DataFrame) else df
+        head_lf = lf.head(1)
+
+        table = None
+        try:
+            external = ExternalDfFetcher(lf=head_lf, flow_id=1, node_id=-1, wait_on_completion=True)
+            if external.status is not None and external.status.status == "Completed":
+                table = arrow_read(external.status.file_ref)
+        except Exception as e:  # noqa: BLE001 - worker availability is best-effort
+            logger.debug(f"ExternalDfFetcher unavailable for first_row peek ({e}); using in-core fallback")
+
+        if table is not None:
+            if table.num_rows == 0:
+                raise ValueError(
+                    "Dynamic rename (first_row) requires at least one row in the input; got 0."
+                )
+            return {name: table.column(name)[0].as_py() for name in table.column_names}
+
+        head = head_lf.collect()
+        if head.height == 0:
+            raise ValueError(
+                "Dynamic rename (first_row) requires at least one row in the input; got 0."
+            )
+        return dict(zip(head.columns, head.row(0), strict=True))
+
     def apply_dynamic_rename(self, settings: transform_schemas.DynamicRenameInput) -> FlowDataEngine:
         """Renames a subset of columns according to a single rule.
 
-        Supports prefix, suffix, and flowfile-formula rename modes, with column selection
-        by name list, by data type, or across all columns.
+        Supports prefix, suffix, flowfile-formula, and first-row rename modes, with
+        column selection by name list, by data type, or across all columns. In
+        `"first_row"` mode the first row is always dropped from the output after
+        its values are promoted to column headers.
 
         Args:
             settings: The dynamic rename configuration.
@@ -2387,17 +2449,24 @@ class FlowDataEngine:
             unchanged if the rule resolves to no renames).
         """
         columns = [(c.column_name, c.data_type_group) for c in self.schema]
-        rename_map = self.resolve_dynamic_rename_map(columns, settings)
+        first_row_values = None
+        if settings.rename_mode == "first_row":
+            first_row_values = self._peek_first_row_as_dict()
+        rename_map = self.resolve_dynamic_rename_map(
+            columns, settings, first_row_values=first_row_values
+        )
+        new_df = self.data_frame.rename(rename_map) if rename_map else self.data_frame
+        if settings.rename_mode == "first_row":
+            new_df = new_df.slice(1)
+            new_records = max(0, self.number_of_records - 1)
+            return FlowDataEngine(new_df, number_of_records=new_records)
         if not rename_map:
             return FlowDataEngine(
                 self.data_frame,
                 number_of_records=self.number_of_records,
                 schema=self.schema,
             )
-        return FlowDataEngine(
-            self.data_frame.rename(rename_map),
-            number_of_records=self.number_of_records,
-        )
+        return FlowDataEngine(new_df, number_of_records=self.number_of_records)
 
     def apply_sql_formula(self, func: str, col_name: str, output_data_type: pl.DataType = None) -> FlowDataEngine:
         """Applies an SQL-style formula using `pl.sql_expr`.

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -2259,8 +2259,10 @@ class FlowGraph:
     def add_dynamic_rename(self, settings: input_schema.NodeDynamicRename) -> "FlowGraph":
         """Adds a node that renames many columns at once via a single rule.
 
-        Supports prefix, suffix, and formula-based renaming across all columns,
-        a specific list of columns, or every column of a given data type.
+        Supports prefix, suffix, formula-based, and first-row renaming across all
+        columns, a specific list of columns, or every column of a given data type.
+        In `first_row` mode the first row is dropped from the output after its
+        values are promoted to column headers.
 
         Args:
             settings: The dynamic rename configuration.

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -957,6 +957,10 @@ def preview_dynamic_rename(request: DynamicRenamePreviewRequest) -> DynamicRenam
     The frontend calls this to render the live old-to-new preview pane inside the
     node's settings panel. Returns either the fully-resolved rename map (possibly
     empty) or an `error` describing a parse failure or duplicate-name collision.
+
+    `first_row` mode is intentionally not previewed here: its new names depend on
+    actual row data, and we don't want to trigger upstream computation from a
+    settings panel. The frontend renders a runtime-only placeholder for that mode.
     """
     columns = [(c.name, c.data_type_group) for c in request.incoming_columns]
     try:

--- a/flowfile_core/flowfile_core/schemas/input_schema.py
+++ b/flowfile_core/flowfile_core/schemas/input_schema.py
@@ -1398,6 +1398,8 @@ class NodeDynamicRename(NodeSingleInput):
             rule = f"suffix '{s.suffix}'"
         elif s.rename_mode == "formula" and s.formula:
             rule = f"formula {s.formula}"
+        elif s.rename_mode == "first_row":
+            rule = "promote first row to headers"
         else:
             return ""
         if s.selection_mode == "all":

--- a/flowfile_core/flowfile_core/schemas/transform_schema.py
+++ b/flowfile_core/flowfile_core/schemas/transform_schema.py
@@ -1024,7 +1024,7 @@ class GraphSolverInput(BaseModel):
     output_column_name: str | None = "graph_group"
 
 
-RenameMode = Literal["prefix", "suffix", "formula"]
+RenameMode = Literal["prefix", "suffix", "formula", "first_row"]
 ColumnSelectionMode = Literal["all", "list", "data_type"]
 ReadableDataTypeGroup = Literal["Numeric", "String", "Date", "Other", "Boolean", "Binary", "Complex"]
 
@@ -1032,12 +1032,17 @@ ReadableDataTypeGroup = Literal["Numeric", "String", "Date", "Other", "Boolean",
 class DynamicRenameInput(BaseModel):
     """Defines settings for a dynamic rename operation.
 
-    Applies a single rule (prefix / suffix / formula) to a set of selected columns,
-    rather than requiring the user to rename columns one-by-one.
+    Applies a single rule (prefix / suffix / formula / first_row) to a set of selected
+    columns, rather than requiring the user to rename columns one-by-one.
 
     In formula mode, the flowfile formula syntax is evaluated with `[column_name]`
     bound to each target column's current name; for example `uppercase([column_name])`
     or `"v2_" + [column_name]`.
+
+    In first_row mode, the first row of the incoming table is promoted to column
+    headers and then dropped from the data. Non-string values are coerced to `str`;
+    null or empty values raise an error. Selection filters still apply — only selected
+    columns are renamed, but the first row is always dropped.
     """
 
     rename_mode: RenameMode = "prefix"

--- a/flowfile_core/tests/flowfile/flowfile_table/test_dynamic_rename.py
+++ b/flowfile_core/tests/flowfile/flowfile_table/test_dynamic_rename.py
@@ -210,3 +210,95 @@ def test_formula_with_no_targets_returns_empty_map():
         selected_columns=["does_not_exist"],
     )
     assert FlowDataEngine.resolve_dynamic_rename_map(columns, settings) == {}
+
+
+def test_first_row_promotes_and_drops():
+    engine = FlowDataEngine(pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+    settings = transform_schema.DynamicRenameInput(rename_mode="first_row")
+    result = engine.apply_dynamic_rename(settings)
+    df = result.data_frame.collect() if isinstance(result.data_frame, pl.LazyFrame) else result.data_frame
+    assert df.columns == ["1", "x"]
+    assert df.rows() == [(2, "y"), (3, "z")]
+
+
+def test_first_row_coerces_non_string_values():
+    engine = FlowDataEngine(pl.DataFrame({"a": [10, 20], "b": [1.5, 2.5]}))
+    settings = transform_schema.DynamicRenameInput(rename_mode="first_row")
+    result = engine.apply_dynamic_rename(settings)
+    names = result.data_frame.collect_schema().names()
+    assert names == ["10", "1.5"]
+
+
+def test_first_row_selection_list_only_renames_targets():
+    engine = FlowDataEngine(pl.DataFrame({"a": ["new_a", "v1", "v2"], "b": ["keep_me", "q", "r"]}))
+    settings = transform_schema.DynamicRenameInput(
+        rename_mode="first_row",
+        selection_mode="list",
+        selected_columns=["a"],
+    )
+    result = engine.apply_dynamic_rename(settings)
+    df = result.data_frame.collect() if isinstance(result.data_frame, pl.LazyFrame) else result.data_frame
+    assert df.columns == ["new_a", "b"]
+    assert df.rows() == [("v1", "q"), ("v2", "r")]
+
+
+def test_first_row_selection_data_type():
+    engine = FlowDataEngine(pl.DataFrame({"name": ["renamed_name", "n1"], "age": [99, 1]}))
+    settings = transform_schema.DynamicRenameInput(
+        rename_mode="first_row",
+        selection_mode="data_type",
+        selected_data_type="String",
+    )
+    result = engine.apply_dynamic_rename(settings)
+    df = result.data_frame.collect() if isinstance(result.data_frame, pl.LazyFrame) else result.data_frame
+    assert df.columns == ["renamed_name", "age"]
+    assert df.rows() == [("n1", 1)]
+
+
+def test_first_row_raises_on_null():
+    engine = FlowDataEngine(pl.DataFrame({"a": [None, "x"], "b": ["y", "z"]}))
+    settings = transform_schema.DynamicRenameInput(rename_mode="first_row")
+    with pytest.raises(ValueError, match="null/empty"):
+        engine.apply_dynamic_rename(settings)
+
+
+def test_first_row_raises_on_empty_string():
+    engine = FlowDataEngine(pl.DataFrame({"a": ["", "x"], "b": ["y", "z"]}))
+    settings = transform_schema.DynamicRenameInput(rename_mode="first_row")
+    with pytest.raises(ValueError, match="null/empty"):
+        engine.apply_dynamic_rename(settings)
+
+
+def test_first_row_raises_on_duplicate_values():
+    engine = FlowDataEngine(pl.DataFrame({"a": ["x", "1"], "b": ["x", "2"]}))
+    settings = transform_schema.DynamicRenameInput(rename_mode="first_row")
+    with pytest.raises(ValueError, match="duplicate column name"):
+        engine.apply_dynamic_rename(settings)
+
+
+def test_first_row_raises_on_empty_input():
+    engine = FlowDataEngine(pl.DataFrame({"a": [], "b": []}, schema={"a": pl.Utf8, "b": pl.Utf8}))
+    settings = transform_schema.DynamicRenameInput(rename_mode="first_row")
+    with pytest.raises(ValueError, match="at least one row"):
+        engine.apply_dynamic_rename(settings)
+
+
+def test_first_row_works_on_lazy_frame():
+    engine = FlowDataEngine(pl.LazyFrame({"a": ["H1", "v1"], "b": ["H2", "v2"]}))
+    settings = transform_schema.DynamicRenameInput(rename_mode="first_row")
+    result = engine.apply_dynamic_rename(settings)
+    df = result.data_frame.collect() if isinstance(result.data_frame, pl.LazyFrame) else result.data_frame
+    assert df.columns == ["H1", "H2"]
+    assert df.rows() == [("v1", "v2")]
+
+
+def test_resolve_map_first_row_pure():
+    columns = [("a", "String"), ("b", "String")]
+    settings = transform_schema.DynamicRenameInput(rename_mode="first_row")
+    rename_map = FlowDataEngine.resolve_dynamic_rename_map(
+        columns, settings, first_row_values={"a": "H1", "b": "H2"}
+    )
+    assert rename_map == {"a": "H1", "b": "H2"}
+
+    # Schema-only call (no first_row_values) is a no-op preview.
+    assert FlowDataEngine.resolve_dynamic_rename_map(columns, settings) == {}

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/dynamicRename/DynamicRename.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/dynamicRename/DynamicRename.vue
@@ -11,6 +11,7 @@
           <el-radio-button value="prefix">Prefix</el-radio-button>
           <el-radio-button value="suffix">Suffix</el-radio-button>
           <el-radio-button value="formula">Formula</el-radio-button>
+          <el-radio-button value="first_row">First row</el-radio-button>
         </el-radio-group>
       </div>
 
@@ -23,7 +24,7 @@
           <div class="listbox-subtitle">Suffix</div>
           <el-input v-model="settings.suffix" placeholder="e.g. _raw" size="small" clearable />
         </div>
-        <div v-else>
+        <div v-else-if="settings.rename_mode === 'formula'">
           <div class="listbox-subtitle">Formula</div>
           <div class="formula-editor">
             <FunctionEditor
@@ -34,6 +35,12 @@
           </div>
           <div class="hint">
             Use <code>[column_name]</code> to reference the current column name.
+          </div>
+        </div>
+        <div v-else>
+          <div class="hint">
+            The first row of the incoming table becomes the new column names. That row is then
+            removed from the data.
           </div>
         </div>
       </div>
@@ -77,19 +84,17 @@
             clearable
             style="width: 100%"
           >
-            <el-option
-              v-for="group in dataTypeGroups"
-              :key="group"
-              :label="group"
-              :value="group"
-            />
+            <el-option v-for="group in dataTypeGroups" :key="group" :label="group" :value="group" />
           </el-select>
         </div>
       </div>
 
       <div class="section">
         <div class="listbox-subtitle">Preview</div>
-        <div v-if="previewError" class="preview-error">{{ previewError }}</div>
+        <div v-if="settings.rename_mode === 'first_row'" class="preview-empty">
+          First row values are read at run time. Run the flow to see the resulting columns.
+        </div>
+        <div v-else-if="previewError" class="preview-error">{{ previewError }}</div>
         <div v-else-if="previewLoading" class="preview-loading">Computing preview...</div>
         <div v-else-if="previewRows.length === 0" class="preview-empty">
           No columns will be renamed.
@@ -215,6 +220,7 @@ const resolveClientPreview = (): PreviewRow[] => {
       if (newName !== name) mapped.push({ oldName: name, newName });
     }
   }
+  // formula and first_row are resolved server-side.
   return mapped;
 };
 
@@ -223,6 +229,12 @@ let previewTimer: ReturnType<typeof setTimeout> | null = null;
 const refreshPreview = () => {
   previewError.value = null;
   const s = settings.value;
+  if (s.rename_mode === "first_row") {
+    // first_row is resolved at run time — no preview call, template shows a placeholder.
+    previewRows.value = [];
+    previewLoading.value = false;
+    return;
+  }
   if (s.rename_mode !== "formula") {
     previewRows.value = resolveClientPreview();
     previewLoading.value = false;

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/googleAnalyticsReader/GoogleAnalyticsReader.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/googleAnalyticsReader/GoogleAnalyticsReader.vue
@@ -38,12 +38,12 @@
               <i class="fa-solid fa-info-circle"></i>
               <span>Create a Google Analytics connection in the Connections manager first.</span>
             </div>
-            <div
-              v-else-if="connectionDefaultPropertyId"
-              class="helper-text"
-            >
+            <div v-else-if="connectionDefaultPropertyId" class="helper-text">
               <i class="fa-solid fa-info-circle"></i>
-              <span>Reading from property <code>{{ connectionDefaultPropertyId }}</code>.</span>
+              <span
+                >Reading from property <code>{{ connectionDefaultPropertyId }}</code
+                >.</span
+              >
             </div>
             <div v-else class="helper-text helper-text-warning">
               <i class="fa-solid fa-triangle-exclamation"></i>
@@ -90,8 +90,8 @@
           <div class="helper-text">
             <i class="fa-solid fa-info-circle"></i>
             <span>
-              Presets use GA4's relative date tokens (e.g. <code>30daysAgo</code>) so every flow
-              run evaluates a rolling window against the current date.
+              Presets use GA4's relative date tokens (e.g. <code>30daysAgo</code>) so every flow run
+              evaluates a rolling window against the current date.
             </span>
           </div>
         </div>
@@ -135,11 +135,7 @@
             placeholder="Pick metrics (e.g. sessions, totalUsers)"
             class="ga-multiselect"
           >
-            <el-option-group
-              v-for="group in metricGroups"
-              :key="group.label"
-              :label="group.label"
-            >
+            <el-option-group v-for="group in metricGroups" :key="group.label" :label="group.label">
               <el-option
                 v-for="opt in group.options"
                 :key="opt.name"
@@ -362,9 +358,7 @@
           </button>
           <div class="helper-text">
             <i class="fa-solid fa-info-circle"></i>
-            <span>
-              Multiple filters on the same kind (dimension or metric) are AND-combined.
-            </span>
+            <span> Multiple filters on the same kind (dimension or metric) are AND-combined. </span>
           </div>
         </div>
       </div>
@@ -513,8 +507,7 @@ const refreshConnectionDefault = () => {
 const syncPropertyIdFromConnection = () => {
   if (!nodeGaReader.value) return;
   if (connectionDefaultPropertyId.value) {
-    nodeGaReader.value.google_analytics_settings.property_id =
-      connectionDefaultPropertyId.value;
+    nodeGaReader.value.google_analytics_settings.property_id = connectionDefaultPropertyId.value;
   }
 };
 
@@ -608,7 +601,10 @@ const getListValue = (filter: GoogleAnalyticsFilter): string[] =>
     .filter((v) => v.length > 0);
 
 const setListValue = (filter: GoogleAnalyticsFilter, values: string[]) => {
-  filter.value = values.map((v) => v.trim()).filter((v) => v.length > 0).join(",");
+  filter.value = values
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0)
+    .join(",");
 };
 
 const getBetweenPair = (filter: GoogleAnalyticsFilter): [string, string] => {

--- a/flowfile_frontend/src/renderer/app/types/node.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/node.types.ts
@@ -525,7 +525,7 @@ export interface RecordIdInput {
 // Dynamic Rename Types
 // ============================================================================
 
-export type RenameMode = "prefix" | "suffix" | "formula";
+export type RenameMode = "prefix" | "suffix" | "formula" | "first_row";
 export type ColumnSelectionMode = "all" | "list" | "data_type";
 export type ReadableDataTypeGroup =
   | "Numeric"

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/SqlExplorePanel.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/SqlExplorePanel.vue
@@ -1,11 +1,18 @@
 <template>
-  <div class="sql-explore-panel">
+  <div :class="['sql-explore-panel', { 'is-fullscreen': isFullscreen }]">
+    <button
+      class="fullscreen-toggle"
+      :title="isFullscreen ? 'Exit fullscreen (Esc)' : 'Fullscreen'"
+      @click="toggleFullscreen"
+    >
+      <i :class="isFullscreen ? 'fa-solid fa-compress' : 'fa-solid fa-expand'"></i>
+    </button>
     <VueGraphicWalker :data="gwData" :fields="gwFields" default-tab="data" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref, onBeforeUnmount, watch } from "vue";
 import VueGraphicWalker from "../../components/nodes/node-types/elements/exploreData/vueGraphicWalker/VueGraphicWalker.vue";
 import type {
   IMutField,
@@ -17,6 +24,33 @@ import type { SqlQueryResult } from "../../types";
 const props = defineProps<{
   result: SqlQueryResult;
 }>();
+
+const isFullscreen = ref(false);
+
+function toggleFullscreen() {
+  isFullscreen.value = !isFullscreen.value;
+}
+
+function handleEsc(e: KeyboardEvent) {
+  if (e.key === "Escape" && isFullscreen.value) {
+    isFullscreen.value = false;
+  }
+}
+
+watch(isFullscreen, (val) => {
+  if (val) {
+    window.addEventListener("keydown", handleEsc);
+    document.body.style.overflow = "hidden";
+  } else {
+    window.removeEventListener("keydown", handleEsc);
+    document.body.style.overflow = "";
+  }
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", handleEsc);
+  document.body.style.overflow = "";
+});
 
 function getSemanticType(dtype: string): ISemanticType {
   const d = dtype.toLowerCase();
@@ -72,5 +106,45 @@ const gwData = computed<IRow[]>(() =>
 .sql-explore-panel {
   width: 100%;
   height: 100%;
+  position: relative;
+}
+
+.sql-explore-panel.is-fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: var(--el-bg-color, #ffffff);
+  padding: 8px;
+}
+
+.fullscreen-toggle {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  z-index: 10;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border-light, #e4e7ed);
+  border-radius: 4px;
+  background: var(--el-bg-color, #ffffff);
+  color: var(--color-text-secondary, #606266);
+  cursor: pointer;
+  font-size: 13px;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.fullscreen-toggle:hover {
+  background: var(--color-background-hover, #f0f0f0);
+  color: var(--el-color-primary, #409eff);
+}
+
+.is-fullscreen .fullscreen-toggle {
+  top: 12px;
+  right: 16px;
 }
 </style>

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/LogViewer/LogViewer.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/LogViewer/LogViewer.vue
@@ -174,7 +174,11 @@ watch(logs, (newLogs) => {
 });
 
 const isErrorLine = (line: string): boolean => {
-  return line.toUpperCase().includes("ERROR");
+  return / - ERROR - /.test(line);
+};
+
+const isWarningLine = (line: string): boolean => {
+  return / - WARNING - /.test(line);
 };
 </script>
 
@@ -220,7 +224,7 @@ const isErrorLine = (line: string): boolean => {
       <div
         v-for="(line, index) in logLines"
         :key="index"
-        :class="{ 'error-line': isErrorLine(line) }"
+        :class="{ 'error-line': isErrorLine(line), 'warning-line': isWarningLine(line) }"
       >
         {{ line }}
       </div>
@@ -330,5 +334,10 @@ const isErrorLine = (line: string): boolean => {
 .error-line {
   background-color: var(--color-danger-light);
   color: var(--color-danger);
+}
+
+.warning-line {
+  background-color: var(--color-warning-light);
+  color: var(--color-warning-dark);
 }
 </style>


### PR DESCRIPTION

This pull request adds support for a new "first row" dynamic rename mode to the Flowfile data engine, allowing users to promote the first row of a table to column headers and then remove it from the data. The implementation includes backend logic, frontend UI, schema changes, and comprehensive tests. The preview functionality intentionally skips "first row" mode, as its results depend on runtime data. The most important changes are grouped below.

**Backend: New "first row" rename mode implementation**

- Added `"first_row"` as a valid `rename_mode` in the `DynamicRenameInput` schema, updating all relevant docstrings and logic to describe this new behavior.
- Implemented logic in `FlowDataEngine` to promote the first row to headers and remove it from the data, including error handling for null, empty, or duplicate header values. [[1]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR2268) [[2]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR2281-R2298) [[3]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR2307-R2316) [[4]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR2373) [[5]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR2385-R2442) [[6]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aL2390-R2469)
- Added a method to efficiently peek the first row, using an external worker if available for performance.

**Frontend: UI and preview changes**

- Updated the dynamic rename node UI to include a "First row" option, with explanatory hints and a runtime-only preview placeholder (no preview is computed for this mode). [[1]](diffhunk://#diff-bd28d2698eae598010668f145ab3de3b6b36fbcdfdfae36db2696a37192e0e61R14) [[2]](diffhunk://#diff-bd28d2698eae598010668f145ab3de3b6b36fbcdfdfae36db2696a37192e0e61L26-R27) [[3]](diffhunk://#diff-bd28d2698eae598010668f145ab3de3b6b36fbcdfdfae36db2696a37192e0e61R40-R45) [[4]](diffhunk://#diff-bd28d2698eae598010668f145ab3de3b6b36fbcdfdfae36db2696a37192e0e61L80-R97) [[5]](diffhunk://#diff-bd28d2698eae598010668f145ab3de3b6b36fbcdfdfae36db2696a37192e0e61R223) [[6]](diffhunk://#diff-bd28d2698eae598010668f145ab3de3b6b36fbcdfdfae36db2696a37192e0e61R232-R237)
- Updated the backend preview endpoint and frontend logic to skip previewing "first row" mode and display a placeholder message instead. [[1]](diffhunk://#diff-32e613ce2488a56db7b959c15d488a566e528efc483b772c3582b5e7992358aaR960-R963) [[2]](diffhunk://#diff-bd28d2698eae598010668f145ab3de3b6b36fbcdfdfae36db2696a37192e0e61L80-R97) [[3]](diffhunk://#diff-bd28d2698eae598010668f145ab3de3b6b36fbcdfdfae36db2696a37192e0e61R232-R237)

**Testing and documentation**

- Added comprehensive tests for "first row" mode, covering correct renaming, selection modes, error cases (nulls, duplicates, empty input), and lazy frame support.
- Updated user-facing descriptions and documentation to reflect the new mode and its behavior. [[1]](diffhunk://#diff-80704d92f5ae9fa1f80f79541dfd20d655bf96ee408205e4c50afb13d5fb6815R1401-R1402) [[2]](diffhunk://#diff-00bdc9357ec0617a3eb0b84361ea9585c7adaa10bc178a849f5b82020e9f8771L1027-R1045)

These changes together provide a robust and user-friendly way to promote the first row of a dataset to column headers, with clear UI/UX and thorough backend validation.