### PR TITLE
Improve stability of flows and improve user experience when looking at run histroy

### DIFF
--- a/flowfile_core/flowfile_core/alembic/versions/010_flow_uuid.py
+++ b/flowfile_core/flowfile_core/alembic/versions/010_flow_uuid.py
@@ -1,0 +1,67 @@
+"""Add flow_uuid to flow_registrations and flow_runs.
+
+Stable identity for flow registrations so that SQLite reusing a deleted
+``FlowRegistration.id`` can never pull another flow's runs into the new flow's
+history. ``FlowRun`` keeps its own ``flow_uuid`` snapshot so deleting a
+registration (which nulls ``registration_id``) preserves run attribution in the
+global view.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-04-30
+"""
+
+from collections.abc import Sequence
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "010"
+down_revision: str | None = "009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add as nullable first so we can backfill before enforcing NOT NULL.
+    with op.batch_alter_table("flow_registrations") as batch:
+        batch.add_column(sa.Column("flow_uuid", sa.String(length=36), nullable=True))
+
+    with op.batch_alter_table("flow_runs") as batch:
+        batch.add_column(sa.Column("flow_uuid", sa.String(length=36), nullable=True))
+        batch.create_index("ix_flow_runs_flow_uuid", ["flow_uuid"])
+
+    bind = op.get_bind()
+
+    # 1. Backfill flow_registrations.flow_uuid (one uuid per registration).
+    rows = bind.execute(sa.text("SELECT id FROM flow_registrations")).fetchall()
+    for (reg_id,) in rows:
+        bind.execute(
+            sa.text("UPDATE flow_registrations SET flow_uuid = :u WHERE id = :i"),
+            {"u": str(uuid4()), "i": reg_id},
+        )
+
+    # 2. Backfill flow_runs.flow_uuid by copying from the registration the run points at.
+    bind.execute(
+        sa.text(
+            "UPDATE flow_runs SET flow_uuid = ("
+            "SELECT flow_uuid FROM flow_registrations "
+            "WHERE flow_registrations.id = flow_runs.registration_id"
+            ") WHERE registration_id IS NOT NULL"
+        )
+    )
+
+    # 3. Now enforce NOT NULL + UNIQUE on flow_registrations.flow_uuid.
+    with op.batch_alter_table("flow_registrations") as batch:
+        batch.alter_column("flow_uuid", existing_type=sa.String(length=36), nullable=False)
+        batch.create_unique_constraint("uq_flow_registrations_flow_uuid", ["flow_uuid"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("flow_registrations") as batch:
+        batch.drop_constraint("uq_flow_registrations_flow_uuid", type_="unique")
+        batch.drop_column("flow_uuid")
+    with op.batch_alter_table("flow_runs") as batch:
+        batch.drop_index("ix_flow_runs_flow_uuid")
+        batch.drop_column("flow_uuid")

--- a/flowfile_core/flowfile_core/catalog/repository.py
+++ b/flowfile_core/flowfile_core/catalog/repository.py
@@ -75,6 +75,8 @@ class CatalogRepository(Protocol):
         owner_id: int | None = None,
     ) -> list[FlowRegistration]: ...
 
+    def list_flows_by_ids(self, registration_ids: list[int]) -> list[FlowRegistration]: ...
+
     def create_flow(self, reg: FlowRegistration) -> FlowRegistration: ...
 
     def update_flow(self, reg: FlowRegistration) -> FlowRegistration: ...
@@ -372,6 +374,11 @@ class SQLAlchemyCatalogRepository:
             q = q.filter_by(owner_id=owner_id)
         return q.order_by(FlowRegistration.name).all()
 
+    def list_flows_by_ids(self, registration_ids: list[int]) -> list[FlowRegistration]:
+        if not registration_ids:
+            return []
+        return self._db.query(FlowRegistration).filter(FlowRegistration.id.in_(registration_ids)).all()
+
     def create_flow(self, reg: FlowRegistration) -> FlowRegistration:
         self._db.add(reg)
         self._db.commit()
@@ -391,10 +398,48 @@ class SQLAlchemyCatalogRepository:
         self._db.query(GlobalArtifact).filter_by(
             source_registration_id=registration_id,
         ).filter(GlobalArtifact.status == "deleted").delete()
+        # Detach historical runs from this registration so a future registration
+        # that happens to reuse the same SQLite-assigned id cannot pull these
+        # runs into its own per-flow history. The runs keep their flow_uuid for
+        # global-history attribution.
+        self._db.query(FlowRun).filter_by(registration_id=registration_id).update(
+            {"registration_id": None}, synchronize_session=False
+        )
         flow = self._db.get(FlowRegistration, registration_id)
         if flow is not None:
             self._db.delete(flow)
             self._db.commit()
+
+    def _runs_of_registration(self, registration_id: int):
+        """Return a filter clause matching FlowRuns belonging to a registration.
+
+        Resolves to ``FlowRun.flow_uuid`` so a deleted+recreated registration with
+        the same SQLite-assigned id can never surface the previous flow's runs.
+        If the registration doesn't exist the scalar subquery yields NULL, which
+        makes the equality unsatisfiable — no rows match, no explicit guard
+        needed at call sites.
+        """
+        uuid_subq = (
+            self._db.query(FlowRegistration.flow_uuid).filter_by(id=registration_id).scalar_subquery()
+        )
+        return FlowRun.flow_uuid == uuid_subq
+
+    def _apply_run_filters(
+        self,
+        q,
+        *,
+        registration_id: int | None = None,
+        schedule_id: int | None = None,
+        run_type: RunType | None = None,
+    ):
+        """Apply the standard run filters to a FlowRun query."""
+        if registration_id is not None:
+            q = q.filter(self._runs_of_registration(registration_id))
+        if schedule_id is not None:
+            q = q.filter(FlowRun.schedule_id == schedule_id)
+        if run_type is not None:
+            q = q.filter(FlowRun.run_type == run_type)
+        return q
 
     def count_flows_in_namespace(self, namespace_id: int) -> int:
         return self._db.query(FlowRegistration).filter_by(namespace_id=namespace_id).count()
@@ -468,13 +513,12 @@ class SQLAlchemyCatalogRepository:
         limit: int = 50,
         offset: int = 0,
     ) -> list[FlowRun]:
