### PR TITLE
fix file browser and add group by drag system

### DIFF
--- a/flowfile_frontend/src/renderer/app/components/common/FileBrowser/fileBrowser.vue
+++ b/flowfile_frontend/src/renderer/app/components/common/FileBrowser/fileBrowser.vue
@@ -91,7 +91,7 @@
               'is-directory': file.is_directory,
             }"
             @click.stop="handleSingleClick(file)"
-            @dblclick="handleDoubleClick(file)"
+            @dblclick.stop="handleDoubleClick(file)"
           >
             <div class="file-item-content">
               <div class="file-icon-wrapper">

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/groupBy/GroupBy.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/groupBy/GroupBy.vue
@@ -13,8 +13,12 @@
           >
             <li
               :class="{ 'is-selected': selectedColumns.includes(col_schema.name) }"
+              draggable="true"
               @click="handleItemClick(index, col_schema.name, $event)"
               @contextmenu="openContextMenu(index, col_schema.name, $event)"
+              @dragstart="onDragStart(col_schema.name, $event)"
+              @dragover.prevent
+              @drop="onDrop(index)"
             >
               {{ col_schema.name }} ({{ col_schema.data_type }})
             </li>
@@ -43,7 +47,7 @@
 
       <div class="listbox-subtitle">Settings</div>
 
-      <div v-if="dataLoaded" class="table-wrapper">
+      <div v-if="dataLoaded" class="table-wrapper" @dragover.prevent @drop="onDropInTable">
         <table class="styled-table">
           <thead>
             <tr>
@@ -135,10 +139,46 @@ const aggOptions: (AggOption | GroupByOption)[] = [
   "concat",
 ];
 const firstSelectedIndex = ref<number | null>(null);
+const draggedColumnName = ref<string | null>(null);
 
 const groupByInput = ref<GroupByInput>({
   agg_cols: [],
 });
+
+const onDragStart = (columnName: string, event: DragEvent) => {
+  draggedColumnName.value = columnName;
+  event.dataTransfer?.setData("text/plain", columnName);
+};
+
+const onDrop = (index: number) => {
+  if (draggedColumnName.value) {
+    const colSchema = nodeData.value?.main_input?.table_schema;
+    if (colSchema) {
+      const fromIndex = colSchema.findIndex((col) => col.name === draggedColumnName.value);
+      if (fromIndex !== -1 && fromIndex !== index) {
+        const [movedColumn] = colSchema.splice(fromIndex, 1);
+        colSchema.splice(index, 0, movedColumn);
+      }
+    }
+    draggedColumnName.value = null;
+  }
+};
+
+const onDropInTable = () => {
+  if (!draggedColumnName.value) return;
+  const column = draggedColumnName.value;
+  const alreadyGroupedBy = groupByInput.value.agg_cols.some(
+    (row) => row.old_name === column && row.agg === "groupby",
+  );
+  if (!alreadyGroupedBy) {
+    groupByInput.value.agg_cols.push({
+      old_name: column,
+      agg: "groupby",
+      new_name: column,
+    });
+  }
+  draggedColumnName.value = null;
+};
 
 const openRowContextMenu = (event: MouseEvent, index: number) => {
   event.preventDefault();

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/output/Output.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/output/Output.vue
@@ -83,6 +83,7 @@
       v-model="showFileSelectionModal"
       title="Select directory or file to write to"
       width="70%"
+      :close-on-click-modal="false"
     >
       <file-browser
         :allowed-file-types="['csv', 'xlsx', 'parquet']"

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/read/Read.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/read/Read.vue
@@ -47,7 +47,12 @@
         </div>
       </div>
 
-      <el-dialog v-model="modalVisibleForOpen" title="Select a file to Read" width="70%">
+      <el-dialog
+        v-model="modalVisibleForOpen"
+        title="Select a file to Read"
+        width="70%"
+        :close-on-click-modal="false"
+      >
         <file-browser
           :allowed-file-types="['csv', 'txt', 'parquet', 'xlsx']"
           mode="open"


### PR DESCRIPTION
This pull request introduces several user experience improvements and new drag-and-drop functionality to the file selection and group-by components in the frontend. The most significant changes are the addition of drag-and-drop column reordering and grouping in the `GroupBy` node, as well as enhancements to modal dialogs to prevent accidental closure. There is also a minor fix to event handling in the file browser.

**GroupBy Node: Drag-and-Drop Enhancements**
* Added drag-and-drop support to reorder columns in the group-by column list by making list items draggable and handling `dragstart`, `dragover`, and `drop` events. (`GroupBy.vue`) [[1]](diffhunk://#diff-68b6015763e62e15e67a44c5bb7c8fa9b03342e875acef717c8fa62936746589R16-R21) [[2]](diffhunk://#diff-68b6015763e62e15e67a44c5bb7c8fa9b03342e875acef717c8fa62936746589R142-R182)
* Enabled drag-and-drop grouping: dragging a column into the table area will automatically add it to the group-by columns if not already present. (`GroupBy.vue`) [[1]](diffhunk://#diff-68b6015763e62e15e67a44c5bb7c8fa9b03342e875acef717c8fa62936746589L46-R50) [[2]](diffhunk://#diff-68b6015763e62e15e67a44c5bb7c8fa9b03342e875acef717c8fa62936746589R142-R182)

**Modal Dialog Improvements**
* Updated file selection dialogs in both the Output and Read nodes to set `:close-on-click-modal="false"`, preventing accidental closure when clicking outside the modal. (`Output.vue`, `Read.vue`) [[1]](diffhunk://#diff-c281fcd34ffac43aac5d5cf6b6975f7803ba327e8d9af05b3dfdce4b131fdbc5R86) [[2]](diffhunk://#diff-ed134c12401d6bcd935f326817454159aa74aa5231b2d19963b7fecf6233caa9L50-R55)

**File Browser Event Handling**
* Fixed double-click event propagation in the file browser by adding `.stop` modifier to the `@dblclick` event, ensuring it does not bubble up unintentionally. (`fileBrowser.vue`)

fixes #449 and adds #448 