-        q = self._db.query(FlowRun)
-        if registration_id is not None:
-            q = q.filter_by(registration_id=registration_id)
-        if schedule_id is not None:
-            q = q.filter(FlowRun.schedule_id == schedule_id)
-        if run_type is not None:
-            q = q.filter(FlowRun.run_type == run_type)
+        q = self._apply_run_filters(
+            self._db.query(FlowRun),
+            registration_id=registration_id,
+            schedule_id=schedule_id,
+            run_type=run_type,
+        )
         return q.order_by(FlowRun.started_at.desc()).offset(offset).limit(limit).all()
 
     def create_run(self, run: FlowRun) -> FlowRun:
@@ -494,14 +538,12 @@ class SQLAlchemyCatalogRepository:
         schedule_id: int | None = None,
         run_type: RunType | None = None,
     ) -> int:
-        q = self._db.query(FlowRun)
-        if registration_id is not None:
-            q = q.filter_by(registration_id=registration_id)
-        if schedule_id is not None:
-            q = q.filter(FlowRun.schedule_id == schedule_id)
-        if run_type is not None:
-            q = q.filter(FlowRun.run_type == run_type)
-        return q.count()
+        return self._apply_run_filters(
+            self._db.query(FlowRun),
+            registration_id=registration_id,
+            schedule_id=schedule_id,
+            run_type=run_type,
+        ).count()
 
     def count_runs_by_status(
         self,
@@ -511,18 +553,17 @@ class SQLAlchemyCatalogRepository:
     ) -> dict[str, int]:
         from sqlalchemy import case, func
 
-        q = self._db.query(
-            func.count().label("total"),
-            func.count(case((FlowRun.success.is_(True), 1))).label("success"),
-            func.count(case((FlowRun.success.is_(False), 1))).label("failed"),
-            func.count(case((FlowRun.success.is_(None), 1))).label("running"),
+        q = self._apply_run_filters(
+            self._db.query(
+                func.count().label("total"),
+                func.count(case((FlowRun.success.is_(True), 1))).label("success"),
+                func.count(case((FlowRun.success.is_(False), 1))).label("failed"),
+                func.count(case((FlowRun.success.is_(None), 1))).label("running"),
+            ),
+            registration_id=registration_id,
+            schedule_id=schedule_id,
+            run_type=run_type,
         )
-        if registration_id is not None:
-            q = q.filter(FlowRun.registration_id == registration_id)
-        if schedule_id is not None:
-            q = q.filter(FlowRun.schedule_id == schedule_id)
-        if run_type is not None:
-            q = q.filter(FlowRun.run_type == run_type)
         row = q.one()
         return {"total": row.total, "success": row.success, "failed": row.failed, "running": row.running}
 
@@ -572,12 +613,12 @@ class SQLAlchemyCatalogRepository:
     # -- Aggregate helpers ---------------------------------------------------
 
     def count_run_for_flow(self, registration_id: int) -> int:
-        return self._db.query(FlowRun).filter_by(registration_id=registration_id).count()
+        return self._db.query(FlowRun).filter(self._runs_of_registration(registration_id)).count()
 
     def last_run_for_flow(self, registration_id: int) -> FlowRun | None:
         return (
             self._db.query(FlowRun)
-            .filter_by(registration_id=registration_id)
+            .filter(self._runs_of_registration(registration_id))
             .order_by(FlowRun.started_at.desc())
             .first()
         )
@@ -727,47 +768,57 @@ class SQLAlchemyCatalogRepository:
     def bulk_get_run_stats(self, flow_ids: list[int]) -> dict[int, tuple[int, FlowRun | None]]:
         """Return run_count and last_run for each flow_id in one query batch.
 
-        Returns a dict: flow_id -> (run_count, last_run_or_none)
+        Grouping is by ``flow_uuid`` (resolved from ``flow_registrations``) so
+        history that survived a registration delete+recreate stays attached to
+        the original flow only.
         """
         if not flow_ids:
             return {}
 
-        # Query 1: counts per registration_id
-        count_rows = (
-            self._db.query(
-                FlowRun.registration_id,
-                func.count(FlowRun.id).label("cnt"),
-            )
-            .filter(FlowRun.registration_id.in_(flow_ids))
-            .group_by(FlowRun.registration_id)
+        # registration_id -> flow_uuid (skip ids that no longer exist)
+        uuid_rows = (
+            self._db.query(FlowRegistration.id, FlowRegistration.flow_uuid)
+            .filter(FlowRegistration.id.in_(flow_ids))
             .all()
         )
-        counts = {r[0]: r[1] for r in count_rows}
+        id_to_uuid = {rid: uuid for rid, uuid in uuid_rows}
+        uuids = list(id_to_uuid.values())
+        if not uuids:
+            return {fid: (0, None) for fid in flow_ids}
 
-        # Query 2: last run per registration_id using a subquery for max started_at
+        # Query 1: counts per flow_uuid
+        count_rows = (
+            self._db.query(FlowRun.flow_uuid, func.count(FlowRun.id).label("cnt"))
+            .filter(FlowRun.flow_uuid.in_(uuids))
+            .group_by(FlowRun.flow_uuid)
+            .all()
+        )
+        counts = {uuid: cnt for uuid, cnt in count_rows}
+
+        # Query 2: last run per flow_uuid using a subquery for max started_at
         subq = (
             self._db.query(
-                FlowRun.registration_id,
+                FlowRun.flow_uuid,
                 func.max(FlowRun.started_at).label("max_started"),
             )
-            .filter(FlowRun.registration_id.in_(flow_ids))
-            .group_by(FlowRun.registration_id)
+            .filter(FlowRun.flow_uuid.in_(uuids))
+            .group_by(FlowRun.flow_uuid)
             .subquery()
         )
         last_runs_rows = (
             self._db.query(FlowRun)
             .join(
                 subq,
-                (FlowRun.registration_id == subq.c.registration_id) & (FlowRun.started_at == subq.c.max_started),
+                (FlowRun.flow_uuid == subq.c.flow_uuid) & (FlowRun.started_at == subq.c.max_started),
             )
             .all()
         )
-        last_runs = {r.registration_id: r for r in last_runs_rows}
+        last_runs = {r.flow_uuid: r for r in last_runs_rows}
 
-        # Build result dict
         result: dict[int, tuple[int, FlowRun | None]] = {}
         for fid in flow_ids:
-            result[fid] = (counts.get(fid, 0), last_runs.get(fid))
+            uuid_ = id_to_uuid.get(fid)
+            result[fid] = (counts.get(uuid_, 0), last_runs.get(uuid_)) if uuid_ else (0, None)
         return result
 
     def list_tables_for_flow(self, registration_id: int) -> list[CatalogTable]:
@@ -902,7 +953,7 @@ class SQLAlchemyCatalogRepository:
         """Check if a flow already has an active (unfinished) run."""
         return (
             self._db.query(FlowRun)
-            .filter(FlowRun.registration_id == registration_id, FlowRun.ended_at.is_(None))
+            .filter(self._runs_of_registration(registration_id), FlowRun.ended_at.is_(None))
             .first()
             is not None
         )

--- a/flowfile_core/flowfile_core/catalog/serializers.py
+++ b/flowfile_core/flowfile_core/catalog/serializers.py
@@ -29,16 +29,19 @@ class VizEnrichment:
     namespace_name: str | None
 
 
-def run_to_out(run: FlowRun, *, has_log: bool) -> FlowRunOut:
+def run_to_out(run: FlowRun, *, has_log: bool, display_name: str | None = None) -> FlowRunOut:
     """Convert a FlowRun ORM row to its FlowRunOut DTO.
 
     ``has_log`` is supplied by the caller because it requires filesystem
-    access (which is not pure).
+    access (which is not pure). ``display_name`` overrides the snapshot
+    ``flow_name`` so the UI can show the registration's current user-typed
+    name (rather than the prefixed file stem captured at run time).
     """
     return FlowRunOut(
         id=run.id,
         registration_id=run.registration_id,
-        flow_name=run.flow_name,
+        flow_uuid=run.flow_uuid,
+        flow_name=display_name or run.flow_name,
         flow_path=run.flow_path,
         user_id=run.user_id,
         started_at=run.started_at,

--- a/flowfile_core/flowfile_core/catalog/services/flows.py
+++ b/flowfile_core/flowfile_core/catalog/services/flows.py
@@ -22,6 +22,27 @@ from flowfile_core.schemas.catalog_schema import (
 
 logger = logging.getLogger(__name__)
 
+# Process-local memo of (registration_id, flow_path) tuples we've already
+# warned about. The first sighting of a missing file is genuinely useful (it
+# can flag a misconfigured volume mount), but every subsequent /catalog/flows
+# request would re-log the same line. Keeping it in-memory means the warning
+# resurfaces after a restart, which is the right cadence for an operator.
+_warned_missing_paths: set[tuple[int, str]] = set()
+
+
+def _warn_missing_file_once(flow: FlowRegistration) -> None:
+    """Log the missing-file warning at most once per (id, path) per process."""
+    key = (flow.id, flow.flow_path or "")
+    if key in _warned_missing_paths:
+        return
+    _warned_missing_paths.add(key)
+    logger.warning(
+        "Registered flow %s (id=%d) references missing file: %s",
+        flow.name,
+        flow.id,
+        flow.flow_path,
+    )
+
 
 class FlowRegistrationService:
     """Owns flow registration CRUD, enrichment and auto-registration."""
@@ -44,12 +65,7 @@ class FlowRegistrationService:
         read_tables = self.repo.list_read_tables_for_flow(flow.id)
         file_exists = os.path.exists(flow.flow_path) if flow.flow_path else False
         if not file_exists:
-            logger.warning(
-                "Registered flow %s (id=%d) references missing file: %s",
-                flow.name,
-                flow.id,
-                flow.flow_path,
-            )
+            _warn_missing_file_once(flow)
         return FlowRegistrationOut(
             id=flow.id,
             name=flow.name,
@@ -96,12 +112,7 @@ class FlowRegistrationService:
             read = read_tables_by_flow.get(flow.id, [])
             file_exists = os.path.exists(flow.flow_path) if flow.flow_path else False
             if not file_exists:
-                logger.warning(
-                    "Registered flow %s (id=%d) references missing file: %s",
-                    flow.name,
-                    flow.id,
-                    flow.flow_path,
-                )
+                _warn_missing_file_once(flow)
             result.append(
                 FlowRegistrationOut(
                     id=flow.id,

--- a/flowfile_core/flowfile_core/catalog/services/runs.py
+++ b/flowfile_core/flowfile_core/catalog/services/runs.py
@@ -44,9 +44,26 @@ class FlowRunService:
             return str(log_file)
         return None
 
-    def run_to_out(self, run: FlowRun) -> FlowRunOut:
+    def _display_names_for(self, runs: list[FlowRun]) -> dict[int, str]:
+        """Bulk-resolve ``registration_id -> current registration name``.
+
+        Used to override the run's snapshot ``flow_name`` (which after a save is
+        the prefixed file stem like ``9_house_price``) with the catalog's
+        user-typed name, so renames are reflected retroactively in run history.
+        """
+        ids = {r.registration_id for r in runs if r.registration_id is not None}
+        if not ids:
+            return {}
+        return {reg.id: reg.name for reg in self.repo.list_flows_by_ids(list(ids)) if reg.name}
+
+    def run_to_out(self, run: FlowRun, name_overrides: dict[int, str] | None = None) -> FlowRunOut:
         """Convert a FlowRun ORM row to FlowRunOut, computing has_log via FS."""
-        return run_to_out(run, has_log=self._resolve_log_path(run.id, run.run_type) is not None)
+        override = (name_overrides or {}).get(run.registration_id) if run.registration_id else None
+        return run_to_out(
+            run,
+            has_log=self._resolve_log_path(run.id, run.run_type) is not None,
+            display_name=override,
+        )
 
     def list_runs(
         self,
@@ -67,8 +84,9 @@ class FlowRunService:
         counts = self.repo.count_runs_by_status(
             registration_id=registration_id, schedule_id=schedule_id, run_type=run_type
         )
+        name_overrides = self._display_names_for(runs)
         return PaginatedFlowRuns(
-            items=[self.run_to_out(r) for r in runs],
+            items=[self.run_to_out(r, name_overrides) for r in runs],
             total=counts["total"],
             total_success=counts["success"],
             total_failed=counts["failed"],
@@ -80,10 +98,16 @@ class FlowRunService:
         run = self.repo.get_run(run_id)
         if run is None:
             raise RunNotFoundError(run_id=run_id)
+        display_name = None
+        if run.registration_id is not None:
+            reg = self.repo.get_flow(run.registration_id)
+            if reg is not None and reg.name:
+                display_name = reg.name
         return FlowRunDetail(
             id=run.id,
             registration_id=run.registration_id,
-            flow_name=run.flow_name,
+            flow_uuid=run.flow_uuid,
+            flow_name=display_name or run.flow_name,
             flow_path=run.flow_path,
             user_id=run.user_id,
             started_at=run.started_at,
@@ -116,10 +140,20 @@ class FlowRunService:
         number_of_nodes: int,
         run_type: RunType,
         flow_snapshot: str | None = None,
+        flow_uuid: str | None = None,
     ) -> FlowRun:
-        """Record a new flow run start."""
+        """Record a new flow run start.
+
+        ``flow_uuid``, if not supplied, is resolved from the registration so the
+        run row stays attributable after a registration delete+recreate.
+        """
+        if flow_uuid is None and registration_id is not None:
+            reg = self.repo.get_flow(registration_id)
+            if reg is not None:
+                flow_uuid = reg.flow_uuid
         run = FlowRun(
             registration_id=registration_id,
+            flow_uuid=flow_uuid,
             flow_name=flow_name,
             flow_path=flow_path,
             user_id=user_id,
@@ -172,13 +206,19 @@ class FlowRunService:
         run_type: RunType,
         node_results_json: str | None = None,
         flow_snapshot: str | None = None,
+        flow_uuid: str | None = None,
     ) -> FlowRun:
         """Record a fully completed run in one step (fallback when start_run was skipped)."""
         duration = None
         if started_at and ended_at:
             duration = (ended_at - started_at).total_seconds()
+        if flow_uuid is None and registration_id is not None:
+            reg = self.repo.get_flow(registration_id)
+            if reg is not None:
+                flow_uuid = reg.flow_uuid
         run = FlowRun(
             registration_id=registration_id,
+            flow_uuid=flow_uuid,
             flow_name=flow_name,
             flow_path=flow_path,
             user_id=user_id,
@@ -225,6 +265,7 @@ class FlowRunService:
         now = datetime.now(timezone.utc)
         run = FlowRun(
             registration_id=flow.id,
+            flow_uuid=flow.flow_uuid,
             flow_name=flow.name,
             flow_path=flow.flow_path,
             user_id=user_id,

--- a/flowfile_core/flowfile_core/database/models.py
+++ b/flowfile_core/flowfile_core/database/models.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Literal
 
 from sqlalchemy import (
@@ -153,6 +154,9 @@ class FlowRegistration(Base):
     __tablename__ = "flow_registrations"
 
     id = Column(Integer, primary_key=True, index=True)
+    # Stable identity that survives delete+recreate. Run history is keyed against this so
+    # SQLite reusing a deleted FlowRegistration.id can never pull another flow's runs in.
+    flow_uuid = Column(String(36), nullable=False, unique=True, default=lambda: str(uuid.uuid4()))
     name = Column(String, nullable=False, index=True)
     description = Column(Text, nullable=True)
     flow_path = Column(String, nullable=False)
@@ -169,6 +173,10 @@ class FlowRun(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     registration_id = Column(Integer, ForeignKey("flow_registrations.id"), nullable=True)
+    # Copied from FlowRegistration.flow_uuid at run-record creation. Survives the
+    # registration being deleted (registration_id is nulled) so historical runs stay
+    # attributable to the original flow without leaking under a new registration.
+    flow_uuid = Column(String(36), nullable=True, index=True)
     flow_name = Column(String, nullable=False)
     flow_path = Column(String, nullable=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -259,6 +259,26 @@ async def trigger_fetch_node_data(flow_id: int, node_id: int, background_tasks: 
     )
 
 
+def _resolve_run_identity(flow) -> tuple[int | None, str, str | None]:
+    """Return ``(registration_id, display_name, flow_path)`` for run-tracking.
+
+    Prefers the catalog registration's user-typed ``name`` over
+    ``flow.flow_settings.name``, which after a save is the file stem
+    (``9_house_price`` for ``9_house_price.yaml``) — that prefix is a filename
+    collision-avoidance trick that should never reach the run-history UI.
+    """
+    fallback_name = getattr(flow.flow_settings, "name", None) or getattr(flow, "__name__", "unknown")
+    flow_path = flow.flow_settings.path or flow.flow_settings.save_location
+    reg_id = getattr(flow.flow_settings, "source_registration_id", None)
+    display_name = fallback_name
+    if reg_id is not None:
+        with get_db_context() as db:
+            reg = SQLAlchemyCatalogRepository(db).get_flow(reg_id)
+            if reg is not None and reg.name:
+                display_name = reg.name
+    return reg_id, display_name, flow_path
+
+
 def _run_and_track(flow, user_id: int | None):
     """Wrapper that runs a flow and persists the run record to the database.
 
@@ -270,14 +290,11 @@ def _run_and_track(flow, user_id: int | None):
     completed but won't appear in the run history. Failures are logged at
     ERROR level so they're visible in logs.
     """
-    flow_name = getattr(flow.flow_settings, "name", None) or getattr(flow, "__name__", "unknown")
-
     # Resolve source_registration_id before execution so kernel nodes
     # (e.g. publish_global) can reference the catalog registration.
     resolve_source_registration_id(flow)
-    logger.debug(
-        f"source_registration_id for flow '{flow_name}': {getattr(flow.flow_settings, 'source_registration_id', None)}"
-    )
+    reg_id, flow_name, flow_path = _resolve_run_identity(flow)
+    logger.debug(f"source_registration_id for flow '{flow_name}': {reg_id}")
 
     # Phase 1: Create run record before execution
     run_id = None
@@ -291,8 +308,6 @@ def _run_and_track(flow, user_id: int | None):
             logger.warning(f"Flow '{flow_name}': snapshot serialization failed: {snap_err}")
 
         with get_db_context() as db:
-            reg_id = getattr(flow.flow_settings, "source_registration_id", None)
-            flow_path = flow.flow_settings.path or flow.flow_settings.save_location
             service = CatalogService(SQLAlchemyCatalogRepository(db))
             db_run = service.start_run(
                 registration_id=reg_id,
@@ -342,8 +357,6 @@ def _run_and_track(flow, user_id: int | None):
         else:
             # Fallback: create the full record if phase 1 failed
             with get_db_context() as db:
-                reg_id = getattr(flow.flow_settings, "source_registration_id", None)
-                flow_path = flow.flow_settings.path or flow.flow_settings.save_location
                 service = CatalogService(SQLAlchemyCatalogRepository(db))
                 service.create_completed_run(
                     registration_id=reg_id,
@@ -383,6 +396,14 @@ async def run_flow(
     """
     logger.info("starting to run...")
     flow = flow_file_handler.get_flow(flow_id)
+    if flow is None:
+        # Frontend's flow_id has drifted from the in-memory handler — typically
+        # after a Save As or backend restart. Surface a 404 so the UI can prompt
+        # a reload instead of falling through to an AttributeError 500.
+        raise HTTPException(
+            status_code=404,
+            detail=f"Flow {flow_id} is no longer in memory. Reload the flow and try again.",
+        )
     lock = get_flow_run_lock(flow_id)
     user_id = current_user.id if current_user else None
     async with lock:

--- a/flowfile_core/flowfile_core/schemas/catalog_schema.py
+++ b/flowfile_core/flowfile_core/schemas/catalog_schema.py
@@ -102,6 +102,7 @@ class CatalogTableSummary(BaseModel):
 class FlowRunOut(BaseModel):
     id: int
     registration_id: int | None = None
+    flow_uuid: str | None = None
     flow_name: str
     flow_path: str | None = None
     user_id: int

--- a/flowfile_core/tests/test_catalog.py
+++ b/flowfile_core/tests/test_catalog.py
@@ -216,6 +216,131 @@ class TestFlowRegistration:
         resp = client.delete(f"/catalog/flows/{created['id']}")
         assert resp.status_code == 204
 
+    def test_delete_flow_detaches_runs_preserves_uuid(self):
+        """Deleting a flow nulls FlowRun.registration_id but preserves flow_uuid.
+
+        The orphaned runs stay in the global Run History (attributed via uuid)
+        but never surface under another flow's per-flow page.
+        """
+        from datetime import datetime, timezone
+
+        ns_id = self._make_namespace()
+        flow = client.post(
+            "/catalog/flows",
+            json={"name": "victim", "flow_path": "/tmp/victim.yaml", "namespace_id": ns_id},
+        ).json()
+
+        with get_db_context() as db:
+            reg_uuid = db.query(FlowRegistration.flow_uuid).filter_by(id=flow["id"]).scalar()
+            assert reg_uuid is not None
+            db.add(
+                FlowRun(
+                    registration_id=flow["id"],
+                    flow_uuid=reg_uuid,
+                    flow_name="victim",
+                    flow_path="/tmp/victim.yaml",
+                    user_id=1,
+                    started_at=datetime.now(timezone.utc),
+                    number_of_nodes=1,
+                    run_type="in_designer_run",
+                )
+            )
+            db.commit()
+
+        client.delete(f"/catalog/flows/{flow['id']}")
+
+        with get_db_context() as db:
+            run = db.query(FlowRun).filter_by(flow_uuid=reg_uuid).one()
+            assert run.registration_id is None
+            assert run.flow_uuid == reg_uuid
+
+    def test_run_history_does_not_leak_after_id_reuse(self):
+        """A new flow that happens to take a deleted flow's registration_id
+        must not inherit the deleted flow's run history.
+        """
+        from datetime import datetime, timezone
+
+        ns_id = self._make_namespace()
+        original = client.post(
+            "/catalog/flows",
+            json={"name": "first", "flow_path": "/tmp/first.yaml", "namespace_id": ns_id},
+        ).json()
+        original_id = original["id"]
+
+        with get_db_context() as db:
+            reg_uuid = db.query(FlowRegistration.flow_uuid).filter_by(id=original_id).scalar()
+            db.add(
+                FlowRun(
+                    registration_id=original_id,
+                    flow_uuid=reg_uuid,
+                    flow_name="first",
+                    flow_path="/tmp/first.yaml",
+                    user_id=1,
+                    started_at=datetime.now(timezone.utc),
+                    number_of_nodes=1,
+                    run_type="in_designer_run",
+                )
+            )
+            db.commit()
+
+        client.delete(f"/catalog/flows/{original_id}")
+
+        # Force a new registration row to claim the same id (simulating SQLite
+        # reusing the freed id, which is what was contaminating the user's
+        # per-flow Run History page).
+        with get_db_context() as db:
+            new_reg = FlowRegistration(
+                id=original_id,
+                flow_uuid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                name="reused",
+                flow_path="/tmp/reused.yaml",
+                namespace_id=ns_id,
+                owner_id=1,
+            )
+            db.add(new_reg)
+            db.commit()
+
+        resp = client.get("/catalog/runs", params={"registration_id": original_id})
+        assert resp.status_code == 200
+        # Must be empty: the orphaned run still has the original flow_uuid,
+        # but the new registration has a different flow_uuid.
+        assert resp.json()["total"] == 0
+        assert resp.json()["items"] == []
+
+    def test_run_history_uses_current_registration_name(self):
+        """Run-history list must show the registration's current user-typed name,
+        not the file-stem snapshot baked into FlowRun.flow_name at run time.
+        """
+        from datetime import datetime, timezone
+
+        ns_id = self._make_namespace()
+        flow = client.post(
+            "/catalog/flows",
+            json={"name": "nice_name", "flow_path": "/tmp/nice.yaml", "namespace_id": ns_id},
+        ).json()
+
+        with get_db_context() as db:
+            reg_uuid = db.query(FlowRegistration.flow_uuid).filter_by(id=flow["id"]).scalar()
+            db.add(
+                FlowRun(
+                    registration_id=flow["id"],
+                    flow_uuid=reg_uuid,
+                    # Simulate the buggy historical capture: prefixed file stem.
+                    flow_name="9_nice_name",
+                    flow_path="/tmp/nice.yaml",
+                    user_id=1,
+                    started_at=datetime.now(timezone.utc),
+                    number_of_nodes=1,
+                    run_type="in_designer_run",
+                )
+            )
+            db.commit()
+
+        items = client.get("/catalog/runs").json()["items"]
+        assert len(items) == 1
+        # Display must use the registration's current name, not the snapshot.
+        assert items[0]["flow_name"] == "nice_name"
+
     def test_flow_file_exists_false_for_missing_path(self):
         ns_id = self._make_namespace()
         created = client.post(
@@ -228,6 +353,37 @@ class TestFlowRegistration:
         ).json()
         resp = client.get(f"/catalog/flows/{created['id']}")
         assert resp.json()["file_exists"] is False
+
+    def test_missing_file_warning_is_deduped(self, caplog):
+        """First lookup of a missing-file flow logs a warning; subsequent lookups
+        within the same process must not re-log it (avoids per-page-load spam)."""
+        import logging
+
+        from flowfile_core.catalog.services import flows as flows_module
+
+        ns_id = self._make_namespace()
+        created = client.post(
+            "/catalog/flows",
+            json={
+                "name": "ghost_dedupe",
+                "flow_path": "/tmp/missing_dedupe_xyz.yaml",
+                "namespace_id": ns_id,
+            },
+        ).json()
+
+        # Reset the process-local memo so this test is order-independent.
+        flows_module._warned_missing_paths.clear()
+        # Drop any records left over from the POST above; we only want to
+        # count what gets emitted by the GETs below.
+        caplog.clear()
+
+        with caplog.at_level(logging.WARNING, logger=flows_module.logger.name):
+            client.get(f"/catalog/flows/{created['id']}")
+            client.get(f"/catalog/flows/{created['id']}")
+            client.get(f"/catalog/flows/{created['id']}")
+
+        warnings = [r for r in caplog.records if "references missing file" in r.getMessage()]
+        assert len(warnings) == 1, f"expected 1 warning, got {len(warnings)}: {warnings}"
 
 
 class TestCatalogTableMaterialization:
@@ -393,11 +549,15 @@ class TestRuns:
             json={"name": "run_flow", "flow_path": "/tmp/run_flow.yaml", "namespace_id": schema["id"]},
         ).json()
 
-        # Create 5 runs directly in DB
+        # Create 5 runs directly in DB. flow_uuid must be copied from the
+        # registration so the per-flow filter (which routes through flow_uuid)
+        # finds them.
         with get_db_context() as db:
+            reg_uuid = db.query(FlowRegistration.flow_uuid).filter_by(id=flow["id"]).scalar()
             for i in range(5):
                 run = FlowRun(
                     registration_id=flow["id"],
+                    flow_uuid=reg_uuid,
                     flow_name="run_flow",
                     flow_path="/tmp/run_flow.yaml",
                     user_id=1,
@@ -1120,10 +1280,13 @@ class TestPushTableTrigger:
             lambda *a, **kw: None,
         )
 
-        # Create an active (unfinished) run
+        # Create an active (unfinished) run. flow_uuid must match the
+        # registration so has_active_run (which routes through flow_uuid) finds it.
         with get_db_context() as db:
+            reg_uuid = db.query(FlowRegistration.flow_uuid).filter_by(id=flow_id).scalar()
             active_run = FlowRun(
                 registration_id=flow_id,
+                flow_uuid=reg_uuid,
                 flow_name="triggered_flow",
                 flow_path="/tmp/triggered.yaml",
                 user_id=1,

--- a/flowfile_core/tests/test_endpoints.py
+++ b/flowfile_core/tests/test_endpoints.py
@@ -431,6 +431,14 @@ def test_run_invalid_flow():
     assert response.status_code == 200, "Flow should just start as normal"
 
 
+def test_run_flow_returns_404_for_unknown_id():
+    """Stale flow_ids (e.g. after Save As re-keying) must surface as a clean 404
+    so the frontend can prompt a reload — not crash with AttributeError 500."""
+    response = client.post("/flow/run/", params={"flow_id": 999_999_999})
+    assert response.status_code == 404
+    assert "no longer in memory" in response.json()["detail"].lower()
+
+
 def test_save_flow():
     flow_id = create_flow_with_manual_input_and_select()
     imported_flow = flow_file_handler.get_flow(flow_id)

--- a/flowfile_frontend/src/renderer/app/components/layout/Header/run.vue
+++ b/flowfile_frontend/src/renderer/app/components/layout/Header/run.vue
@@ -33,7 +33,9 @@ const props = defineProps({
   },
 });
 
-// Use the composable
+// Pass a getter so the composable always reads the *current* prop value.
+// Without this, Save As re-keys nodeStore.flow_id but the run button keeps
+// firing /flow/run/ and getFlowSettings against the old (template) id.
 const {
   runFlow: executeFlow,
   cancelFlow,
@@ -41,7 +43,7 @@ const {
   startPolling,
   stopPolling,
   checkRunStatus,
-} = useFlowExecution(props.flowId, props.pollingConfig, {
+} = useFlowExecution(() => props.flowId, props.pollingConfig, {
   persistPolling: props.persistPolling,
   pollingKey: `run_button_${props.flowId}`,
 });

--- a/flowfile_frontend/src/renderer/app/components/nodes/NodeWrapper.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/NodeWrapper.vue
@@ -187,9 +187,11 @@ const flowStore = useFlowStore();
 const nodeEl = ref<HTMLElement | null>(null);
 const menuEl = ref<HTMLElement | null>(null);
 
-// Use the flow execution composable with persistent polling
+// Use the flow execution composable with persistent polling.
+// Getter form (not a snapshot number) so Save As doesn't leave the node
+// polling against the old flow id.
 const { triggerNodeFetch, isPollingActive } = useFlowExecution(
-  flowStore.flowId,
+  () => flowStore.flowId,
   { interval: 2000, enabled: true },
   {
     persistPolling: true,

--- a/flowfile_frontend/src/renderer/app/composables/useFlowExecution.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useFlowExecution.ts
@@ -90,7 +90,12 @@ const updateRunStatus = async (
 };
 
 export function useFlowExecution(
-  flowId: Ref<number> | number,
+  // Accept a getter (`() => number`) or a Ref so the composable always reads
+  // the *current* flow_id. Passing a raw number freezes the value at setup
+  // time — fine only for components whose flow id is fixed for their entire
+  // lifetime. After Save As re-keys to a new id, callers that captured the
+  // old number keep polling stale endpoints.
+  flowId: Ref<number> | number | (() => number),
   pollingConfig: PollingConfig = {
     interval: 2000,
     enabled: true,
@@ -110,6 +115,7 @@ export function useFlowExecution(
 
   // Get the actual flow ID value
   const getFlowId = () => {
+    if (typeof flowId === "function") return flowId();
     return typeof flowId === "number" ? flowId : flowId.value;
   };
 
@@ -292,13 +298,28 @@ export function useFlowExecution(
       });
       nodeStore.showLogViewer();
       startPolling(() => checkRunStatus());
-    } catch (error) {
+    } catch (error: any) {
       console.error("Error starting run:", error);
       unFreezeFlow();
       editorStore.isRunning = false;
       isExecuting.value = false;
       state.setExecutionState(getPollingKey(), false);
-      showNotification("Error", "Failed to start the flow", "error");
+      // 404 means the in-memory flow_id doesn't match the backend — typically
+      // a stale id after Save As or a backend restart. Tell the user
+      // specifically so they reopen instead of retrying blindly.
+      if (error?.response?.status === 404) {
+        const detail =
+          error?.response?.data?.detail ??
+          "The flow id this tab is using no longer exists on the server.";
+        showNotification("Flow id is stale", `${detail} Reopen the flow and try again.`, "error");
+      } else {
+        const detail = error?.response?.data?.detail ?? error?.message;
+        showNotification(
+          "Error",
+          detail ? `Failed to start the flow: ${detail}` : "Failed to start the flow",
+          "error",
+        );
+      }
     }
   };
 

--- a/flowfile_frontend/src/renderer/app/features/designer/dataPreview.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/dataPreview.vue
@@ -233,9 +233,11 @@ const props = withDefaults(defineProps<Props>(), {
   flowId: undefined,
 });
 
-// Use the flow execution composable with persistent polling for node fetches
+// Use the flow execution composable with persistent polling for node fetches.
+// Getter form so Save As re-keying nodeStore.flow_id doesn't leave us polling
+// the old (template) id.
 const { triggerNodeFetch, isPollingActive } = useFlowExecution(
-  props.flowId || nodeStore.flow_id,
+  () => props.flowId || nodeStore.flow_id,
   { interval: 2000, enabled: true },
   {
     persistPolling: true, // Keep polling even when component unmounts
@@ -464,9 +466,7 @@ const windowKeyHandler = async (e: KeyboardEvent) => {
   // Don't fight the browser when the user is in a text input or editor.
   if (
     target &&
-    (target.tagName === "INPUT" ||
-      target.tagName === "TEXTAREA" ||
-      target.isContentEditable)
+    (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
   ) {
     return;
   }

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/DesignerView.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/DesignerView.vue
@@ -77,6 +77,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, nextTick } from "vue";
 import { useRouter } from "vue-router";
+import { ElNotification } from "element-plus";
 import HeaderButtons from "../../components/layout/Header/HeaderButtons.vue";
 import Status from "../../features/designer/editor/status.vue";
 import CanvasFlow from "./Canvas.vue";
@@ -86,6 +87,9 @@ import { FlowApi } from "../../api";
 import { fetchNodes } from "../../features/designer/utils";
 import type { NodeTemplate, FlowSettings } from "../../types";
 import { useNodeStore } from "../../stores/column-store";
+
+const notifyError = (title: string, message: string) =>
+  ElNotification({ title, message, type: "error", position: "top-left" });
 
 const router = useRouter();
 
@@ -140,10 +144,12 @@ const openFlow = (eventData: { message: string; flowPath: string }) => {
 const reloadCanvas = async (flowPath: string) => {
   isSwitching.value = true;
   try {
-    console.log("reloadCanvas", flowPath);
     const flowId = await importSavedFlow(flowPath);
     if (flowId === undefined) {
-      console.error("Failed to import flow from path:", flowPath);
+      notifyError(
+        "Couldn't open flow",
+        `Server returned no flow id for ${flowPath}. The file may be missing or unreadable.`,
+      );
       return;
     }
     // setFlowId triggers the Canvas watcher which loads the flow.
@@ -152,6 +158,9 @@ const reloadCanvas = async (flowPath: string) => {
       await headerButtons.value.loadFlowSettings();
     }
     await fetchActiveFlows();
+  } catch (error: any) {
+    const detail = error?.response?.data?.detail ?? error?.message ?? String(error);
+    notifyError("Couldn't open flow", `Failed to open ${flowPath}: ${detail}`);
   } finally {
     isSwitching.value = false;
   }

--- a/flowfile_frontend/src/renderer/app/views/FlowSelectorView/FlowSelectorView.vue
+++ b/flowfile_frontend/src/renderer/app/views/FlowSelectorView/FlowSelectorView.vue
@@ -1,17 +1,19 @@
 <template>
-  <!-- TODO(ux): switch the dirty-dot color based on the active theme's
-       accent, and consider moving it so it sits adjacent to the close icon
-       on the right instead of inline with the tab name. -->
   <div class="flow-tabs-container">
     <div class="flow-tabs">
       <el-tooltip
         v-for="flow in flows"
         :key="flow.flow_id"
-        :content="flow.display_name || flow.name"
         placement="bottom"
         :show-after="400"
         :hide-after="0"
       >
+        <template #content>
+          <div>{{ flow.display_name || flow.name }}</div>
+          <div v-if="isDirty(flow.flow_id)" class="tooltip-dirty-line">
+            ● Unsaved changes
+          </div>
+        </template>
         <div
           class="flow-tab"
           :class="{ active: selectedFlowId === flow.flow_id, dirty: isDirty(flow.flow_id) }"
@@ -20,15 +22,19 @@
           <div class="tab-content">
             <span class="material-icons tab-icon">account_tree</span>
             <span class="tab-name">{{ flow.display_name || flow.name }}</span>
+          </div>
+          <span class="tab-indicator">
             <span
               v-if="isDirty(flow.flow_id)"
               class="dirty-dot"
               aria-label="Unsaved changes"
-              title="Unsaved changes"
             ></span>
-          </div>
-          <span class="material-icons close-icon" @click.stop="confirmCloseTab(flow.flow_id)">
-            close
+            <span
+              class="material-icons close-icon"
+              @click.stop="confirmCloseTab(flow.flow_id)"
+            >
+              close
+            </span>
           </span>
         </div>
       </el-tooltip>
@@ -344,7 +350,7 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: var(--spacing-2);
-  width: calc(100% - 20px);
+  width: calc(100% - 24px);
   overflow: hidden;
 }
 
@@ -367,13 +373,30 @@ defineExpose({
 /* TODO(ux): announce dirty-state changes via aria-live so screen readers
    are notified when a flow becomes dirty, instead of relying on the static
    aria-label alone. */
-.dirty-dot {
+.tab-indicator {
+  position: absolute;
+  right: var(--spacing-2);
+  top: 50%;
+  transform: translateY(-50%);
+  display: grid;
+  place-items: center;
+  width: 18px;
+  height: 18px;
   flex-shrink: 0;
-  width: 6px;
-  height: 6px;
+}
+
+.tab-indicator > .dirty-dot,
+.tab-indicator > .close-icon {
+  grid-area: 1 / 1;
+}
+
+.dirty-dot {
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  background-color: var(--color-accent, #1976d2);
-  margin-left: var(--spacing-1, 4px);
+  background-color: var(--color-primary, #1976d2);
+  transition: opacity var(--transition-fast);
+  pointer-events: none;
 }
 
 .flow-tab.dirty .tab-name {
@@ -388,27 +411,39 @@ defineExpose({
   font-size: var(--font-size-lg);
   color: var(--color-text-muted);
   opacity: 0;
-  position: absolute;
-  right: var(--spacing-2);
   border-radius: var(--border-radius-full);
   padding: 2px;
-  transition: all var(--transition-fast);
+  cursor: pointer;
   transform: scale(0.9);
+  transition: opacity var(--transition-fast),
+              background-color var(--transition-fast),
+              color var(--transition-fast),
+              transform var(--transition-fast);
 }
 
 .flow-tab:hover .close-icon {
   opacity: 1;
+  transform: scale(1);
+}
+
+.flow-tab.dirty:hover .dirty-dot {
+  opacity: 0;
 }
 
 .close-icon:hover {
   background-color: var(--color-background-tertiary);
   color: var(--color-text-secondary);
-  transform: scale(1);
 }
 
 .active .close-icon:hover {
   background-color: var(--color-background-hover);
   color: var(--color-primary);
+}
+
+.tooltip-dirty-line {
+  margin-top: 4px;
+  font-size: 11px;
+  opacity: 0.9;
 }
 
 /* New flow tab styling */

--- a/flowfile_frontend/src/renderer/styles/components/_styled-table.css
+++ b/flowfile_frontend/src/renderer/styles/components/_styled-table.css
@@ -22,20 +22,10 @@
   vertical-align: middle;
 }
 
-/* Column Widths */
-.styled-table th:first-child,
-.styled-table td:first-child {
-  width: 35%;
-}
-
-.styled-table th:nth-child(2),
-.styled-table td:nth-child(2) {
-  width: 30%;
-}
-
+/* Last-cell border reset (column widths intentionally not set here — let
+ * table-layout: fixed distribute evenly, or each table override per-column) */
 .styled-table th:last-child,
 .styled-table td:last-child {
-  width: 35%;
   border-right: none;
 }
 

--- a/flowfile_worker/flowfile_worker/funcs.py
+++ b/flowfile_worker/flowfile_worker/funcs.py
@@ -127,7 +127,7 @@ def apply_model_task(
 
     flowfile_logger = get_worker_logger(flowfile_flow_id, flowfile_node_id)
     flowfile_logger.info(
-        f"Starting apply_model_task: model_path={model_path}, output_column={output_column}"
+        f"Starting apply_model_task, output_column={output_column}"
     )
     try:
         with open(model_path, "rb") as f:
@@ -137,7 +137,7 @@ def apply_model_task(
         scored_lf = trainer.apply(lf, model, output_column)
         scored_df = collect_lazy_frame(scored_lf)
         scored_df.write_ipc(file_path)
-        flowfile_logger.info(f"apply_model_task scored {scored_df.height} rows -> {file_path}")
+        flowfile_logger.info(f"apply_model_task scored {scored_df.height} rows")
         with progress.get_lock():
             progress.value = 100
     except Exception as e:


### PR DESCRIPTION
This pull request introduces a stable identity for flows by adding a `flow_uuid` field to both `flow_registrations` and `flow_runs`. This change ensures that historical run attribution is preserved even if a flow registration is deleted and its database ID is reused, which is particularly important for SQLite's row ID reuse behavior. Additionally, the codebase is refactored to consistently use `flow_uuid` for run attribution and statistics, and the user experience is improved by displaying the current flow name in run history, even after renames. There are also improvements to logging for missing flow files.

The most important changes are:

**Database schema and attribution improvements:**

* Added a `flow_uuid` field to `flow_registrations` and `flow_runs`, including a migration script to backfill and enforce uniqueness, ensuring that run history cannot be incorrectly attributed after a registration is deleted and its ID is reused. (`flowfile_core/alembic/versions/010_flow_uuid.py`)
* All queries and statistics that previously used `registration_id` for grouping or filtering runs are refactored to use `flow_uuid`, preventing run history from being mixed up after flow registration deletion and recreation. (`repository.py`) [[1]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9R401-R443) [[2]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L471-R521) [[3]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L497-R546) [[4]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L514-L525) [[5]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L575-R621) [[6]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L730-R821) [[7]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9L905-R956)

**User experience improvements:**

* Run history now displays the current user-typed flow name (from the registration) instead of the snapshot name captured at run time, so renames are reflected retroactively in the UI. (`serializers.py`, `services/runs.py`) [[1]](diffhunk://#diff-cb31ad8351c2f12bca51b69cf43ac2dd13d70a1c3dc5cbc95564de11a5378bdeL32-R44) [[2]](diffhunk://#diff-743ca9f94a2f305421a4fbaed6076714205627f160fa7ed3c997e73a9e5309e3L47-R66) [[3]](diffhunk://#diff-743ca9f94a2f305421a4fbaed6076714205627f160fa7ed3c997e73a9e5309e3R87-R89) [[4]](diffhunk://#diff-743ca9f94a2f305421a4fbaed6076714205627f160fa7ed3c997e73a9e5309e3R101-R110)

**API and service changes:**

* Added a `list_flows_by_ids` repository method for efficient bulk lookup of flow registrations, supporting the new name resolution logic. (`repository.py`) [[1]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9R78-R79) [[2]](diffhunk://#diff-b9ee68cb6feede6a22ebec1bdbb7d7336e521ff8216f5cf93ce7764b70f7afa9R377-R381)
* The `start_run` service method now sets `flow_uuid` for new runs, either from the provided value or by resolving from the registration, ensuring all runs have correct attribution. (`services/runs.py`)

**Operational/logging improvements:**

* Added a process-local memoization to ensure missing flow file warnings are logged only once per (id, path) per process, reducing log noise for repeated catalog requests. (`services/flows.py`) [[1]](diffhunk://#diff-6efd6fc8a30f6e67bcd5e3dba1816d7bc7887a59da68c124898c6e5e4e45635fR25-R45) [[2]](diffhunk://#diff-6efd6fc8a30f6e67bcd5e3dba1816d7bc7887a59da68c124898c6e5e4e45635fL47-R68) [[3]](diffhunk://#diff-6efd6fc8a30f6e67bcd5e3dba1816d7bc7887a59da68c124898c6e5e4e45635fL99-R115)