### PR TITLE
Feature/group nodes

### DIFF
--- a/flowfile/tests/test_api.py
+++ b/flowfile/tests/test_api.py
@@ -342,7 +342,6 @@ class TestFlowfileAPI:
         stop_flowfile_server_process()
 
 
-
 if __name__ == "__main__":
     # Run tests with pytest
     pytest.main([__file__, "-v", "-s"])

--- a/flowfile_core/flowfile_core/ai/tools/registry.py
+++ b/flowfile_core/flowfile_core/ai/tools/registry.py
@@ -201,11 +201,16 @@ def _node_settings_to_tool_spec(node_type: str, settings_cls: type) -> ToolSpec:
 #   dependency fields on ``NodeSingleInput`` / ``NodeMultiInput``; resolver
 #   canonicalises against ``InsertionContext.upstream_node_ids`` so the LLM
 #   does not need to fill them.
-# * ``cache_results`` / ``pos_x`` / ``pos_y`` / ``is_setup`` / ``description``
-#   / ``node_reference`` / ``user_id`` / ``is_flow_output`` /
-#   ``is_user_defined`` / ``output_field_config`` — NodeBase metadata not
+# * ``cache_results`` / ``pos_x`` / ``pos_y`` / ``group_id`` / ``is_setup``
+#   / ``description`` / ``node_reference`` / ``user_id`` / ``is_flow_output``
+#   / ``is_user_defined`` / ``output_field_config`` — NodeBase metadata not
 #   needed for stage-3 settings authoring. All have safe defaults; positions
-#   and ``user_id`` are filled by other planner machinery.
+#   and ``user_id`` are filled by other planner machinery. ``group_id`` is
+#   visual group membership (organizational only, no execution impact) — the
+#   agent leaves new nodes ungrouped at the ``None`` default. Stripping it
+#   also keeps single-input inner-shape detection working: an unfiltered
+#   NodeBase field would make ``_resolve_inner_input_field`` see two
+#   type-specific fields and fall back to the enveloped spec.
 _PLANNER_INJECTED_SETTINGS_FIELDS: Final[frozenset[str]] = frozenset(
     {
         "flow_id",
@@ -215,6 +220,7 @@ _PLANNER_INJECTED_SETTINGS_FIELDS: Final[frozenset[str]] = frozenset(
         "cache_results",
         "pos_x",
         "pos_y",
+        "group_id",
         "is_setup",
         "description",
         "node_reference",

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -901,6 +901,10 @@ class FlowGraph:
         self._output_cols = [] if output_cols is None else output_cols
         self._node_ids = []
         self._node_db = {}
+        # Visual node groups: organizational only, never read by the executor.
+        # Membership lives on each node's setting_input.group_id; this is the box registry.
+        self._groups: dict[int, schemas.GroupInformation] = {}
+        self._active_group_id: int | None = None
         self.cache_results = cache_results
         self.__name__ = name if name else "flow_" + str(id(self))
         self.depends_on = {}
@@ -1070,6 +1074,7 @@ class FlowGraph:
         self._node_db.clear()
         self._node_ids.clear()
         self._flow_starts.clear()
+        self._groups.clear()
         self._results = None
 
         # Restore flow settings (preserve original flow_id and source_registration_id)
@@ -1153,9 +1158,198 @@ class FlowGraph:
 
                 to_node.add_node_connection(from_node, insert_type)
 
+        # Member group_ids were re-applied above via add_<type>(setting_input);
+        # repopulate the box registry (name/color/bounds) from the snapshot.
+        self.restore_groups(flow_info.groups)
+
         logger.info(f"Restored flow from snapshot with {len(self._node_db)} nodes")
 
     # ==================== End History Management Methods ====================
+
+    # ==================== Group Management Methods ====================
+    # Groups are purely visual containers. They never affect execution; the only
+    # link to a node is that node's setting_input.group_id. The group box props
+    # (name/color/bounds) live in self._groups and ride along in FlowfileData.
+
+    def _next_group_id(self) -> int:
+        """Allocate a group id unique among this flow's groups (separate from node ids)."""
+        return (max(self._groups) if self._groups else 0) + 1
+
+    def _member_node_ids(self, group_id: int) -> list[int]:
+        """Derive a group's members by scanning node group_id (single source of truth)."""
+        return [node.node_id for node in self.nodes if getattr(node.setting_input, "group_id", None) == group_id]
+
+    def _set_node_group(self, node_id: int, group_id: int | None) -> None:
+        node = self.get_node(node_id)
+        if node is not None and node.setting_input is not None and hasattr(node.setting_input, "group_id"):
+            node.setting_input.group_id = group_id
+
+    def _recompute_group_bounds(self, group_id: int | None = None) -> None:
+        """Refit one or all group boxes around their member nodes.
+
+        Uses nominal node dimensions since the backend doesn't know rendered sizes;
+        the frontend refines bounds on first user interaction. Groups with no members
+        keep their current bounds.
+        """
+        node_width, node_height, padding, header = 180.0, 80.0, 40.0, 36.0
+        target_ids = [group_id] if group_id is not None else list(self._groups)
+        for gid in target_ids:
+            group = self._groups.get(gid)
+            if group is None:
+                continue
+            members = [self.get_node(nid) for nid in self._member_node_ids(gid)]
+            members = [m for m in members if m is not None and m.setting_input is not None]
+            if not members:
+                continue
+            xs = [float(m.setting_input.pos_x or 0) for m in members]
+            ys = [float(m.setting_input.pos_y or 0) for m in members]
+            min_x, min_y = min(xs), min(ys)
+            max_x = max(x + node_width for x in xs)
+            max_y = max(y + node_height for y in ys)
+            group.x_position = min_x - padding
+            group.y_position = min_y - padding - header
+            group.width = (max_x - min_x) + 2 * padding
+            group.height = (max_y - min_y) + 2 * padding + header
+
+    def create_group(
+        self,
+        name: str,
+        node_ids: list[int],
+        *,
+        color: schemas.GroupColor | None = None,
+        bounds: schemas.GroupBounds | None = None,
+    ) -> schemas.GroupInformation:
+        """Create a visual group and assign the given nodes to it. Organizational only.
+
+        Bounds are computed from member positions when not supplied.
+        """
+
+        def _do() -> schemas.GroupInformation:
+            group_id = self._next_group_id()
+            group = schemas.GroupInformation(id=group_id, name=name, color=color)
+            if bounds is not None:
+                group.x_position, group.y_position, group.width, group.height = bounds
+            self._groups[group_id] = group
+            for node_id in node_ids:
+                self._set_node_group(node_id, group_id)
+            if bounds is None:
+                self._recompute_group_bounds(group_id)
+            return group
+
+        return self._execute_with_history(_do, HistoryActionType.CREATE_GROUP, f"Create group '{name}'")
+
+    def update_group(
+        self,
+        group_id: int,
+        *,
+        name: str | None = None,
+        color: schemas.GroupColor | None = None,
+        bounds: schemas.GroupBounds | None = None,
+        collapsed: bool | None = None,
+    ) -> schemas.GroupInformation:
+        """Rename / recolor / move / resize / collapse a group box."""
+        group = self._groups.get(group_id)
+        if group is None:
+            raise ValueError(f"Group {group_id} does not exist")
+
+        def _do() -> schemas.GroupInformation:
+            if name is not None:
+                group.name = name
+            if color is not None:
+                group.color = color
+            if bounds is not None:
+                group.x_position, group.y_position, group.width, group.height = bounds
+            if collapsed is not None:
+                group.collapsed = collapsed
+            return group
+
+        return self._execute_with_history(_do, HistoryActionType.UPDATE_GROUP, f"Update group '{group.name}'")
+
+    def delete_group(self, group_id: int) -> None:
+        """Remove a group box (ungroup). Member nodes are kept."""
+        group = self._groups.get(group_id)
+        if group is None:
+            return
+
+        def _do() -> None:
+            for node_id in self._member_node_ids(group_id):
+                self._set_node_group(node_id, None)
+            self._groups.pop(group_id, None)
+
+        self._execute_with_history(_do, HistoryActionType.DELETE_GROUP, f"Delete group '{group.name}'")
+
+    def add_nodes_to_group(self, group_id: int, node_ids: list[int]) -> schemas.GroupInformation:
+        """Add nodes to an existing group and refit its bounds."""
+        group = self._groups.get(group_id)
+        if group is None:
+            raise ValueError(f"Group {group_id} does not exist")
+
+        def _do() -> schemas.GroupInformation:
+            for node_id in node_ids:
+                self._set_node_group(node_id, group_id)
+            self._recompute_group_bounds(group_id)
+            return group
+
+        return self._execute_with_history(_do, HistoryActionType.UPDATE_GROUP_MEMBERSHIP, "Add nodes to group")
+
+    def remove_nodes_from_group(self, node_ids: list[int]) -> None:
+        """Remove nodes from whatever group they belong to; prune groups left empty."""
+
+        def _do() -> None:
+            affected: set[int] = set()
+            for node_id in node_ids:
+                node = self.get_node(node_id)
+                current = getattr(node.setting_input, "group_id", None) if node is not None else None
+                if current is not None:
+                    affected.add(current)
+                    self._set_node_group(node_id, None)
+            for gid in affected:
+                if not self._member_node_ids(gid):
+                    self._groups.pop(gid, None)
+                else:
+                    self._recompute_group_bounds(gid)
+
+        self._execute_with_history(_do, HistoryActionType.UPDATE_GROUP_MEMBERSHIP, "Remove nodes from group")
+
+    def assign_node_to_named_group(
+        self, node_id: int, name: str, *, color: schemas.GroupColor | None = None
+    ) -> schemas.GroupInformation:
+        """Assign a node to a group identified by name, creating it if absent (find-or-create)."""
+        existing = next((group for group in self._groups.values() if group.name == name), None)
+        if existing is not None:
+            return self.add_nodes_to_group(existing.id, [node_id])
+        return self.create_group(name, [node_id], color=color)
+
+    def set_node_positions(self, updates: list[schemas.NodePositionUpdate]) -> None:
+        """Persist dragged node positions (absolute canvas coordinates) onto setting_input.
+
+        Plain mutator: the caller (update_layout route) captures history once for the
+        whole drag-end batch so node moves and group-bounds changes share one snapshot.
+        """
+        for update in updates:
+            node = self.get_node(update.node_id)
+            if node is not None and node.setting_input is not None and hasattr(node.setting_input, "pos_x"):
+                node.setting_input.pos_x = update.pos_x
+                node.setting_input.pos_y = update.pos_y
+
+    def set_group_bounds(self, updates: list[schemas.GroupBoundsUpdate]) -> None:
+        """Persist group box bounds (used together with set_node_positions on drag/resize)."""
+        for update in updates:
+            group = self._groups.get(update.group_id)
+            if group is not None:
+                group.x_position = update.x_position
+                group.y_position = update.y_position
+                group.width = update.width
+                group.height = update.height
+
+    def restore_groups(self, groups: list[schemas.GroupInformation]) -> None:
+        """Replace the runtime group registry (used by open_flow and restore_from_snapshot)."""
+        self._groups = {group.id: group for group in groups}
+        for group in self._groups.values():
+            if group.width <= 0 or group.height <= 0:
+                self._recompute_group_bounds(group.id)
+
+    # ==================== End Group Management Methods ====================
 
     def add_node_to_starting_list(self, node: FlowNode) -> None:
         """Adds a node to the list of starting nodes for the flow if not already present.
@@ -1252,6 +1446,9 @@ class FlowGraph:
                 elif node:
                     self.flow_logger.warning(f"Node {node_id} lacks setting_input attribute.")
                 # else: Node not found, already warned by calculate_layered_layout
+
+            # Reflowed node positions invalidate group boxes — refit them.
+            self._recompute_group_bounds()
 
             end_time = time()
             self.flow_logger.info(
@@ -2825,6 +3022,7 @@ class FlowGraph:
         node = self._node_db.get(node_id)
         if node:
             logger.info(f"Found node: {node_id}, processing deletion")
+            group_id = getattr(node.setting_input, "group_id", None)
 
             lead_to_steps: list[FlowNode] = node.leads_to_nodes
             logger.debug(f"Node {node_id} leads to {len(lead_to_steps)} other nodes")
@@ -2846,6 +3044,9 @@ class FlowGraph:
             logger.debug(f"Successfully removed node {node_id} from node_db")
             del node
             logger.info("Node object deleted")
+            # Drop a group that just lost its last member.
+            if group_id is not None and group_id in self._groups and not self._member_node_ids(group_id):
+                self._groups.pop(group_id, None)
         else:
             logger.error(f"Failed to find node with id {node_id}")
             raise Exception(f"Node with id {node_id} does not exist")
@@ -3308,6 +3509,10 @@ class FlowGraph:
 
         node = self.get_node(node_database_reader.node_id)
         if node:
+            # Persist as user_provided so it survives the reset() triggered by setting_input
+            # below; otherwise the schema callback rebuilds from _func and routes schema
+            # prediction through a full worker data read.
+            node.user_provided_schema_callback = schema_callback
             node.schema_callback = schema_callback
             node.node_type = node_type
             node.name = node_type
@@ -4513,6 +4718,7 @@ class FlowGraph:
                 node_reference=node_info.node_reference,
                 x_position=int(node_info.x_position),
                 y_position=int(node_info.y_position),
+                group_id=node_info.group_id,
                 left_input_id=node_info.left_input_id,
                 right_input_id=node_info.right_input_id,
                 input_ids=node_info.input_ids,
@@ -4532,12 +4738,19 @@ class FlowGraph:
             source_registration_id=self.flow_settings.source_registration_id,
             parameters=self.flow_settings.parameters,
         )
+        # Persist only groups that still have members (prune orphans).
+        groups = [
+            schemas.FlowfileGroup(**self._groups[group_id].model_dump())
+            for group_id in self._groups
+            if self._member_node_ids(group_id)
+        ]
         return schemas.FlowfileData(
             flowfile_version=__version__,
             flowfile_id=self.flow_id,
             flowfile_name=self.__name__,
             flowfile_settings=settings,
             nodes=nodes,
+            groups=groups,
         )
 
     def get_node_storage(self) -> schemas.FlowInformation:
@@ -4765,7 +4978,12 @@ class FlowGraph:
         for node in self.nodes:
             nodes.append(node.get_node_input())
             edges.extend(node.get_edge_input())
-        return schemas.VueFlowInput(node_edges=edges, node_inputs=nodes)
+        groups = [
+            schemas.FlowfileGroup(**self._groups[group_id].model_dump())
+            for group_id in self._groups
+            if self._member_node_ids(group_id)
+        ]
+        return schemas.VueFlowInput(node_edges=edges, node_inputs=nodes, groups=groups)
 
     def reset(self):
         """Forces a deep reset on all nodes in the graph."""

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -904,6 +904,7 @@ class FlowGraph:
         # Visual node groups: organizational only, never read by the executor.
         # Membership lives on each node's setting_input.group_id; this is the box registry.
         self._groups: dict[int, schemas.GroupInformation] = {}
+        self._group_id_seq: int = 0  # monotonic group-id allocator; never reuses a freed id
         self._active_group_id: int | None = None
         self.cache_results = cache_results
         self.__name__ = name if name else "flow_" + str(id(self))
@@ -1172,8 +1173,9 @@ class FlowGraph:
     # (name/color/bounds) live in self._groups and ride along in FlowfileData.
 
     def _next_group_id(self) -> int:
-        """Allocate a group id unique among this flow's groups (separate from node ids)."""
-        return (max(self._groups) if self._groups else 0) + 1
+        """Allocate a monotonically increasing group id (never reuses a freed id this session)."""
+        self._group_id_seq = max([self._group_id_seq, *self._groups]) + 1
+        return self._group_id_seq
 
     def _member_node_ids(self, group_id: int) -> list[int]:
         """Derive a group's members by scanning node group_id (single source of truth)."""
@@ -1394,6 +1396,7 @@ class FlowGraph:
     def restore_groups(self, groups: list[schemas.GroupInformation]) -> None:
         """Replace the runtime group registry (used by open_flow and restore_from_snapshot)."""
         self._groups = {group.id: group for group in groups}
+        self._group_id_seq = max(self._groups, default=0)  # next id resumes above the highest restored
         for group in self._groups.values():
             if group.width <= 0 or group.height <= 0:
                 self._recompute_group_bounds(group.id)

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -1184,32 +1184,67 @@ class FlowGraph:
         if node is not None and node.setting_input is not None and hasattr(node.setting_input, "group_id"):
             node.setting_input.group_id = group_id
 
+    def _child_group_ids(self, group_id: int) -> list[int]:
+        """Sub-groups whose immediate parent is this group."""
+        return [gid for gid, g in self._groups.items() if g.parent_group_id == group_id]
+
+    def _group_depth(self, group_id: int) -> int:
+        """Nesting depth (0 = top-level); cycle-safe."""
+        depth, seen, current = 0, set(), self._groups.get(group_id)
+        while current is not None and current.parent_group_id is not None and current.id not in seen:
+            seen.add(current.id)
+            depth += 1
+            current = self._groups.get(current.parent_group_id)
+        return depth
+
+    def _is_ancestor_group(self, ancestor_id: int, group_id: int) -> bool:
+        """True if ancestor_id equals group_id or one of its ancestors (cycle-safe)."""
+        seen, current = set(), self._groups.get(group_id)
+        while current is not None and current.id not in seen:
+            if current.id == ancestor_id:
+                return True
+            seen.add(current.id)
+            current = self._groups.get(current.parent_group_id) if current.parent_group_id is not None else None
+        return False
+
     def _recompute_group_bounds(self, group_id: int | None = None) -> None:
-        """Refit one or all group boxes around their member nodes.
+        """Refit one or all group boxes around their member nodes and child groups.
 
         Uses nominal node dimensions since the backend doesn't know rendered sizes;
         the frontend refines bounds on first user interaction. Groups with no members
-        keep their current bounds.
+        keep their current bounds. When refitting all groups, deepest first so a parent
+        unions already-fitted child-group boxes.
         """
         node_width, node_height, padding, header = 180.0, 80.0, 40.0, 36.0
-        target_ids = [group_id] if group_id is not None else list(self._groups)
+        if group_id is not None:
+            target_ids = [group_id]
+        else:
+            target_ids = sorted(self._groups, key=self._group_depth, reverse=True)
         for gid in target_ids:
             group = self._groups.get(gid)
             if group is None:
                 continue
-            members = [self.get_node(nid) for nid in self._member_node_ids(gid)]
-            members = [m for m in members if m is not None and m.setting_input is not None]
-            if not members:
+            boxes: list[tuple[float, float, float, float]] = []  # (x, y, w, h)
+            for nid in self._member_node_ids(gid):
+                node = self.get_node(nid)
+                if node is not None and node.setting_input is not None:
+                    nx = float(node.setting_input.pos_x or 0)
+                    ny = float(node.setting_input.pos_y or 0)
+                    boxes.append((nx, ny, node_width, node_height))
+            for cid in self._child_group_ids(gid):
+                child = self._groups.get(cid)
+                if child is not None:
+                    boxes.append((child.x_position, child.y_position, child.width, child.height))
+            if not boxes:
                 continue
-            xs = [float(m.setting_input.pos_x or 0) for m in members]
-            ys = [float(m.setting_input.pos_y or 0) for m in members]
-            min_x, min_y = min(xs), min(ys)
-            max_x = max(x + node_width for x in xs)
-            max_y = max(y + node_height for y in ys)
-            group.x_position = min_x - padding
-            group.y_position = min_y - padding - header
-            group.width = (max_x - min_x) + 2 * padding
-            group.height = (max_y - min_y) + 2 * padding + header
+            min_x = min(b[0] for b in boxes) - padding
+            min_y = min(b[1] for b in boxes) - padding - header
+            max_x = max(b[0] + b[2] for b in boxes) + padding
+            max_y = max(b[1] + b[3] for b in boxes) + padding
+            group.x_position = min_x
+            group.y_position = min_y
+            group.width = max_x - min_x
+            group.height = max_y - min_y
 
     def create_group(
         self,
@@ -1218,20 +1253,29 @@ class FlowGraph:
         *,
         color: schemas.GroupColor | None = None,
         bounds: schemas.GroupBounds | None = None,
+        parent_group_id: int | None = None,
+        child_group_ids: list[int] | None = None,
     ) -> schemas.GroupInformation:
-        """Create a visual group and assign the given nodes to it. Organizational only.
+        """Create a visual group. Organizational only.
 
-        Bounds are computed from member positions when not supplied.
+        Members are the given nodes (group_id) and child groups (their parent_group_id).
+        The new group itself nests under parent_group_id. Bounds are computed when not supplied.
         """
 
         def _do() -> schemas.GroupInformation:
             group_id = self._next_group_id()
-            group = schemas.GroupInformation(id=group_id, name=name, color=color)
+            group = schemas.GroupInformation(
+                id=group_id, name=name, color=color, parent_group_id=parent_group_id
+            )
             if bounds is not None:
                 group.x_position, group.y_position, group.width, group.height = bounds
             self._groups[group_id] = group
             for node_id in node_ids:
                 self._set_node_group(node_id, group_id)
+            for cid in child_group_ids or []:
+                child = self._groups.get(cid)
+                if child is not None and not self._is_ancestor_group(cid, group_id):
+                    child.parent_group_id = group_id
             if bounds is None:
                 self._recompute_group_bounds(group_id)
             return group
@@ -1266,14 +1310,19 @@ class FlowGraph:
         return self._execute_with_history(_do, HistoryActionType.UPDATE_GROUP, f"Update group '{group.name}'")
 
     def delete_group(self, group_id: int) -> None:
-        """Remove a group box (ungroup). Member nodes are kept."""
+        """Remove a group box (ungroup). Members and sub-groups lift up one level."""
         group = self._groups.get(group_id)
         if group is None:
             return
+        new_parent = group.parent_group_id
 
         def _do() -> None:
             for node_id in self._member_node_ids(group_id):
-                self._set_node_group(node_id, None)
+                self._set_node_group(node_id, new_parent)
+            for cid in self._child_group_ids(group_id):
+                child = self._groups.get(cid)
+                if child is not None:
+                    child.parent_group_id = new_parent
             self._groups.pop(group_id, None)
 
         self._execute_with_history(_do, HistoryActionType.DELETE_GROUP, f"Delete group '{group.name}'")
@@ -1304,7 +1353,7 @@ class FlowGraph:
                     affected.add(current)
                     self._set_node_group(node_id, None)
             for gid in affected:
-                if not self._member_node_ids(gid):
+                if not self._member_node_ids(gid) and not self._child_group_ids(gid):
                     self._groups.pop(gid, None)
                 else:
                     self._recompute_group_bounds(gid)
@@ -3044,8 +3093,13 @@ class FlowGraph:
             logger.debug(f"Successfully removed node {node_id} from node_db")
             del node
             logger.info("Node object deleted")
-            # Drop a group that just lost its last member.
-            if group_id is not None and group_id in self._groups and not self._member_node_ids(group_id):
+            # Drop a group that just lost its last member (keep it if it still holds sub-groups).
+            if (
+                group_id is not None
+                and group_id in self._groups
+                and not self._member_node_ids(group_id)
+                and not self._child_group_ids(group_id)
+            ):
                 self._groups.pop(group_id, None)
         else:
             logger.error(f"Failed to find node with id {node_id}")
@@ -4740,7 +4794,7 @@ class FlowGraph:
         groups = [
             schemas.FlowfileGroup(**self._groups[group_id].model_dump())
             for group_id in self._groups
-            if self._member_node_ids(group_id)
+            if self._member_node_ids(group_id) or self._child_group_ids(group_id)
         ]
         return schemas.FlowfileData(
             flowfile_version=__version__,
@@ -4979,7 +5033,7 @@ class FlowGraph:
         groups = [
             schemas.FlowfileGroup(**self._groups[group_id].model_dump())
             for group_id in self._groups
-            if self._member_node_ids(group_id)
+            if self._member_node_ids(group_id) or self._child_group_ids(group_id)
         ]
         return schemas.VueFlowInput(node_edges=edges, node_inputs=nodes, groups=groups)
 

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -3509,9 +3509,7 @@ class FlowGraph:
 
         node = self.get_node(node_database_reader.node_id)
         if node:
-            # Persist as user_provided so it survives the reset() triggered by setting_input
-            # below; otherwise the schema callback rebuilds from _func and routes schema
-            # prediction through a full worker data read.
+            # Persist so the lightweight callback survives the reset() that setting_input triggers.
             node.user_provided_schema_callback = schema_callback
             node.schema_callback = schema_callback
             node.node_type = node_type

--- a/flowfile_core/flowfile_core/flowfile/flow_node/executor.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_node/executor.py
@@ -338,6 +338,10 @@ class NodeExecutor:
         """Prepare node state before execution."""
         self.node.clear_table_example()
         state.reset_results_only()
+        # Clear a stale cancel flag from a prior run so the get_resulting_data guard
+        # only trips for a cancel issued during this run (node.reset() is a no-op when
+        # the hash is unchanged, so reset it here unconditionally).
+        state.is_canceled = False
         self.node.results.errors = None
         self.node.results.resulting_data = None
         self.node.results.example_data = None

--- a/flowfile_core/flowfile_core/flowfile/flow_node/executor.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_node/executor.py
@@ -338,10 +338,7 @@ class NodeExecutor:
         """Prepare node state before execution."""
         self.node.clear_table_example()
         state.reset_results_only()
-        # Clear a stale cancel flag from a prior run so the get_resulting_data guard
-        # only trips for a cancel issued during this run (node.reset() is a no-op when
-        # the hash is unchanged, so reset it here unconditionally).
-        state.is_canceled = False
+        state.is_canceled = False  # clear any stale cancel flag from a prior run
         self.node.results.errors = None
         self.node.results.resulting_data = None
         self.node.results.example_data = None

--- a/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
@@ -828,9 +828,6 @@ class FlowNode:
                     self.print("getting resulting data")
                     try:
                         if self._execution_state.is_canceled:
-                            # Cancel may release _execution_lock (held by a schema callback
-                            # running the node function) before this thread acquires it; do not
-                            # (re)start the function for a canceled node.
                             raise Exception("Node execution canceled")
                         if isinstance(self.function, FlowDataEngine):
                             fl: FlowDataEngine = self.function

--- a/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
@@ -513,6 +513,7 @@ class FlowNode:
         node_information.is_setup = self.is_setup
         node_information.x_position = self.setting_input.pos_x
         node_information.y_position = self.setting_input.pos_y
+        node_information.group_id = getattr(self.setting_input, "group_id", None)
         node_information.type = self.node_type
 
     def get_node_information(self) -> schemas.NodeInformation:
@@ -826,6 +827,11 @@ class FlowNode:
                 if self.results.resulting_data is None and self.results.errors is None:
                     self.print("getting resulting data")
                     try:
+                        if self._execution_state.is_canceled:
+                            # Cancel may release _execution_lock (held by a schema callback
+                            # running the node function) before this thread acquires it; do not
+                            # (re)start the function for a canceled node.
+                            raise Exception("Node execution canceled")
                         if isinstance(self.function, FlowDataEngine):
                             fl: FlowDataEngine = self.function
                         elif self.node_type == "external_source":
@@ -1356,6 +1362,7 @@ class FlowNode:
             # Reset execution state but preserve source file info for change detection
             self._execution_state.has_run_with_current_setup = False
             self._execution_state.has_completed_last_run = False
+            self._execution_state.is_canceled = False
             self._execution_state.result_schema = None
             self._execution_state.predicted_schema = None
             self._execution_state.execution_hash = None
@@ -1673,6 +1680,7 @@ class FlowNode:
         return schemas.NodeInput(
             pos_y=self.setting_input.pos_y,
             pos_x=self.setting_input.pos_x,
+            group_id=getattr(self.setting_input, "group_id", None),
             id=self.node_id,
             node_reference=node_reference,
             **template_fields,

--- a/flowfile_core/flowfile_core/flowfile/manage/io_flowfile.py
+++ b/flowfile_core/flowfile_core/flowfile/manage/io_flowfile.py
@@ -172,6 +172,7 @@ def _flowfile_data_to_flow_information(flowfile_data: schemas.FlowfileData) -> s
             setting_data["node_id"] = node.id
             setting_data["pos_x"] = float(node.x_position or 0)
             setting_data["pos_y"] = float(node.y_position or 0)
+            setting_data["group_id"] = node.group_id
             setting_data["description"] = node.description or ""
             setting_data["node_reference"] = node.node_reference
             setting_data["is_setup"] = True
@@ -213,6 +214,7 @@ def _flowfile_data_to_flow_information(flowfile_data: schemas.FlowfileData) -> s
             node_reference=node.node_reference,
             x_position=node.x_position,
             y_position=node.y_position,
+            group_id=node.group_id,
             left_input_id=node.left_input_id,
             right_input_id=node.right_input_id,
             input_ids=node.input_ids,
@@ -246,6 +248,7 @@ def _flowfile_data_to_flow_information(flowfile_data: schemas.FlowfileData) -> s
         data=nodes_dict,
         node_starts=node_starts,
         node_connections=connections,
+        groups=[schemas.GroupInformation(**group.model_dump()) for group in flowfile_data.groups],
     )
 
 
@@ -384,6 +387,10 @@ def open_flow(flow_path: Path, user_id: int | None = None) -> FlowGraph:
             from_node = new_flow.get_node(missing_connection[0])
             if from_node:
                 to_node.add_node_connection(from_node)
+
+    # Restore visual groups. Member group_ids were re-applied above via
+    # add_<type>(setting_input); legacy pickles may lack the field entirely.
+    new_flow.restore_groups(getattr(flow_storage_obj, "groups", None) or [])
 
     new_flow.mark_as_saved()
     return new_flow

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -720,6 +720,104 @@ def connect_node(flow_id: int, node_connection: input_schema.NodeConnection) -> 
     return OperationResponse(success=True, history=flow.get_history_state())
 
 
+# ============================================================================
+# Node-group editor endpoints (visual containers; organizational only)
+# ============================================================================
+
+
+class GroupOperationResponse(OperationResponse):
+    """OperationResponse that also returns the affected group (for server-assigned ids)."""
+
+    group: schemas.FlowfileGroup | None = None
+
+
+def _group_to_schema(group: schemas.GroupInformation) -> schemas.FlowfileGroup:
+    return schemas.FlowfileGroup(**group.model_dump())
+
+
+def _bounds_from_request(req: schemas.CreateGroupRequest | schemas.UpdateGroupRequest) -> schemas.GroupBounds | None:
+    """Build explicit bounds only when the frontend supplied all four values."""
+    values = (req.x_position, req.y_position, req.width, req.height)
+    if all(value is not None for value in values):
+        return schemas.GroupBounds(*values)
+    return None
+
+
+def _get_running_flow(flow_id: int):
+    flow = flow_file_handler.get_flow(flow_id)
+    if flow is None:
+        raise HTTPException(404, "could not find the flow")
+    if flow.flow_settings.is_running:
+        raise HTTPException(422, "Flow is running")
+    return flow
+
+
+@router.post("/editor/create_group/", tags=["editor"], response_model=GroupOperationResponse)
+def create_group(flow_id: int, request: schemas.CreateGroupRequest) -> GroupOperationResponse:
+    """Create a visual group around a set of nodes. Returns the new server-assigned group."""
+    flow = _get_running_flow(flow_id)
+    group = flow.create_group(request.name, request.node_ids, color=request.color, bounds=_bounds_from_request(request))
+    return GroupOperationResponse(success=True, history=flow.get_history_state(), group=_group_to_schema(group))
+
+
+@router.post("/editor/update_group/", tags=["editor"], response_model=GroupOperationResponse)
+def update_group(flow_id: int, group_id: int, request: schemas.UpdateGroupRequest) -> GroupOperationResponse:
+    """Rename / recolor / move / resize / collapse a group box."""
+    flow = _get_running_flow(flow_id)
+    try:
+        group = flow.update_group(
+            group_id,
+            name=request.name,
+            color=request.color,
+            bounds=_bounds_from_request(request),
+            collapsed=request.collapsed,
+        )
+    except ValueError as exc:
+        raise HTTPException(404, str(exc)) from exc
+    return GroupOperationResponse(success=True, history=flow.get_history_state(), group=_group_to_schema(group))
+
+
+@router.post("/editor/delete_group/", tags=["editor"], response_model=OperationResponse)
+def delete_group(flow_id: int, group_id: int) -> OperationResponse:
+    """Delete a group box (ungroup). Member nodes are kept."""
+    flow = _get_running_flow(flow_id)
+    flow.delete_group(group_id)
+    return OperationResponse(success=True, history=flow.get_history_state())
+
+
+@router.post("/editor/group/add_nodes/", tags=["editor"], response_model=GroupOperationResponse)
+def add_nodes_to_group(flow_id: int, group_id: int, request: schemas.GroupMembershipRequest) -> GroupOperationResponse:
+    """Add nodes to an existing group."""
+    flow = _get_running_flow(flow_id)
+    try:
+        group = flow.add_nodes_to_group(group_id, request.node_ids)
+    except ValueError as exc:
+        raise HTTPException(404, str(exc)) from exc
+    return GroupOperationResponse(success=True, history=flow.get_history_state(), group=_group_to_schema(group))
+
+
+@router.post("/editor/group/remove_nodes/", tags=["editor"], response_model=OperationResponse)
+def remove_nodes_from_group(flow_id: int, request: schemas.GroupMembershipRequest) -> OperationResponse:
+    """Remove nodes from their group; a group emptied this way is pruned."""
+    flow = _get_running_flow(flow_id)
+    flow.remove_nodes_from_group(request.node_ids)
+    return OperationResponse(success=True, history=flow.get_history_state())
+
+
+@router.post("/editor/update_layout/", tags=["editor"], response_model=OperationResponse)
+def update_layout(flow_id: int, request: schemas.UpdateLayoutRequest) -> OperationResponse:
+    """Persist dragged node positions and/or group bounds (one drag-end -> one call).
+
+    Also closes the long-standing gap where dragged node positions were never persisted.
+    """
+    flow = _get_running_flow(flow_id)
+    if request.node_positions or request.group_bounds:
+        flow.capture_history_snapshot(HistoryActionType.MOVE_NODES, "Update layout")
+        flow.set_node_positions(request.node_positions)
+        flow.set_group_bounds(request.group_bounds)
+    return OperationResponse(success=True, history=flow.get_history_state())
+
+
 @router.get("/editor/expression_doc", tags=["editor"], response_model=list[output_model.ExpressionsOverview])
 def get_expression_doc() -> list[output_model.ExpressionsOverview]:
     """Retrieves documentation for available Polars expressions."""

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -756,7 +756,14 @@ def _get_running_flow(flow_id: int):
 def create_group(flow_id: int, request: schemas.CreateGroupRequest) -> GroupOperationResponse:
     """Create a visual group around a set of nodes. Returns the new server-assigned group."""
     flow = _get_running_flow(flow_id)
-    group = flow.create_group(request.name, request.node_ids, color=request.color, bounds=_bounds_from_request(request))
+    group = flow.create_group(
+        request.name,
+        request.node_ids,
+        color=request.color,
+        bounds=_bounds_from_request(request),
+        parent_group_id=request.parent_group_id,
+        child_group_ids=request.child_group_ids,
+    )
     return GroupOperationResponse(success=True, history=flow.get_history_state(), group=_group_to_schema(group))
 
 

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -819,7 +819,8 @@ def update_layout(flow_id: int, request: schemas.UpdateLayoutRequest) -> Operati
     """
     flow = _get_running_flow(flow_id)
     if request.node_positions or request.group_bounds:
-        flow.capture_history_snapshot(HistoryActionType.MOVE_NODES, "Update layout")
+        if request.record_history:
+            flow.capture_history_snapshot(HistoryActionType.MOVE_NODES, "Update layout")
         flow.set_node_positions(request.node_positions)
         flow.set_group_bounds(request.group_bounds)
     return OperationResponse(success=True, history=flow.get_history_state())

--- a/flowfile_core/flowfile_core/schemas/history_schema.py
+++ b/flowfile_core/flowfile_core/schemas/history_schema.py
@@ -22,12 +22,17 @@ class HistoryActionType(str, Enum):
     ADD_NODE = "add_node"
     DELETE_NODE = "delete_node"
     MOVE_NODE = "move_node"
+    MOVE_NODES = "move_nodes"
     ADD_CONNECTION = "add_connection"
     DELETE_CONNECTION = "delete_connection"
     UPDATE_SETTINGS = "update_settings"
     COPY_NODE = "copy_node"
     PASTE_NODES = "paste_nodes"
     APPLY_LAYOUT = "apply_layout"
+    CREATE_GROUP = "create_group"
+    UPDATE_GROUP = "update_group"
+    DELETE_GROUP = "delete_group"
+    UPDATE_GROUP_MEMBERSHIP = "update_group_membership"
     BATCH = "batch"
 
 
@@ -89,10 +94,29 @@ class CompressedSnapshot:
                 tuple(n.get("outputs") or []),
                 n.get("x_position"),
                 n.get("y_position"),
+                n.get("group_id"),
                 # Include a hash of setting_input for change detection
                 hash(str(n.get("setting_input"))) if n.get("setting_input") else None,
             )
             node_signatures.append(sig)
+
+        # Group boxes are visual-only but must register here so group edits flip the
+        # dirty flag and aren't deduplicated away by capture_snapshot/capture_if_changed.
+        groups = snapshot_dict.get("groups", []) or []
+        group_signatures = tuple(
+            (
+                g.get("id"),
+                g.get("name"),
+                g.get("color"),
+                g.get("x_position"),
+                g.get("y_position"),
+                g.get("width"),
+                g.get("height"),
+                g.get("collapsed"),
+                g.get("parent_group_id"),
+            )
+            for g in sorted(groups, key=lambda x: x.get("id", 0))
+        )
 
         settings = snapshot_dict.get("flowfile_settings", {})
         # Convert to a stable string so lists/dicts inside settings (e.g. parameters) are hashable
@@ -105,6 +129,7 @@ class CompressedSnapshot:
                 snapshot_dict.get("flowfile_id"),
                 settings_tuple,
                 tuple(node_signatures),
+                group_signatures,
             )
         )
 

--- a/flowfile_core/flowfile_core/schemas/input_schema.py
+++ b/flowfile_core/flowfile_core/schemas/input_schema.py
@@ -359,6 +359,7 @@ class NodeBase(BaseModel):
     cache_results: bool | None = False
     pos_x: float | None = 0
     pos_y: float | None = 0
+    group_id: int | None = None  # Visual group membership (organizational only; no execution impact)
     is_setup: bool | None = True
     description: str | None = ""
     node_reference: str | None = None  # Unique reference identifier for code generation (lowercase, no spaces)

--- a/flowfile_core/flowfile_core/schemas/schemas.py
+++ b/flowfile_core/flowfile_core/schemas/schemas.py
@@ -593,6 +593,8 @@ class UpdateLayoutRequest(BaseModel):
 
     node_positions: list[NodePositionUpdate] = Field(default_factory=list)
     group_bounds: list[GroupBoundsUpdate] = Field(default_factory=list)
+    # False -> apply without a new undo entry (folds into a preceding op's snapshot).
+    record_history: bool = True
 
 
 class NodeDefault(BaseModel):

--- a/flowfile_core/flowfile_core/schemas/schemas.py
+++ b/flowfile_core/flowfile_core/schemas/schemas.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, NamedTuple
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_serializer, field_validator
 
@@ -261,6 +261,7 @@ class FlowfileNode(BaseModel):
     node_reference: str | None = None  # Unique reference identifier for code generation
     x_position: int | None = 0
     y_position: int | None = 0
+    group_id: int | None = None  # Visual group this node belongs to (organizational only)
     left_input_id: int | None = None
     right_input_id: int | None = None
     input_ids: list[int] | None = Field(default_factory=list)
@@ -276,6 +277,7 @@ class FlowfileNode(BaseModel):
         "node_id",
         "pos_x",
         "pos_y",
+        "group_id",
         "is_setup",
         "description",
         "node_reference",
@@ -299,6 +301,44 @@ class FlowfileNode(BaseModel):
         return value.model_dump(exclude=self._setting_input_exclude)
 
 
+# Allowed group tints. Single source of truth — mirrored by the frontend `GroupColor` union.
+GroupColor = Literal["slate", "blue", "green", "amber", "rose", "violet", "cyan"]
+
+
+class GroupBounds(NamedTuple):
+    """Axis-aligned bounds of a group box, in absolute canvas coordinates."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+
+
+class _GroupFields(BaseModel):
+    """Shared fields for the runtime and serialization group models (one definition, zero drift).
+
+    Groups are purely visual containers; they have no effect on execution or the DAG.
+    """
+
+    id: int
+    name: str = "Group"
+    color: GroupColor | None = None  # None -> frontend default tint
+    x_position: float = 0.0
+    y_position: float = 0.0
+    width: float = 400.0
+    height: float = 250.0
+    collapsed: bool = False  # whether the box is collapsed to a compact bar
+    parent_group_id: int | None = None  # reserved for future nesting; unused in v1
+
+
+class GroupInformation(_GroupFields):
+    """Runtime representation of a visual node group (stored in FlowGraph._groups)."""
+
+
+class FlowfileGroup(_GroupFields):
+    """Serialized representation of a visual node group (YAML/JSON)."""
+
+
 class FlowfileData(BaseModel):
     """Root model for flowfile serialization (YAML/JSON)."""
 
@@ -307,6 +347,7 @@ class FlowfileData(BaseModel):
     flowfile_name: str
     flowfile_settings: FlowfileSettings
     nodes: list[FlowfileNode]
+    groups: list[FlowfileGroup] = Field(default_factory=list)
 
 
 class NodeTemplate(BaseModel):
@@ -356,6 +397,7 @@ class NodeInformation(BaseModel):
     node_reference: str | None = None  # Unique reference identifier for code generation
     x_position: int | None = 0
     y_position: int | None = 0
+    group_id: int | None = None
     left_input_id: int | None = None
     right_input_id: int | None = None
     input_ids: list[int] | None = Field(default_factory=list)
@@ -410,6 +452,7 @@ class FlowInformation(BaseModel):
     data: dict[int, NodeInformation] = {}
     node_starts: list[int]
     node_connections: list[tuple[int, int]] = []
+    groups: list[GroupInformation] = Field(default_factory=list)
 
     @field_validator("flow_name", mode="before")
     def ensure_string(cls, v):
@@ -450,6 +493,7 @@ class NodeInput(NodeTemplate):
     id: int
     pos_x: float
     pos_y: float
+    group_id: int | None = None
     output_names: list[str] | None = None
     node_reference: str | None = None
 
@@ -486,6 +530,67 @@ class VueFlowInput(BaseModel):
 
     node_edges: list[NodeEdge]
     node_inputs: list[NodeInput]
+    groups: list[FlowfileGroup] = Field(default_factory=list)
+
+
+# ============================================================================
+# Node-group editor request bodies (organizational only; no execution impact)
+# ============================================================================
+
+
+class CreateGroupRequest(BaseModel):
+    """Body for POST /editor/create_group/. Bounds are optional; computed from members if omitted."""
+
+    node_ids: list[int]
+    name: str = "Group"
+    color: GroupColor | None = None
+    x_position: float | None = None
+    y_position: float | None = None
+    width: float | None = None
+    height: float | None = None
+
+
+class UpdateGroupRequest(BaseModel):
+    """Body for POST /editor/update_group/. All fields optional -> partial update."""
+
+    name: str | None = None
+    color: GroupColor | None = None
+    x_position: float | None = None
+    y_position: float | None = None
+    width: float | None = None
+    height: float | None = None
+    collapsed: bool | None = None
+
+
+class GroupMembershipRequest(BaseModel):
+    """Body for adding/removing nodes from a group."""
+
+    node_ids: list[int]
+
+
+class NodePositionUpdate(BaseModel):
+    """A single node's new absolute canvas position."""
+
+    node_id: int
+    pos_x: float
+    pos_y: float
+
+
+class GroupBoundsUpdate(BaseModel):
+    """A single group's new absolute bounds."""
+
+    group_id: int
+    x_position: float
+    y_position: float
+    width: float
+    height: float
+
+
+class UpdateLayoutRequest(BaseModel):
+    """Batch persistence of dragged node positions and/or group bounds (one drag-end -> one call)."""
+
+    node_positions: list[NodePositionUpdate] = Field(default_factory=list)
+    group_bounds: list[GroupBoundsUpdate] = Field(default_factory=list)
 
 
 class NodeDefault(BaseModel):

--- a/flowfile_core/flowfile_core/schemas/schemas.py
+++ b/flowfile_core/flowfile_core/schemas/schemas.py
@@ -548,6 +548,8 @@ class CreateGroupRequest(BaseModel):
     y_position: float | None = None
     width: float | None = None
     height: float | None = None
+    parent_group_id: int | None = None  # nest the new group under this group
+    child_group_ids: list[int] = Field(default_factory=list)  # existing groups to nest inside the new one
 
 
 class UpdateGroupRequest(BaseModel):

--- a/flowfile_core/tests/flowfile/flow_node/test_cancellation_and_schema.py
+++ b/flowfile_core/tests/flowfile/flow_node/test_cancellation_and_schema.py
@@ -1,0 +1,105 @@
+"""Tests for cancellation handling and database_reader schema-callback wiring.
+
+Covers the fix for remote flows that hung / re-spawned worker tasks on cancel
+when a source was unreachable:
+  - get_resulting_data must not (re)run the node function once the node is canceled
+  - reset() and _prepare_for_execution must clear the cancel flag between runs
+  - the database_reader keeps its lightweight get_schema callback across reset
+    (instead of falling back to a full worker data read for schema prediction)
+"""
+
+import pytest
+
+from flowfile_core.flowfile.flow_graph import FlowGraph
+from flowfile_core.flowfile.handler import FlowfileHandler
+from flowfile_core.schemas import input_schema, schemas
+
+
+def _graph(flow_id: int, execution_location: str = "local") -> FlowGraph:
+    handler = FlowfileHandler()
+    handler.register_flow(
+        schemas.FlowSettings(
+            flow_id=flow_id,
+            name="cancel_test",
+            path=".",
+            execution_mode="Development",
+            execution_location=execution_location,
+        )
+    )
+    return handler.get_flow(flow_id)
+
+
+def _add_manual_input(graph: FlowGraph, node_id: int = 1) -> None:
+    graph.add_node_promise(
+        input_schema.NodePromise(flow_id=graph.flow_id, node_id=node_id, node_type="manual_input")
+    )
+    graph.add_manual_input(
+        input_schema.NodeManualInput(
+            flow_id=graph.flow_id,
+            node_id=node_id,
+            raw_data_format=input_schema.RawData.from_pylist([{"name": "Alice", "age": 30}]),
+        )
+    )
+
+
+def test_canceled_node_does_not_run_function():
+    graph = _graph(9101)
+    _add_manual_input(graph)
+    node = graph.get_node(1)
+    assert node.get_resulting_data() is not None  # normal path produces data
+
+    # Simulate a cancel arriving as the node (re)enters execution: results cleared
+    # (as on a fresh run) and the node flagged canceled. The guard must stop it from
+    # running the function again (which previously spawned a fresh worker task).
+    node.results.resulting_data = None
+    node.results.errors = None
+    node._execution_state.is_canceled = True
+
+    with pytest.raises(Exception, match="cancel"):
+        node.get_resulting_data()
+    assert node.results.errors and "cancel" in node.results.errors.lower()
+
+
+def test_reset_clears_cancel_flag():
+    graph = _graph(9102)
+    _add_manual_input(graph)
+    node = graph.get_node(1)
+    node._execution_state.is_canceled = True
+    node.reset(deep=True)
+    assert node._execution_state.is_canceled is False
+
+
+def test_prepare_for_execution_clears_cancel_flag():
+    graph = _graph(9103)
+    _add_manual_input(graph)
+    node = graph.get_node(1)
+    node._execution_state.is_canceled = True
+    node.executor._prepare_for_execution(node._execution_state)
+    assert node._execution_state.is_canceled is False
+
+
+def test_database_reader_keeps_lightweight_schema_callback(sqlite_db):
+    """Regression: the DB reader's direct get_schema callback must survive the
+    reset() triggered by setting_input, instead of falling back to a full worker
+    data read (the root cause of the hang / cancel re-trigger)."""
+    graph = _graph(9104, execution_location="local")
+    graph.add_node_promise(
+        input_schema.NodePromise(flow_id=graph.flow_id, node_id=1, node_type="database_reader")
+    )
+    connection = input_schema.DatabaseConnection(
+        database_type="sqlite", password_ref="", database=f"sqlite:///{sqlite_db}"
+    )
+    settings = input_schema.DatabaseSettings(database_connection=connection, table_name="movies")
+    reader = input_schema.NodeDatabaseReader(
+        database_settings=settings, node_id=1, flow_id=graph.flow_id, user_id=1
+    )
+    graph.add_database_reader(reader)
+
+    node = graph.get_node(1)
+    assert node.user_provided_schema_callback is not None
+
+    # After a reset (which nulls _schema_callback) schema prediction still works
+    # via the lightweight callback — no worker / full data read needed.
+    node.reset(deep=True)
+    schema = node.get_predicted_schema()
+    assert schema is not None and len(schema) == 6

--- a/flowfile_core/tests/flowfile/test_node_groups.py
+++ b/flowfile_core/tests/flowfile/test_node_groups.py
@@ -287,3 +287,38 @@ def test_nested_groups_round_trip(temp_dir):
 
     by_name = {g.name: g for g in reloaded._groups.values()}
     assert by_name["Inner"].parent_group_id == by_name["Outer"].id
+
+
+# ---------------------------------------------------------------------------
+# Group id allocation
+# ---------------------------------------------------------------------------
+
+
+def test_next_group_id_does_not_reuse_freed_id():
+    graph = build_two_node_graph()
+    add_manual_input(graph, [{"a": 5}], node_id=3)
+    g1 = graph.create_group("A", [1])
+    g2 = graph.create_group("B", [2])
+    g3 = graph.create_group("C", [3])
+    assert [g1.id, g2.id, g3.id] == [1, 2, 3]
+
+    graph.delete_group(g3.id)  # free the highest id
+    g4 = graph.create_group("D", [3])
+    assert g4.id == 4  # monotonic; the freed id 3 is not reused
+    assert g4.id not in {g1.id, g2.id}
+
+
+def test_restore_groups_resyncs_id_counter(temp_dir):
+    graph = build_two_node_graph()
+    add_manual_input(graph, [{"a": 5}], node_id=3)
+    graph.create_group("A", [1])
+    graph.create_group("B", [2])
+    graph.create_group("C", [3])  # ids 1, 2, 3
+
+    path = temp_dir / "flow.yaml"
+    graph.save_flow(str(path))
+    reloaded = open_flow(path)
+
+    assert reloaded._group_id_seq == 3  # counter resumes above the highest restored id
+    regrouped = reloaded.create_group("D", [1])
+    assert regrouped.id == 4

--- a/flowfile_core/tests/flowfile/test_node_groups.py
+++ b/flowfile_core/tests/flowfile/test_node_groups.py
@@ -1,0 +1,196 @@
+"""
+Tests for visual node groups (organizational containers; no execution impact).
+
+Run with:
+    pytest flowfile_core/tests/flowfile/test_node_groups.py -v
+
+Covers: membership on nodes, serialization round-trip (incl. that group_id is not
+duplicated inside setting_input), backward compatibility, apply_layout bounds refit,
+empty-group pruning/auto-delete, and undo/redo of group operations.
+"""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from flowfile_core.flowfile.flow_graph import FlowGraph
+from flowfile_core.flowfile.handler import FlowfileHandler
+from flowfile_core.flowfile.manage.io_flowfile import open_flow
+from flowfile_core.schemas import input_schema, schemas
+
+
+def create_graph(flow_id: int = 1) -> FlowGraph:
+    handler = FlowfileHandler()
+    handler.register_flow(
+        schemas.FlowSettings(flow_id=flow_id, name="test_flow", path=".", execution_mode="Development")
+    )
+    return handler.get_flow(flow_id)
+
+
+def add_manual_input(graph: FlowGraph, data, node_id: int = 1) -> FlowGraph:
+    graph.add_node_promise(input_schema.NodePromise(flow_id=graph.flow_id, node_id=node_id, node_type="manual_input"))
+    graph.add_manual_input(
+        input_schema.NodeManualInput(
+            flow_id=graph.flow_id, node_id=node_id, raw_data_format=input_schema.RawData.from_pylist(data)
+        )
+    )
+    return graph
+
+
+def build_two_node_graph(flow_id: int = 1) -> FlowGraph:
+    graph = create_graph(flow_id)
+    add_manual_input(graph, [{"a": 1, "b": 2}], node_id=1)
+    add_manual_input(graph, [{"a": 3, "b": 4}], node_id=2)
+    return graph
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+def test_create_group_assigns_membership():
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2], color="blue")
+
+    assert group.id in graph._groups
+    assert graph.get_node(1).setting_input.group_id == group.id
+    assert graph.get_node(2).setting_input.group_id == group.id
+    assert sorted(graph._member_node_ids(group.id)) == [1, 2]
+    # Bounds were computed from members.
+    assert group.width > 0 and group.height > 0
+
+
+def test_serialization_keeps_group_id_at_top_level_not_in_setting_input():
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2])
+
+    data = graph.get_flowfile_data()
+    assert len(data.groups) == 1
+    assert data.groups[0].id == group.id
+
+    dumped = data.model_dump()
+    for node in dumped["nodes"]:
+        assert node["group_id"] == group.id  # top-level
+        # group_id must NOT leak into the nested settings payload
+        assert "group_id" not in (node["setting_input"] or {})
+
+
+def test_yaml_round_trip_preserves_groups(temp_dir):
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2], color="green")
+    group_bounds = (group.x_position, group.y_position, group.width, group.height)
+
+    path = temp_dir / "flow.yaml"
+    graph.save_flow(str(path))
+    reloaded = open_flow(path)
+
+    assert len(reloaded._groups) == 1
+    restored = next(iter(reloaded._groups.values()))
+    assert restored.name == "Cleaning"
+    assert restored.color == "green"
+    assert (restored.x_position, restored.y_position, restored.width, restored.height) == pytest.approx(group_bounds)
+    assert reloaded.get_node(1).setting_input.group_id == restored.id
+    assert reloaded.get_node(2).setting_input.group_id == restored.id
+
+
+def test_backward_compat_flow_without_groups(temp_dir):
+    graph = build_two_node_graph()  # no groups created
+    path = temp_dir / "flow.yaml"
+    graph.save_flow(str(path))
+    reloaded = open_flow(path)
+
+    assert reloaded._groups == {}
+    assert reloaded.get_node(1).setting_input.group_id is None
+    assert reloaded.get_node(2).setting_input.group_id is None
+
+
+def test_apply_layout_refits_group_bounds():
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2])
+    graph.apply_layout()
+
+    members = [graph.get_node(1), graph.get_node(2)]
+    refit = graph._groups[group.id]
+    # Box encloses every member's top-left after the reflow.
+    for node in members:
+        assert refit.x_position <= node.setting_input.pos_x
+        assert refit.y_position <= node.setting_input.pos_y
+
+
+def test_delete_last_member_prunes_group():
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2])
+    graph.delete_node(1)
+    assert group.id in graph._groups  # node 2 still a member
+    graph.delete_node(2)
+    assert group.id not in graph._groups
+
+
+def test_remove_nodes_from_group_prunes_when_empty():
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2])
+    graph.remove_nodes_from_group([1, 2])
+    assert group.id not in graph._groups
+    assert graph.get_node(1).setting_input.group_id is None
+
+
+def test_empty_group_not_serialized():
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1])
+    graph._set_node_group(1, None)  # orphan the group without going through prune paths
+    data = graph.get_flowfile_data()
+    assert all(g.id != group.id for g in data.groups)
+
+
+def test_assign_node_to_named_group_find_or_create():
+    graph = build_two_node_graph()
+    first = graph.assign_node_to_named_group(1, "Shared")
+    second = graph.assign_node_to_named_group(2, "Shared")
+    assert first.id == second.id
+    assert sorted(graph._member_node_ids(first.id)) == [1, 2]
+
+
+def test_undo_redo_create_group():
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2])
+    assert group.id in graph._groups
+
+    graph.undo()
+    assert graph._groups == {}
+    assert graph.get_node(1).setting_input.group_id is None
+
+    graph.redo()
+    assert len(graph._groups) == 1
+    assert graph.get_node(1).setting_input.group_id is not None
+
+
+def test_set_node_positions_persists():
+    graph = build_two_node_graph()
+    graph.set_node_positions(
+        [schemas.NodePositionUpdate(node_id=1, pos_x=321.0, pos_y=654.0)]
+    )
+    assert graph.get_node(1).setting_input.pos_x == 321.0
+    assert graph.get_node(1).setting_input.pos_y == 654.0
+
+
+def test_collapsed_flag_round_trips(temp_dir):
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2])
+    assert graph._groups[group.id].collapsed is False  # default
+    graph.update_group(group.id, collapsed=True)
+    assert graph._groups[group.id].collapsed is True
+
+    path = temp_dir / "flow.yaml"
+    graph.save_flow(str(path))
+    reloaded = open_flow(path)
+    assert next(iter(reloaded._groups.values())).collapsed is True
+
+
+def test_collapse_toggle_is_undoable():
+    graph = build_two_node_graph()
+    group = graph.create_group("Cleaning", [1, 2])
+    graph.update_group(group.id, collapsed=True)
+    graph.undo()
+    assert graph._groups[group.id].collapsed is False

--- a/flowfile_core/tests/flowfile/test_node_groups.py
+++ b/flowfile_core/tests/flowfile/test_node_groups.py
@@ -194,3 +194,96 @@ def test_collapse_toggle_is_undoable():
     graph.update_group(group.id, collapsed=True)
     graph.undo()
     assert graph._groups[group.id].collapsed is False
+
+
+# ---------------------------------------------------------------------------
+# Nested (embedded) groups
+# ---------------------------------------------------------------------------
+
+
+def test_nested_create_sets_parent_group_id():
+    graph = build_two_node_graph()
+    add_manual_input(graph, [{"a": 5}], node_id=3)
+    outer = graph.create_group("Outer", [1, 2, 3])
+    inner = graph.create_group("Inner", [1, 2], parent_group_id=outer.id)
+
+    assert graph._groups[inner.id].parent_group_id == outer.id
+    assert graph._child_group_ids(outer.id) == [inner.id]
+    # Nodes 1,2 moved to the sub-group; node 3 stays in the outer group (no stealing).
+    assert graph.get_node(1).setting_input.group_id == inner.id
+    assert graph.get_node(2).setting_input.group_id == inner.id
+    assert graph.get_node(3).setting_input.group_id == outer.id
+
+
+def test_create_group_wraps_existing_groups():
+    graph = build_two_node_graph()
+    a = graph.create_group("A", [1])
+    b = graph.create_group("B", [2])
+    wrapper = graph.create_group("Wrapper", [], child_group_ids=[a.id, b.id])
+
+    assert graph._groups[a.id].parent_group_id == wrapper.id
+    assert graph._groups[b.id].parent_group_id == wrapper.id
+    assert sorted(graph._child_group_ids(wrapper.id)) == sorted([a.id, b.id])
+
+
+def test_delete_group_lifts_members_one_level():
+    graph = build_two_node_graph()
+    outer = graph.create_group("Outer", [])
+    inner = graph.create_group("Inner", [1, 2], parent_group_id=outer.id)
+    graph.delete_group(inner.id)
+
+    assert inner.id not in graph._groups
+    assert graph.get_node(1).setting_input.group_id == outer.id
+    assert graph.get_node(2).setting_input.group_id == outer.id
+
+
+def test_delete_top_level_group_ungroups_to_none():
+    graph = build_two_node_graph()
+    g = graph.create_group("G", [1, 2])
+    graph.delete_group(g.id)
+    assert g.id not in graph._groups
+    assert graph.get_node(1).setting_input.group_id is None
+
+
+def test_group_with_child_groups_not_pruned_when_last_node_removed():
+    graph = build_two_node_graph()
+    add_manual_input(graph, [{"a": 5}], node_id=3)
+    outer = graph.create_group("Outer", [3])
+    inner = graph.create_group("Inner", [1, 2], parent_group_id=outer.id)
+    graph.remove_nodes_from_group([3])  # outer loses its only node but still holds a sub-group
+
+    assert outer.id in graph._groups
+    assert graph._child_group_ids(outer.id) == [inner.id]
+
+
+def test_bounds_wrap_child_groups():
+    graph = build_two_node_graph()
+    add_manual_input(graph, [{"a": 5}], node_id=3)
+    graph.set_node_positions(
+        [
+            schemas.NodePositionUpdate(node_id=1, pos_x=0.0, pos_y=0.0),
+            schemas.NodePositionUpdate(node_id=2, pos_x=120.0, pos_y=120.0),
+            schemas.NodePositionUpdate(node_id=3, pos_x=600.0, pos_y=400.0),
+        ]
+    )
+    inner = graph.create_group("Inner", [1, 2])
+    outer = graph.create_group("Outer", [3], child_group_ids=[inner.id])
+
+    o, i = graph._groups[outer.id], graph._groups[inner.id]
+    assert o.x_position <= i.x_position
+    assert o.y_position <= i.y_position
+    assert o.x_position + o.width >= i.x_position + i.width
+    assert o.y_position + o.height >= i.y_position + i.height
+
+
+def test_nested_groups_round_trip(temp_dir):
+    graph = build_two_node_graph()
+    outer = graph.create_group("Outer", [])
+    graph.create_group("Inner", [1, 2], parent_group_id=outer.id)
+
+    path = temp_dir / "flow.yaml"
+    graph.save_flow(str(path))
+    reloaded = open_flow(path)
+
+    by_name = {g.name: g for g in reloaded._groups.values()}
+    assert by_name["Inner"].parent_group_id == by_name["Outer"].id

--- a/flowfile_core/tests/test_group_routes.py
+++ b/flowfile_core/tests/test_group_routes.py
@@ -142,6 +142,43 @@ def test_update_unknown_group_returns_404():
     assert resp.status_code == 404
 
 
+def test_update_layout_record_history_false_skips_undo_entry():
+    flow_id = make_flow(956)
+    created = client.post(
+        "/editor/create_group/", params={"flow_id": flow_id}, json={"node_ids": [1, 2], "name": "G"}
+    ).json()
+    group_id = created["group"]["id"]
+    undo_after_create = created["history"]["undo_count"]
+
+    folded = client.post(
+        "/editor/update_layout/",
+        params={"flow_id": flow_id},
+        json={
+            "group_bounds": [
+                {"group_id": group_id, "x_position": 1.0, "y_position": 2.0, "width": 300.0, "height": 200.0}
+            ],
+            "record_history": False,
+        },
+    )
+    assert folded.status_code == 200, folded.text
+    # Bounds applied, but no new undo step (folded into the create entry).
+    assert folded.json()["history"]["undo_count"] == undo_after_create
+    assert flow_file_handler.get_flow(flow_id)._groups[group_id].width == 300.0
+
+    # Omitting the flag keeps the default: one new undo step.
+    recorded = client.post(
+        "/editor/update_layout/",
+        params={"flow_id": flow_id},
+        json={
+            "group_bounds": [
+                {"group_id": group_id, "x_position": 3.0, "y_position": 4.0, "width": 320.0, "height": 220.0}
+            ]
+        },
+    )
+    assert recorded.status_code == 200, recorded.text
+    assert recorded.json()["history"]["undo_count"] == undo_after_create + 1
+
+
 def test_create_group_rejected_while_running():
     flow_id = make_flow(954)
     flow_file_handler.get_flow(flow_id).flow_settings.is_running = True

--- a/flowfile_core/tests/test_group_routes.py
+++ b/flowfile_core/tests/test_group_routes.py
@@ -1,0 +1,154 @@
+"""
+Route tests for the node-group editor endpoints.
+
+Run with:
+    pytest flowfile_core/tests/test_group_routes.py -v
+"""
+from fastapi.testclient import TestClient
+
+from flowfile_core import flow_file_handler, main
+from flowfile_core.schemas import input_schema, schemas
+
+
+def get_test_client() -> TestClient:
+    with TestClient(main.app) as c:
+        token = c.post("/auth/token").json()["access_token"]
+    client = TestClient(main.app)
+    client.headers = {"Authorization": f"Bearer {token}"}
+    return client
+
+
+client = get_test_client()
+
+
+def make_flow(flow_id: int) -> int:
+    """Register a flow with two manual_input nodes (ids 1 and 2)."""
+    if flow_file_handler.get_flow(flow_id) is not None:
+        flow_file_handler.delete_flow(flow_id)
+    flow_file_handler.register_flow(schemas.FlowSettings(flow_id=flow_id, name="grp", path="."))
+    graph = flow_file_handler.get_flow(flow_id)
+    for node_id, value in ((1, 1), (2, 2)):
+        graph.add_node_promise(
+            input_schema.NodePromise(flow_id=flow_id, node_id=node_id, node_type="manual_input")
+        )
+        graph.add_manual_input(
+            input_schema.NodeManualInput(
+                flow_id=flow_id, node_id=node_id, raw_data_format=input_schema.RawData.from_pylist([{"a": value}])
+            )
+        )
+    return flow_id
+
+
+def test_create_update_delete_group():
+    flow_id = make_flow(950)
+
+    created = client.post(
+        "/editor/create_group/",
+        params={"flow_id": flow_id},
+        json={"node_ids": [1, 2], "name": "Cleaning", "color": "blue"},
+    )
+    assert created.status_code == 200, created.text
+    body = created.json()
+    assert body["success"] is True
+    assert body["group"]["name"] == "Cleaning"
+    assert body["group"]["color"] == "blue"
+    assert "history" in body
+    group_id = body["group"]["id"]
+
+    # Group + member group_ids appear in the VueFlow payload
+    data = client.get("/flow_data/v2", params={"flow_id": flow_id}).json()
+    assert len(data["groups"]) == 1
+    assert data["groups"][0]["id"] == group_id
+    assert all(node["group_id"] == group_id for node in data["node_inputs"])
+
+    updated = client.post(
+        "/editor/update_group/",
+        params={"flow_id": flow_id, "group_id": group_id},
+        json={"name": "Clean", "color": "green"},
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["group"]["name"] == "Clean"
+    assert updated.json()["group"]["color"] == "green"
+
+    deleted = client.post("/editor/delete_group/", params={"flow_id": flow_id, "group_id": group_id})
+    assert deleted.status_code == 200, deleted.text
+    after = client.get("/flow_data/v2", params={"flow_id": flow_id}).json()
+    assert after["groups"] == []
+    assert len(after["node_inputs"]) == 2  # nodes survive ungroup
+
+
+def test_update_layout_persists_positions_and_bounds():
+    flow_id = make_flow(951)
+    group_id = client.post(
+        "/editor/create_group/", params={"flow_id": flow_id}, json={"node_ids": [1, 2], "name": "G"}
+    ).json()["group"]["id"]
+
+    resp = client.post(
+        "/editor/update_layout/",
+        params={"flow_id": flow_id},
+        json={
+            "node_positions": [{"node_id": 1, "pos_x": 111.0, "pos_y": 222.0}],
+            "group_bounds": [
+                {"group_id": group_id, "x_position": 10.0, "y_position": 20.0, "width": 500.0, "height": 300.0}
+            ],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    graph = flow_file_handler.get_flow(flow_id)
+    assert graph.get_node(1).setting_input.pos_x == 111.0
+    assert graph.get_node(1).setting_input.pos_y == 222.0
+    assert graph._groups[group_id].width == 500.0
+
+
+def test_add_and_remove_group_members():
+    flow_id = make_flow(952)
+    group_id = client.post(
+        "/editor/create_group/", params={"flow_id": flow_id}, json={"node_ids": [1], "name": "G"}
+    ).json()["group"]["id"]
+
+    added = client.post(
+        "/editor/group/add_nodes/", params={"flow_id": flow_id, "group_id": group_id}, json={"node_ids": [2]}
+    )
+    assert added.status_code == 200, added.text
+    graph = flow_file_handler.get_flow(flow_id)
+    assert sorted(graph._member_node_ids(group_id)) == [1, 2]
+
+    removed = client.post(
+        "/editor/group/remove_nodes/", params={"flow_id": flow_id}, json={"node_ids": [1, 2]}
+    )
+    assert removed.status_code == 200, removed.text
+    assert group_id not in graph._groups  # pruned when emptied
+
+
+def test_update_group_collapse():
+    flow_id = make_flow(955)
+    group_id = client.post(
+        "/editor/create_group/", params={"flow_id": flow_id}, json={"node_ids": [1, 2], "name": "G"}
+    ).json()["group"]["id"]
+
+    resp = client.post(
+        "/editor/update_group/", params={"flow_id": flow_id, "group_id": group_id}, json={"collapsed": True}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["group"]["collapsed"] is True
+    assert flow_file_handler.get_flow(flow_id)._groups[group_id].collapsed is True
+
+
+def test_update_unknown_group_returns_404():
+    flow_id = make_flow(953)
+    resp = client.post(
+        "/editor/update_group/", params={"flow_id": flow_id, "group_id": 999}, json={"name": "x"}
+    )
+    assert resp.status_code == 404
+
+
+def test_create_group_rejected_while_running():
+    flow_id = make_flow(954)
+    flow_file_handler.get_flow(flow_id).flow_settings.is_running = True
+    try:
+        resp = client.post(
+            "/editor/create_group/", params={"flow_id": flow_id}, json={"node_ids": [1], "name": "G"}
+        )
+        assert resp.status_code == 422
+    finally:
+        flow_file_handler.get_flow(flow_id).flow_settings.is_running = False

--- a/flowfile_frame/flowfile_frame/flow_frame.py
+++ b/flowfile_frame/flowfile_frame/flow_frame.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import re
 from collections.abc import Iterable, Iterator, Mapping
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Literal, Union, get_args, get_origin
 
 import polars as pl
@@ -18,6 +19,7 @@ from flowfile_core.flowfile.flow_graph import FlowGraph, add_connection
 from flowfile_core.flowfile.flow_graph_utils import combine_flow_graphs_with_mapping
 from flowfile_core.flowfile.flow_node.flow_node import FlowNode
 from flowfile_core.schemas import input_schema, transform_schema
+from flowfile_core.schemas.schemas import GroupColor
 from flowfile_frame.cloud_storage.frame_helpers import add_write_ff_to_cloud_storage
 from flowfile_frame.config import logger
 from flowfile_frame.expr import Column, Expr, col, lit
@@ -2211,6 +2213,43 @@ class FlowFrame:
             maintain_order=maintain_order,
             description=description,
         )
+
+    @contextmanager
+    def group(self, name: str, *, color: GroupColor | None = None) -> Iterator[FlowFrame]:
+        """Group every node created inside this block into a labeled visual container.
+
+        Organizational only: groups affect the canvas overview/layout, never execution
+        or results. This is unrelated to :meth:`group_by` (which performs aggregation).
+
+        Example:
+            >>> with df.group("Clean customer data"):
+            ...     df = df.filter(col("age") > 18).select(["id", "name"])
+        """
+        before = set(self.flow_graph._node_db.keys())
+        try:
+            yield self
+        finally:
+            # Group only nodes that are new in this block AND not already grouped
+            # (so an inner `with df.group(...)` keeps its own membership).
+            new_node_ids = [
+                node_id
+                for node_id, node in self.flow_graph._node_db.items()
+                if node_id not in before and getattr(node.setting_input, "group_id", None) is None
+            ]
+            if new_node_ids:
+                self.flow_graph.create_group(name, new_node_ids, color=color)
+
+    def set_group(self, name: str, *, color: GroupColor | None = None) -> FlowFrame:
+        """Assign this frame's current node to a (new or existing) named visual group.
+
+        Returns ``self`` for chaining. Organizational only; see :meth:`group` for the
+        block form. Unrelated to :meth:`group_by` (aggregation).
+
+        Example:
+            >>> df = df.filter(col("age") > 18).set_group("Clean customer data")
+        """
+        self.flow_graph.assign_node_to_named_group(self.node_id, name, color=color)
+        return self
 
     def to_graph(self):
         """Get the underlying ETL graph."""

--- a/flowfile_frame/flowfile_frame/flow_frame.pyi
+++ b/flowfile_frame/flowfile_frame/flow_frame.pyi
@@ -234,6 +234,9 @@ class FlowFrame:
 
     def get_node_settings(self, description: Optional[str] = None) -> FlowNode: ...
 
+    # Group every node created inside this block into a labeled visual container.
+    def group(self, name: str, color: GroupColor | None = None, description: Optional[str] = None) -> Iterator[FlowFrame]: ...
+
     # Start a group by operation.
     def group_by(self, *by, description: Optional[str] = None, maintain_order: bool = False, **named_by) -> group_frame.GroupByFrame: ...
 
@@ -340,6 +343,9 @@ class FlowFrame:
 
     # Serialize the logical plan of this LazyFrame to a file or string in JSON format.
     def serialize(self, file: IOBase | str | Path | None = None, format: SerializationFormat = 'binary', description: Optional[str] = None) -> bytes | str | None: ...
+
+    # Assign this frame's current node to a (new or existing) named visual group.
+    def set_group(self, name: str, color: GroupColor | None = None, description: Optional[str] = None) -> 'FlowFrame': ...
 
     # Flag a column as sorted.
     def set_sorted(self, column: str | list[str], *more_columns, descending: bool | list[bool] = False, nulls_last: bool | list[bool] = False, description: Optional[str] = None) -> 'FlowFrame': ...

--- a/flowfile_frame/tests/test_node_groups.py
+++ b/flowfile_frame/tests/test_node_groups.py
@@ -1,0 +1,85 @@
+"""
+Tests for visual node grouping in the flowfile_frame API.
+
+Run with:
+    pytest flowfile_frame/tests/test_node_groups.py -v
+
+Visual groups are organizational only and unrelated to ``group_by`` (aggregation).
+"""
+import flowfile_frame as ff
+
+
+def _df() -> ff.FlowFrame:
+    return ff.from_dict({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+
+def test_context_manager_groups_block_nodes():
+    df = _df()
+    source_node = df.node_id
+    with df.group("Cleaning", color="blue"):
+        df = df.filter(ff.col("a") > 1)
+        df = df.select(["a", "b"])
+    last_node = df.node_id
+
+    graph = df.flow_graph
+    assert len(graph._groups) == 1
+    group = next(iter(graph._groups.values()))
+    assert group.name == "Cleaning"
+    assert group.color == "blue"
+
+    members = set(graph._member_node_ids(group.id))
+    assert last_node in members
+    assert source_node not in members  # created before the block
+
+
+def test_nodes_outside_block_not_grouped():
+    df = _df()
+    with df.group("Inside"):
+        df = df.filter(ff.col("a") > 1)
+    grouped_node = df.node_id
+    df = df.select(["a"])  # outside the block
+    outside_node = df.node_id
+
+    group = next(iter(df.flow_graph._groups.values()))
+    members = set(df.flow_graph._member_node_ids(group.id))
+    assert grouped_node in members
+    assert outside_node not in members
+
+
+def test_set_group_find_or_create_reuses_group_by_name():
+    df = _df()
+    df = df.filter(ff.col("a") > 1).set_group("Shared")
+    first_node = df.node_id
+    df = df.select(["a"]).set_group("Shared")
+    second_node = df.node_id
+
+    graph = df.flow_graph
+    assert len(graph._groups) == 1  # same name -> same group
+    group = next(iter(graph._groups.values()))
+    assert set(graph._member_node_ids(group.id)) == {first_node, second_node}
+
+
+def test_group_and_group_by_coexist():
+    df = _df()
+    with df.group("Prep"):
+        df = df.filter(ff.col("a") > 0)
+    aggregated = df.group_by("a").agg(ff.col("b").sum())  # aggregation; not a visual group
+
+    data = aggregated.flow_graph.get_flowfile_data()
+    assert len(data.groups) == 1  # exactly the visual group
+
+
+def test_round_trip_through_save_open(tmp_path):
+    from flowfile_core.flowfile.manage.io_flowfile import open_flow
+
+    df = _df()
+    with df.group("Cleaning"):
+        df = df.filter(ff.col("a") > 1)
+    grouped_node = df.node_id
+
+    path = tmp_path / "flow.yaml"
+    df.save_graph(str(path))
+    reloaded = open_flow(path)
+
+    assert len(reloaded._groups) == 1
+    assert reloaded.get_node(grouped_node).setting_input.group_id is not None

--- a/flowfile_frontend/package-lock.json
+++ b/flowfile_frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Flowfile",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Flowfile",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^31.1.1",
         "@ag-grid-community/core": "^31.1.1",

--- a/flowfile_frontend/src/renderer/app/api/flow.api.ts
+++ b/flowfile_frontend/src/renderer/app/api/flow.api.ts
@@ -13,6 +13,10 @@ import type {
   UndoRedoResult,
   OperationResponse,
   FlowArtifactData,
+  CreateGroupRequest,
+  UpdateGroupRequest,
+  UpdateLayoutRequest,
+  GroupOperationResponse,
 } from "../types";
 
 export class FlowApi {
@@ -285,6 +289,90 @@ export class FlowApi {
   }
 
   // ============================================================================
+  // Node Group Operations (visual containers; organizational only)
+  // ============================================================================
+
+  /** Create a visual group around a set of nodes. Returns the server-assigned group. */
+  static async createGroup(
+    flowId: number,
+    request: CreateGroupRequest,
+  ): Promise<GroupOperationResponse> {
+    const response = await axios.post<GroupOperationResponse>("/editor/create_group/", request, {
+      params: { flow_id: flowId },
+      headers: { "Content-Type": "application/json", accept: "application/json" },
+    });
+    return response.data;
+  }
+
+  /** Rename / recolor / move / resize a group box. */
+  static async updateGroup(
+    flowId: number,
+    groupId: number,
+    request: UpdateGroupRequest,
+  ): Promise<GroupOperationResponse> {
+    const response = await axios.post<GroupOperationResponse>("/editor/update_group/", request, {
+      params: { flow_id: flowId, group_id: groupId },
+      headers: { "Content-Type": "application/json", accept: "application/json" },
+    });
+    return response.data;
+  }
+
+  /** Delete (ungroup) a group box. Member nodes are kept. */
+  static async deleteGroup(flowId: number, groupId: number): Promise<OperationResponse> {
+    const response = await axios.post<OperationResponse>(
+      "/editor/delete_group/",
+      {},
+      {
+        params: { flow_id: flowId, group_id: groupId },
+        headers: { accept: "application/json" },
+      },
+    );
+    return response.data;
+  }
+
+  /** Add nodes to an existing group. */
+  static async addNodesToGroup(
+    flowId: number,
+    groupId: number,
+    nodeIds: number[],
+  ): Promise<GroupOperationResponse> {
+    const response = await axios.post<GroupOperationResponse>(
+      "/editor/group/add_nodes/",
+      { node_ids: nodeIds },
+      {
+        params: { flow_id: flowId, group_id: groupId },
+        headers: { "Content-Type": "application/json", accept: "application/json" },
+      },
+    );
+    return response.data;
+  }
+
+  /** Remove nodes from their group (a group emptied this way is pruned). */
+  static async removeNodesFromGroup(flowId: number, nodeIds: number[]): Promise<OperationResponse> {
+    const response = await axios.post<OperationResponse>(
+      "/editor/group/remove_nodes/",
+      { node_ids: nodeIds },
+      {
+        params: { flow_id: flowId },
+        headers: { "Content-Type": "application/json", accept: "application/json" },
+      },
+    );
+    return response.data;
+  }
+
+  /** Persist dragged node positions and/or group bounds (one drag-end -> one call). */
+  static async updateLayout(
+    flowId: number,
+    request: UpdateLayoutRequest,
+  ): Promise<OperationResponse> {
+    const response = await axios.post<OperationResponse>("/editor/update_layout/", request, {
+      params: { flow_id: flowId },
+      headers: { "Content-Type": "application/json", accept: "application/json" },
+    });
+    return response.data;
+  }
+
+  // ============================================================================
   // History/Undo-Redo Operations
   // ============================================================================
 
@@ -352,10 +440,7 @@ export class FlowApi {
    * Get the named input keys available for a kernel node.
    * Each entry has: name, source_node_id, source_node_type.
    */
-  static async getNodeInputNames(
-    flowId: number,
-    nodeId: number,
-  ): Promise<InputNameInfo[]> {
+  static async getNodeInputNames(flowId: number, nodeId: number): Promise<InputNameInfo[]> {
     const response = await axios.get("/node/input_names", {
       params: { flow_id: flowId, node_id: nodeId },
       headers: { accept: "application/json" },

--- a/flowfile_frontend/src/renderer/app/components/layout/Header/HeaderButtons.vue
+++ b/flowfile_frontend/src/renderer/app/components/layout/Header/HeaderButtons.vue
@@ -372,27 +372,43 @@ const executionLocationOptions = ref<ExecutionLocationOption[]>([
 
 const emit = defineEmits(["openFlow", "refreshFlow", "flowSaved", "logs-start", "logs-stop"]);
 
-const loadFlowSettings = async () => {
-  if (!(nodeStore.flow_id && nodeStore.flow_id > 0)) return;
+// Collapse the concurrent watcher-triggered + explicit loadFlowSettings calls fired on
+// flow load (setFlowId fires the flow_id watcher while initialSetup also calls explicitly)
+// into one getFlowSettings + one run_status. Keyed by flow_id; cleared once settled.
+let settingsLoad: { id: number; promise: Promise<void> } | null = null;
 
-  flowSettings.value = await getFlowSettings(nodeStore.flow_id);
-  if (!flowSettings.value) return;
+const loadFlowSettings = async (): Promise<void> => {
+  const flowId = nodeStore.flow_id;
+  if (!(flowId && flowId > 0)) return;
+  if (settingsLoad && settingsLoad.id === flowId) return settingsLoad.promise;
 
-  flowSettings.value.execution_mode = flowSettings.value.execution_mode || "Development";
-  flowSettings.value.show_edge_labels = flowSettings.value.show_edge_labels ?? false;
-  flowSettings.value.parameters = flowSettings.value.parameters ?? [];
-  editorStore.displayLogViewer = flowSettings.value.show_detailed_progress;
-  editorStore.showEdgeLabels = flowSettings.value.show_edge_labels;
+  const promise = (async () => {
+    flowSettings.value = await getFlowSettings(flowId);
+    if (!flowSettings.value) return;
 
-  if (!runButton.value) return;
+    flowSettings.value.execution_mode = flowSettings.value.execution_mode || "Development";
+    flowSettings.value.show_edge_labels = flowSettings.value.show_edge_labels ?? false;
+    flowSettings.value.parameters = flowSettings.value.parameters ?? [];
+    editorStore.displayLogViewer = flowSettings.value.show_detailed_progress;
+    editorStore.showEdgeLabels = flowSettings.value.show_edge_labels;
 
-  if (flowSettings.value.is_running) {
-    editorStore.isRunning = true;
-    runButton.value.startPolling(runButton.value.checkRunStatus);
-  } else {
-    editorStore.isRunning = false;
-    runButton.value.stopPolling();
-    updateRunStatus(nodeStore.flow_id, nodeStore);
+    if (!runButton.value) return;
+
+    if (flowSettings.value.is_running) {
+      editorStore.isRunning = true;
+      runButton.value.startPolling(runButton.value.checkRunStatus);
+    } else {
+      editorStore.isRunning = false;
+      runButton.value.stopPolling();
+      updateRunStatus(flowId, nodeStore);
+    }
+  })();
+
+  settingsLoad = { id: flowId, promise };
+  try {
+    await promise;
+  } finally {
+    if (settingsLoad?.id === flowId) settingsLoad = null;
   }
 };
 

--- a/flowfile_frontend/src/renderer/app/components/nodes/GroupNode.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/GroupNode.vue
@@ -89,8 +89,6 @@ async function onToggleCollapse(): Promise<void> {
     :class="{ selected, collapsed: data.collapsed }"
     :style="{ '--group-accent': accent, borderColor: accent }"
   >
-    <!-- When collapsed the members are hidden, so the pill exposes its own in/out handles
-         that boundary "proxy" edges attach to (see useNodeGroups.addGroupProxyEdges). -->
     <template v-if="data.collapsed">
       <Handle
         :id="GROUP_TARGET_HANDLE"
@@ -173,7 +171,6 @@ async function onToggleCollapse(): Promise<void> {
   font-weight: 600;
   position: relative;
 }
-/* A collapsed group is just the header pill — fill it and round all corners. */
 .group-node.collapsed .group-header {
   height: 100%;
   border-radius: 8px;
@@ -257,7 +254,6 @@ async function onToggleCollapse(): Promise<void> {
   cursor: pointer;
   padding: 0;
 }
-/* In/out connection points on the collapsed pill (proxy edges attach here). */
 .group-handle {
   width: 9px;
   height: 9px;

--- a/flowfile_frontend/src/renderer/app/components/nodes/GroupNode.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/GroupNode.vue
@@ -1,0 +1,267 @@
+<script setup lang="ts">
+// Visual group container: a labeled, auto-fitting box drawn behind its member nodes.
+// Organizational only — it has no effect on execution. Rename/recolor/collapse persist
+// via FlowApi.updateGroup; ungroup/collapse are delegated to the useNodeGroups composable.
+import { Handle, Position, useVueFlow } from "@vue-flow/core";
+import { computed, nextTick, ref } from "vue";
+
+import { FlowApi } from "../../api";
+import {
+  GROUP_SOURCE_HANDLE,
+  GROUP_TARGET_HANDLE,
+  useNodeGroups,
+} from "../../composables/useNodeGroups";
+import { useFlowStore } from "../../stores/flow-store";
+import type { GroupColor, GroupNodeData } from "../../types/flow.types";
+
+const props = defineProps<{
+  id: string;
+  data: GroupNodeData;
+  selected?: boolean;
+}>();
+
+const flowStore = useFlowStore();
+const { updateNodeData } = useVueFlow();
+const { ungroupNodes, setGroupCollapsed } = useNodeGroups();
+
+const GROUP_COLORS: GroupColor[] = ["slate", "blue", "green", "amber", "rose", "violet", "cyan"];
+// Header/border tint per color token. Body uses the same hue at low alpha.
+const COLOR_HEX: Record<GroupColor, string> = {
+  slate: "#64748b",
+  blue: "#3b82f6",
+  green: "#22c55e",
+  amber: "#f59e0b",
+  rose: "#f43f5e",
+  violet: "#8b5cf6",
+  cyan: "#06b6d4",
+};
+
+const activeColor = computed<GroupColor>(() => props.data.color ?? "slate");
+const accent = computed(() => COLOR_HEX[activeColor.value]);
+
+const editing = ref(false);
+const labelDraft = ref("");
+const labelInput = ref<HTMLInputElement | null>(null);
+const showPalette = ref(false);
+
+const groupId = computed(() => props.data.id);
+
+async function persist(update: Parameters<typeof FlowApi.updateGroup>[2]): Promise<void> {
+  if (flowStore.flowId === null) return;
+  const response = await FlowApi.updateGroup(flowStore.flowId, groupId.value, update);
+  flowStore.updateHistoryState(response.history);
+}
+
+function startEditing(): void {
+  labelDraft.value = props.data.label;
+  editing.value = true;
+  nextTick(() => labelInput.value?.focus());
+}
+
+async function commitLabel(): Promise<void> {
+  if (!editing.value) return;
+  editing.value = false;
+  const name = labelDraft.value.trim();
+  if (!name || name === props.data.label) return;
+  updateNodeData(props.id, { label: name });
+  await persist({ name });
+}
+
+async function pickColor(color: GroupColor): Promise<void> {
+  showPalette.value = false;
+  if (color === props.data.color) return;
+  updateNodeData(props.id, { color });
+  await persist({ color });
+}
+
+async function onUngroup(): Promise<void> {
+  await ungroupNodes(groupId.value);
+}
+
+async function onToggleCollapse(): Promise<void> {
+  await setGroupCollapsed(groupId.value, !props.data.collapsed);
+}
+</script>
+
+<template>
+  <div
+    class="group-node"
+    :class="{ selected, collapsed: data.collapsed }"
+    :style="{ '--group-accent': accent, borderColor: accent }"
+  >
+    <!-- When collapsed the members are hidden, so the pill exposes its own in/out handles
+         that boundary "proxy" edges attach to (see useNodeGroups.addGroupProxyEdges). -->
+    <template v-if="data.collapsed">
+      <Handle
+        :id="GROUP_TARGET_HANDLE"
+        type="target"
+        :position="Position.Left"
+        class="group-handle"
+      />
+      <Handle
+        :id="GROUP_SOURCE_HANDLE"
+        type="source"
+        :position="Position.Right"
+        class="group-handle"
+      />
+    </template>
+    <div class="group-header" :style="{ backgroundColor: accent }">
+      <button
+        class="group-collapse"
+        :title="data.collapsed ? 'Expand group' : 'Collapse group'"
+        @click.stop="onToggleCollapse"
+      >
+        {{ data.collapsed ? "▸" : "▾" }}
+      </button>
+      <button
+        class="group-color-dot"
+        title="Change color"
+        @click.stop="showPalette = !showPalette"
+      ></button>
+
+      <input
+        v-if="editing"
+        ref="labelInput"
+        v-model="labelDraft"
+        class="group-label-input"
+        @keyup.enter="commitLabel"
+        @blur="commitLabel"
+        @click.stop
+      />
+      <span v-else class="group-label" :title="data.label" @dblclick.stop="startEditing">
+        {{ data.label }}
+      </span>
+
+      <button class="group-ungroup" title="Ungroup" @click.stop="onUngroup">✕</button>
+
+      <div v-if="showPalette" class="group-palette" @click.stop>
+        <button
+          v-for="color in GROUP_COLORS"
+          :key="color"
+          class="group-swatch"
+          :style="{ backgroundColor: COLOR_HEX[color] }"
+          :title="color"
+          @click="pickColor(color)"
+        ></button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.group-node {
+  width: 100%;
+  height: 100%;
+  border: 1.5px solid var(--group-accent, #64748b);
+  border-radius: 10px;
+  /* Tint the body lightly so edges/nodes stay readable through it. */
+  background-color: color-mix(in srgb, var(--group-accent, #64748b) 7%, transparent);
+  box-sizing: border-box;
+}
+.group-node.selected {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--group-accent, #64748b) 60%, transparent);
+}
+.group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 8px;
+  border-radius: 8px 8px 0 0;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  position: relative;
+}
+/* A collapsed group is just the header pill — fill it and round all corners. */
+.group-node.collapsed .group-header {
+  height: 100%;
+  border-radius: 8px;
+}
+.group-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: text;
+}
+.group-label-input {
+  flex: 1;
+  border: none;
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.group-collapse {
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+.group-collapse:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+.group-color-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(255, 255, 255, 0.8);
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  flex: 0 0 auto;
+}
+.group-ungroup {
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 3px;
+  flex: 0 0 auto;
+}
+.group-ungroup:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+.group-palette {
+  position: absolute;
+  top: 28px;
+  left: 8px;
+  display: flex;
+  gap: 4px;
+  padding: 5px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 10;
+}
+.group-swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  padding: 0;
+}
+/* In/out connection points on the collapsed pill (proxy edges attach here). */
+.group-handle {
+  width: 9px;
+  height: 9px;
+  background: var(--group-accent, #64748b);
+  border: 1.5px solid #fff;
+}
+</style>

--- a/flowfile_frontend/src/renderer/app/composables/useDragAndDrop.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useDragAndDrop.ts
@@ -23,6 +23,7 @@ import type {
   OperationResponse,
 } from "../types";
 import { FlowApi, NodeApi } from "../api";
+import { buildGroupNode, groupNodeId, useNodeGroups } from "./useNodeGroups";
 import { useEditorStore } from "../stores/editor-store";
 import { parseTabularText, inferColumnDataType } from "../utils/clipboardUtils";
 import { DEFAULT_OUTPUT_HANDLE, outputHandle, outputLabel } from "../utils/outputHandle";
@@ -299,6 +300,8 @@ export default function useDragAndDrop() {
     fromObject,
   } = useVueFlow();
 
+  const { addGroupProxyEdges } = useNodeGroups();
+
   watch(isDragging, (dragging) => {
     document.body.style.userSelect = dragging ? "none" : "";
   });
@@ -438,16 +441,35 @@ export default function useDragAndDrop() {
 
   async function importFlow(flowData: VueFlowInput) {
     await createEmptyFlow();
-    const allNodes = await Promise.all(flowData.node_inputs.map((node) => getNodeToAdd(node)));
+    const childNodes = await Promise.all(flowData.node_inputs.map((node) => getNodeToAdd(node)));
 
-    addNodes(allNodes);
+    // Build group container nodes, then reparent member nodes — converting each
+    // member's absolute position to be relative to its group origin (VueFlow stores
+    // child positions relative to the parent).
+    const groups = flowData.groups ?? [];
+    const groupById = new Map(groups.map((group) => [group.id, group]));
+    const groupNodes: Node[] = groups.map((group) => buildGroupNode(group));
+    flowData.node_inputs.forEach((input, index) => {
+      if (input.group_id == null) return;
+      const group = groupById.get(input.group_id);
+      if (!group) return;
+      childNodes[index].parentNode = groupNodeId(group.id);
+      childNodes[index].position = {
+        x: input.pos_x - group.x_position,
+        y: input.pos_y - group.y_position,
+      };
+      if (group.collapsed) childNodes[index].hidden = true;
+    });
+
+    // Groups first so a parent exists before its children reference it.
+    addNodes([...groupNodes, ...childNodes]);
     id = getMaxDataId(flowData.node_inputs);
 
     // Add labels to edges from source node output handles, node_reference, or df_{nodeId} default
     const editorStore = useEditorStore();
     const edgesWithLabels = flowData.node_edges.map((edge) => {
       if (!editorStore.showEdgeLabels) return edge;
-      const sourceNode = allNodes.find((n) => n.id === edge.source);
+      const sourceNode = childNodes.find((n) => n.id === edge.source);
       if (sourceNode?.data?.outputs) {
         const output = (sourceNode.data.outputs as NodeHandle[]).find(
           (o) => o.id === edge.sourceHandle,
@@ -463,6 +485,16 @@ export default function useDragAndDrop() {
     });
 
     addEdges(edgesWithLabels);
+
+    // Collapsed groups load with their members hidden, so VueFlow drops the members'
+    // edges. Re-create the boundary proxy edges once the pill handles have rendered.
+    const collapsedGroups = groups.filter((group) => group.collapsed);
+    if (collapsedGroups.length > 0) {
+      await nextTick();
+      for (const group of collapsedGroups) {
+        addGroupProxyEdges(groupNodeId(group.id));
+      }
+    }
   }
 
   async function onDrop(event: DragEvent, flowId: number): Promise<OperationResponse | undefined> {

--- a/flowfile_frontend/src/renderer/app/composables/useDragAndDrop.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useDragAndDrop.ts
@@ -24,6 +24,7 @@ import type {
 } from "../types";
 import { FlowApi, NodeApi } from "../api";
 import { buildGroupNode, groupNodeId, useNodeGroups } from "./useNodeGroups";
+import { fetchNodeTemplates } from "./useNodes";
 import { useEditorStore } from "../stores/editor-store";
 import { parseTabularText, inferColumnDataType } from "../utils/clipboardUtils";
 import { DEFAULT_OUTPUT_HANDLE, outputHandle, outputLabel } from "../utils/outputHandle";
@@ -161,9 +162,7 @@ const componentCache: Map<string, Promise<any>> = new Map();
  */
 export async function getNodeTemplateByItem(item: string): Promise<NodeTemplate | undefined> {
   try {
-    const { default: axios } = await import("axios");
-    const response = await axios.get("/node_list");
-    const allNodes = response.data as NodeTemplate[];
+    const allNodes = await fetchNodeTemplates();
     return allNodes.find((node) => node.item === item);
   } catch (error) {
     console.error("Failed to get node template for item:", item, error);
@@ -486,8 +485,7 @@ export default function useDragAndDrop() {
 
     addEdges(edgesWithLabels);
 
-    // Collapsed groups load with their members hidden, so VueFlow drops the members'
-    // edges. Re-create the boundary proxy edges once the pill handles have rendered.
+    // Re-create proxy edges for groups that load collapsed.
     const collapsedGroups = groups.filter((group) => group.collapsed);
     if (collapsedGroups.length > 0) {
       await nextTick();

--- a/flowfile_frontend/src/renderer/app/composables/useDragAndDrop.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useDragAndDrop.ts
@@ -447,7 +447,49 @@ export default function useDragAndDrop() {
     // child positions relative to the parent).
     const groups = flowData.groups ?? [];
     const groupById = new Map(groups.map((group) => [group.id, group]));
-    const groupNodes: Node[] = groups.map((group) => buildGroupNode(group));
+    const groupDepth = (group: (typeof groups)[number]): number => {
+      let depth = 0;
+      let current: (typeof groups)[number] | undefined = group;
+      const seen = new Set<number>();
+      while (current?.parent_group_id != null && !seen.has(current.id)) {
+        seen.add(current.id);
+        depth += 1;
+        current = groupById.get(current.parent_group_id);
+      }
+      return depth;
+    };
+    // Hidden if the group itself or any ancestor is collapsed.
+    const anyCollapsedFrom = (groupId: number): boolean => {
+      let current = groupById.get(groupId);
+      const seen = new Set<number>();
+      while (current && !seen.has(current.id)) {
+        if (current.collapsed) return true;
+        seen.add(current.id);
+        current =
+          current.parent_group_id != null ? groupById.get(current.parent_group_id) : undefined;
+      }
+      return false;
+    };
+
+    // Parents before children so a nested group's parent exists first; nested groups get a
+    // parent-relative position and a depth-based z-index (deeper above shallower, below nodes).
+    const groupNodes: Node[] = [...groups]
+      .sort((a, b) => groupDepth(a) - groupDepth(b))
+      .map((group) => {
+        const node = buildGroupNode(group, groupDepth(group));
+        if (group.parent_group_id != null) {
+          const parent = groupById.get(group.parent_group_id);
+          if (parent) {
+            node.parentNode = groupNodeId(group.parent_group_id);
+            node.position = {
+              x: group.x_position - parent.x_position,
+              y: group.y_position - parent.y_position,
+            };
+          }
+          if (anyCollapsedFrom(group.parent_group_id)) node.hidden = true;
+        }
+        return node;
+      });
     flowData.node_inputs.forEach((input, index) => {
       if (input.group_id == null) return;
       const group = groupById.get(input.group_id);
@@ -457,7 +499,7 @@ export default function useDragAndDrop() {
         x: input.pos_x - group.x_position,
         y: input.pos_y - group.y_position,
       };
-      if (group.collapsed) childNodes[index].hidden = true;
+      if (anyCollapsedFrom(group.id)) childNodes[index].hidden = true;
     });
 
     // Groups first so a parent exists before its children reference it.
@@ -485,8 +527,13 @@ export default function useDragAndDrop() {
 
     addEdges(edgesWithLabels);
 
-    // Re-create proxy edges for groups that load collapsed.
-    const collapsedGroups = groups.filter((group) => group.collapsed);
+    // Re-create proxy edges for groups that load collapsed and are not themselves hidden
+    // inside a collapsed ancestor.
+    const collapsedGroups = groups.filter(
+      (group) =>
+        group.collapsed &&
+        (group.parent_group_id == null || !anyCollapsedFrom(group.parent_group_id)),
+    );
     if (collapsedGroups.length > 0) {
       await nextTick();
       for (const group of collapsedGroups) {

--- a/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
@@ -235,8 +235,13 @@ export function useNodeGroups() {
     const width = maxX - minX;
     const height = maxY - minY;
     // Move the box origin, then re-anchor each child relative to it (absolute unchanged).
+    // A nested group's VueFlow position is relative to its parent, so convert from absolute.
+    const groupNode = findNode(groupVueId);
+    const parent = groupNode?.parentNode ? findNode(groupNode.parentNode) : undefined;
     updateNode(groupVueId, {
-      position: { x: minX, y: minY },
+      position: parent
+        ? { x: minX - parent.computedPosition.x, y: minY - parent.computedPosition.y }
+        : { x: minX, y: minY },
       style: { width: `${width}px`, height: `${height}px` },
     });
     for (const item of snapshot) {
@@ -303,12 +308,14 @@ export function useNodeGroups() {
         newVueId,
         topLevel.map((node) => node.id),
       );
-      // Tighten the box to the real rendered sizes and persist those bounds.
+      // Tighten the box to the real rendered sizes and persist those bounds. createGroup
+      // already recorded the undo entry, so fold these bounds into it (record_history: false).
       const fit = refitGroup(newVueId);
       if (fit) {
         await FlowApi.updateLayout(flowStore.flowId, {
           node_positions: [],
           group_bounds: [fit.bounds],
+          record_history: false,
         });
       }
     }
@@ -412,7 +419,8 @@ export function useNodeGroups() {
       await nextTick();
       updateNodeInternals([parentId]); // measure this group's new box before the parent refits
       await nextTick();
-      await persistGroupChainRefit(ancestorVueId);
+      // updateGroup already recorded the undo entry; fold the ancestor refit into it.
+      await persistGroupChainRefit(ancestorVueId, false);
     }
   };
 
@@ -446,7 +454,10 @@ export function useNodeGroups() {
   };
 
   /** Refit a group and every ancestor group (so a moved nested group re-wraps up the tree). */
-  const persistGroupChainRefit = async (startGroupVueId: string): Promise<void> => {
+  const persistGroupChainRefit = async (
+    startGroupVueId: string,
+    recordHistory = true,
+  ): Promise<void> => {
     if (flowStore.flowId === null) return;
     const group_bounds: GroupBoundsUpdate[] = [];
     let node_positions: NodePositionUpdate[] = [];
@@ -469,7 +480,11 @@ export function useNodeGroups() {
       current = parent;
     }
     if (group_bounds.length === 0 && node_positions.length === 0) return;
-    const response = await FlowApi.updateLayout(flowStore.flowId, { node_positions, group_bounds });
+    const response = await FlowApi.updateLayout(flowStore.flowId, {
+      node_positions,
+      group_bounds,
+      record_history: recordHistory,
+    });
     flowStore.updateHistoryState(response.history);
   };
 
@@ -484,7 +499,8 @@ export function useNodeGroups() {
     if (node.type === GROUP_NODE_TYPE) {
       // Persist the whole subtree — children moved with the parent.
       await persistLayout(descendantsOf(node.id), [node]);
-      if (node.parentNode) await persistGroupChainRefit(node.parentNode);
+      // persistLayout already recorded the undo entry; fold the ancestor refit into it.
+      if (node.parentNode) await persistGroupChainRefit(node.parentNode, false);
       return;
     }
     if (node.parentNode) {

--- a/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
@@ -46,8 +46,9 @@ export const absolutePosition = (node: GraphNode): XYPosition => ({
   y: node.computedPosition.y,
 });
 
-/** Build the VueFlow container node for a group (rendered behind its children). */
-export const buildGroupNode = (group: GroupInput): Node<GroupNodeData> => ({
+/** Build the VueFlow container node for a group (rendered behind its children).
+ * depth = nesting level; deeper groups paint above shallower ones, all below member nodes. */
+export const buildGroupNode = (group: GroupInput, depth = 0): Node<GroupNodeData> => ({
   id: groupNodeId(group.id),
   type: GROUP_NODE_TYPE,
   position: { x: group.x_position, y: group.y_position },
@@ -58,7 +59,7 @@ export const buildGroupNode = (group: GroupInput): Node<GroupNodeData> => ({
     color: group.color ?? null,
     collapsed: group.collapsed ?? false,
   },
-  zIndex: 0,
+  zIndex: -1000 + depth,
   connectable: false,
   // Removed only via the explicit "ungroup" action — never by the generic delete path.
   deletable: false,
@@ -82,6 +83,45 @@ export function useNodeGroups() {
 
   const childNodesOf = (groupVueId: string): GraphNode[] =>
     getNodes.value.filter((node) => node.parentNode === groupVueId);
+
+  /** All descendants (nodes and nested groups) of a group, depth-first. Cycle-guarded. */
+  const descendantsOf = (groupVueId: string): GraphNode[] => {
+    const out: GraphNode[] = [];
+    const stack = [...childNodesOf(groupVueId)];
+    const seen = new Set<string>();
+    while (stack.length) {
+      const node = stack.pop() as GraphNode;
+      if (seen.has(node.id)) continue;
+      seen.add(node.id);
+      out.push(node);
+      if (node.type === GROUP_NODE_TYPE) stack.push(...childNodesOf(node.id));
+    }
+    return out;
+  };
+
+  /** Nesting depth of a group node (0 = top level), walking its parentNode chain. */
+  const vueGroupDepth = (vueId: string | undefined): number => {
+    let depth = 0;
+    let current = vueId ? findNode(vueId) : undefined;
+    const seen = new Set<string>();
+    while (current?.parentNode && !seen.has(current.id)) {
+      seen.add(current.id);
+      depth += 1;
+      current = findNode(current.parentNode);
+    }
+    return depth;
+  };
+
+  /** Hide/show a group's whole subtree. Hiding cascades to all descendants; showing stops at
+   * a nested collapsed group (its own members stay hidden). */
+  const setSubtreeHidden = (groupVueId: string, hidden: boolean): void => {
+    for (const child of childNodesOf(groupVueId)) {
+      updateNode(child.id, { hidden });
+      if (child.type === GROUP_NODE_TYPE && (hidden || !(child.data as GroupNodeData)?.collapsed)) {
+        setSubtreeHidden(child.id, hidden);
+      }
+    }
+  };
 
   /** Reroute the collapsed group's boundary edges to the pill as UI-only proxy edges. */
   const addGroupProxyEdges = (groupVueId: string): void => {
@@ -144,16 +184,19 @@ export function useNodeGroups() {
     removeNodes([groupVueId]);
   };
 
-  /** Reparent on-canvas nodes into a group, converting positions to parent-relative. */
-  const attachNodesToGroup = (group: GroupInput, nodeIds: number[]): void => {
-    const parentId = groupNodeId(group.id);
-    for (const nodeId of nodeIds) {
-      const node = findNode(String(nodeId));
+  /** Reparent VueFlow nodes (custom or group) into a parent group, converting positions
+   * to be relative to the parent's absolute origin. The parent must already exist. */
+  const attachNodesToGroup = (parentVueId: string, childVueIds: string[]): void => {
+    const parent = findNode(parentVueId);
+    const px = parent ? parent.computedPosition.x : 0;
+    const py = parent ? parent.computedPosition.y : 0;
+    for (const childId of childVueIds) {
+      const node = findNode(childId);
       if (!node) continue;
       const abs = absolutePosition(node);
-      updateNode(String(nodeId), {
-        parentNode: parentId,
-        position: { x: abs.x - group.x_position, y: abs.y - group.y_position },
+      updateNode(childId, {
+        parentNode: parentVueId,
+        position: { x: abs.x - px, y: abs.y - py },
       });
     }
   };
@@ -207,29 +250,61 @@ export function useNodeGroups() {
         width,
         height,
       },
-      positions: snapshot.map((s) => ({ node_id: Number(s.id), pos_x: s.x, pos_y: s.y })),
+      positions: snapshot
+        .filter((s) => !isGroupNodeId(s.id))
+        .map((s) => ({ node_id: Number(s.id), pos_x: s.x, pos_y: s.y })),
     };
   };
 
-  /** Group the currently selected (non-group) nodes into a new auto-fitted container. */
+  /** Group the selected nodes/groups into a new container, nested under their common parent. */
   const groupSelectedNodes = async (): Promise<void> => {
     if (flowStore.flowId === null) return;
-    const selected = getSelectedNodes.value.filter((node) => node.type === CUSTOM_NODE_TYPE);
+    const selected = getSelectedNodes.value.filter(
+      (node) => node.type === CUSTOM_NODE_TYPE || node.type === GROUP_NODE_TYPE,
+    );
     if (selected.length === 0) {
       ElMessage.info("Select one or more nodes to group.");
       return;
     }
-    const nodeIds = selected.map((node) => Number(node.id));
+    // Items nested inside another selected group ride along inside it; only "top-level"
+    // selected items become direct children of the new group.
+    const selectedIds = new Set(selected.map((node) => node.id));
+    const topLevel = selected.filter(
+      (node) => !(node.parentNode && selectedIds.has(node.parentNode)),
+    );
+    // Nest the new group under the parent shared by every top-level item (undefined => top level).
+    const parents = new Set(topLevel.map((node) => node.parentNode));
+    const commonParentVueId = parents.size === 1 ? [...parents][0] : undefined;
+    const nodeIds = topLevel.filter((n) => n.type === CUSTOM_NODE_TYPE).map((n) => Number(n.id));
+    const childGroupIds = topLevel
+      .filter((n) => n.type === GROUP_NODE_TYPE)
+      .map((n) => groupBackendId(n.id));
     const response = await FlowApi.createGroup(flowStore.flowId, {
       node_ids: nodeIds,
       name: "Group",
+      parent_group_id: commonParentVueId ? groupBackendId(commonParentVueId) : null,
+      child_group_ids: childGroupIds,
     });
     if (response.group) {
+      const newVueId = groupNodeId(response.group.id);
+      const depth = commonParentVueId ? vueGroupDepth(commonParentVueId) + 1 : 0;
       // Parent must exist before children reference it.
-      addNodes([buildGroupNode(response.group)]);
-      attachNodesToGroup(response.group, nodeIds);
-      // Tighten the box to the real rendered node sizes and persist those bounds.
-      const fit = refitGroup(groupNodeId(response.group.id));
+      addNodes([buildGroupNode(response.group, depth)]);
+      if (commonParentVueId) {
+        const parent = findNode(commonParentVueId);
+        const px = parent ? parent.computedPosition.x : 0;
+        const py = parent ? parent.computedPosition.y : 0;
+        updateNode(newVueId, {
+          parentNode: commonParentVueId,
+          position: { x: response.group.x_position - px, y: response.group.y_position - py },
+        });
+      }
+      attachNodesToGroup(
+        newVueId,
+        topLevel.map((node) => node.id),
+      );
+      // Tighten the box to the real rendered sizes and persist those bounds.
+      const fit = refitGroup(newVueId);
       if (fit) {
         await FlowApi.updateLayout(flowStore.flowId, {
           node_positions: [],
@@ -245,8 +320,16 @@ export function useNodeGroups() {
     if (flowStore.flowId === null) return;
     const parentId = groupNodeId(groupId);
     removeGroupProxyEdges(groupId);
-    for (const child of childNodesOf(parentId)) {
-      detachNodeToAbsolute(child);
+    const grandparentVueId = findNode(parentId)?.parentNode;
+    const children = childNodesOf(parentId);
+    if (grandparentVueId) {
+      // Lift members and sub-groups up one level into the grandparent.
+      attachNodesToGroup(
+        grandparentVueId,
+        children.map((child) => child.id),
+      );
+    } else {
+      for (const child of children) detachNodeToAbsolute(child);
     }
     removeGroupNode(parentId);
     const response = await FlowApi.deleteGroup(flowStore.flowId, groupId);
@@ -282,9 +365,7 @@ export function useNodeGroups() {
     const group = findNode(parentId);
     if (!group) return;
     if (!collapsed) removeGroupProxyEdges(groupId);
-    for (const child of childNodesOf(parentId)) {
-      updateNode(child.id, { hidden: collapsed });
-    }
+    setSubtreeHidden(parentId, collapsed);
     updateNodeData(parentId, { collapsed });
     let bounds: GroupBoundsUpdate;
     if (collapsed) {
@@ -325,16 +406,31 @@ export function useNodeGroups() {
       height: bounds.height,
     });
     flowStore.updateHistoryState(response.history);
+    // This group's box changed size; re-wrap its ancestors so a nested group stays inside.
+    const ancestorVueId = findNode(parentId)?.parentNode;
+    if (ancestorVueId) {
+      await nextTick();
+      updateNodeInternals([parentId]); // measure this group's new box before the parent refits
+      await nextTick();
+      await persistGroupChainRefit(ancestorVueId);
+    }
   };
 
   /** Persist absolute positions for a set of nodes and/or bounds for a set of groups. */
   const persistLayout = async (nodes: GraphNode[], groups: GraphNode[] = []): Promise<void> => {
     if (flowStore.flowId === null) return;
-    const nodePositions: NodePositionUpdate[] = nodes.map((node) => {
-      const abs = absolutePosition(node);
-      return { node_id: Number(node.id), pos_x: abs.x, pos_y: abs.y };
-    });
-    const groupBounds: GroupBoundsUpdate[] = groups.map((group) => ({
+    // Group nodes carry bounds; only custom nodes produce a numeric node position.
+    const groupNodes: GraphNode[] = [...groups];
+    const nodePositions: NodePositionUpdate[] = [];
+    for (const node of nodes) {
+      if (node.type === GROUP_NODE_TYPE) {
+        groupNodes.push(node);
+      } else {
+        const abs = absolutePosition(node);
+        nodePositions.push({ node_id: Number(node.id), pos_x: abs.x, pos_y: abs.y });
+      }
+    }
+    const groupBounds: GroupBoundsUpdate[] = groupNodes.map((group) => ({
       group_id: groupBackendId(group.id),
       x_position: group.computedPosition.x,
       y_position: group.computedPosition.y,
@@ -349,27 +445,50 @@ export function useNodeGroups() {
     flowStore.updateHistoryState(response.history);
   };
 
+  /** Refit a group and every ancestor group (so a moved nested group re-wraps up the tree). */
+  const persistGroupChainRefit = async (startGroupVueId: string): Promise<void> => {
+    if (flowStore.flowId === null) return;
+    const group_bounds: GroupBoundsUpdate[] = [];
+    let node_positions: NodePositionUpdate[] = [];
+    let current: string | undefined = startGroupVueId;
+    const seen = new Set<string>();
+    while (current && !seen.has(current)) {
+      seen.add(current);
+      const fit = refitGroup(current);
+      if (fit) {
+        group_bounds.push(fit.bounds);
+        if (node_positions.length === 0) node_positions = fit.positions;
+      }
+      const parent: string | undefined = findNode(current)?.parentNode;
+      if (parent) {
+        // Measure this group's resized box before refitting its parent (dimensions update async).
+        await nextTick();
+        updateNodeInternals([current]);
+        await nextTick();
+      }
+      current = parent;
+    }
+    if (group_bounds.length === 0 && node_positions.length === 0) return;
+    const response = await FlowApi.updateLayout(flowStore.flowId, { node_positions, group_bounds });
+    flowStore.updateHistoryState(response.history);
+  };
+
   /**
    * Persist a drag-end:
-   * - group moved → its bounds + every child's new absolute position;
-   * - grouped child moved → auto-fit the box and persist box + member positions;
+   * - group moved → its bounds + every child's new absolute position (and refit ancestors);
+   * - grouped child moved → auto-fit the box and every ancestor box;
    * - free node moved → the dragged node, or all selected free nodes (multi-select).
    */
   const persistDrag = async (node: GraphNode): Promise<void> => {
     if (flowStore.flowId === null) return;
     if (node.type === GROUP_NODE_TYPE) {
-      await persistLayout(childNodesOf(node.id), [node]);
+      // Persist the whole subtree — children moved with the parent.
+      await persistLayout(descendantsOf(node.id), [node]);
+      if (node.parentNode) await persistGroupChainRefit(node.parentNode);
       return;
     }
     if (node.parentNode) {
-      const fit = refitGroup(node.parentNode);
-      if (fit) {
-        const response = await FlowApi.updateLayout(flowStore.flowId, {
-          node_positions: fit.positions,
-          group_bounds: [fit.bounds],
-        });
-        flowStore.updateHistoryState(response.history);
-      }
+      await persistGroupChainRefit(node.parentNode);
       return;
     }
     const selected = getSelectedNodes.value.filter(

--- a/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
@@ -23,15 +23,14 @@ const GROUP_PADDING = 40;
 const GROUP_HEADER = 36;
 // Height of a collapsed group (header bar only).
 const GROUP_COLLAPSED_HEIGHT = 34;
-// Width of a collapsed group — a compact pill, independent of the expanded box width.
 const GROUP_COLLAPSED_WIDTH = 200;
+// Fallback node footprint when a member isn't measured yet (matches the backend's
+// nominal sizes in _recompute_group_bounds).
+const NOMINAL_NODE_WIDTH = 180;
+const NOMINAL_NODE_HEIGHT = 80;
 
-// Handle ids on the collapsed pill that boundary "proxy" edges attach to.
 export const GROUP_TARGET_HANDLE = "group-target";
 export const GROUP_SOURCE_HANDLE = "group-source";
-// Proxy edges are UI-only stand-ins shown while a group is collapsed: they reroute the
-// edges crossing the group boundary to the pill. Ids are prefixed so Canvas.vue can skip
-// backend persistence for them and so we can find/remove them on expand/ungroup.
 export const GROUP_PROXY_EDGE_PREFIX = "group-proxy-";
 export const GROUP_PROXY_EDGE_TYPE = "group-proxy";
 
@@ -77,18 +76,14 @@ export function useNodeGroups() {
     removeEdges,
     updateNode,
     updateNodeData,
+    updateNodeInternals,
   } = useVueFlow();
   const flowStore = useFlowStore();
 
   const childNodesOf = (groupVueId: string): GraphNode[] =>
     getNodes.value.filter((node) => node.parentNode === groupVueId);
 
-  /**
-   * While a group is collapsed its members are hidden, so VueFlow drops every edge that
-   * touches them. Re-show the connections crossing the group boundary as UI-only "proxy"
-   * edges routed to the collapsed pill: external→member becomes external→pill, and
-   * member→external becomes pill→external. Internal (member↔member) edges stay hidden.
-   */
+  /** Reroute the collapsed group's boundary edges to the pill as UI-only proxy edges. */
   const addGroupProxyEdges = (groupVueId: string): void => {
     const groupId = groupBackendId(groupVueId);
     const memberIds = new Set(childNodesOf(groupVueId).map((node) => node.id));
@@ -99,7 +94,7 @@ export function useNodeGroups() {
     for (const edge of getEdges.value) {
       const sourceIn = memberIds.has(edge.source);
       const targetIn = memberIds.has(edge.target);
-      if (sourceIn === targetIn) continue; // internal or fully external — nothing to reroute
+      if (sourceIn === targetIn) continue;
       const proxy: Edge = targetIn
         ? {
             id: `${prefix}in-${edge.source}-${edge.sourceHandle ?? ""}`,
@@ -109,7 +104,6 @@ export function useNodeGroups() {
             targetHandle: GROUP_TARGET_HANDLE,
             type: GROUP_PROXY_EDGE_TYPE,
             selectable: false,
-            deletable: false,
             focusable: false,
             data: { isGroupProxy: true, groupId },
           }
@@ -121,7 +115,6 @@ export function useNodeGroups() {
             targetHandle: edge.targetHandle,
             type: GROUP_PROXY_EDGE_TYPE,
             selectable: false,
-            deletable: false,
             focusable: false,
             data: { isGroupProxy: true, groupId },
           };
@@ -129,10 +122,14 @@ export function useNodeGroups() {
       seen.add(proxy.id);
       proxies.push(proxy);
     }
-    if (proxies.length > 0) addEdges(proxies);
+    if (proxies.length > 0) {
+      addEdges(proxies);
+      // re-measure so the right-edge source handle tracks the new compact width
+      updateNodeInternals([groupVueId]);
+    }
   };
 
-  /** Remove the proxy edges created for a (now expanding/ungrouping) collapsed group. */
+  /** Remove a collapsed group's proxy edges. */
   const removeGroupProxyEdges = (groupId: number): void => {
     const prefix = `${GROUP_PROXY_EDGE_PREFIX}${groupId}-`;
     const ids = getEdges.value.filter((edge) => edge.id.startsWith(prefix)).map((edge) => edge.id);
@@ -184,8 +181,8 @@ export function useNodeGroups() {
         id: child.id,
         x: abs.x,
         y: abs.y,
-        w: child.dimensions.width || 0,
-        h: child.dimensions.height || 0,
+        w: child.dimensions.width || NOMINAL_NODE_WIDTH,
+        h: child.dimensions.height || NOMINAL_NODE_HEIGHT,
       };
     });
     const minX = Math.min(...snapshot.map((s) => s.x)) - GROUP_PADDING;
@@ -284,7 +281,6 @@ export function useNodeGroups() {
     const parentId = groupNodeId(groupId);
     const group = findNode(parentId);
     if (!group) return;
-    // Expanding: drop the proxy edges first so the real edges re-render once members unhide.
     if (!collapsed) removeGroupProxyEdges(groupId);
     for (const child of childNodesOf(parentId)) {
       updateNode(child.id, { hidden: collapsed });
@@ -302,11 +298,14 @@ export function useNodeGroups() {
         width: GROUP_COLLAPSED_WIDTH,
         height: GROUP_COLLAPSED_HEIGHT,
       };
-      // The pill's handles only render once `collapsed` is applied; wait a tick so the
-      // proxy edges have handles to attach to.
-      await nextTick();
+      await nextTick(); // wait for the pill's handles to render before attaching proxies
       addGroupProxyEdges(parentId);
     } else {
+      // After a refresh, members loaded hidden and were never measured — force a
+      // re-measure before refit so the box accounts for their sizes.
+      await nextTick();
+      updateNodeInternals(childNodesOf(parentId).map((child) => child.id));
+      await nextTick();
       const fit = refitGroup(parentId);
       bounds = fit
         ? fit.bounds

--- a/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
@@ -1,0 +1,399 @@
+// composables/useNodeGroups.ts
+// Shared logic for visual node groups — labeled, resizable containers drawn around
+// nodes. Groups are organizational only: they never affect execution or results.
+//
+// The #1 correctness concern is absolute<->relative position conversion: VueFlow
+// stores a child's `position` relative to its parent group, while the backend stores
+// absolute canvas coordinates. The helpers below centralize that conversion.
+import { type Edge, type GraphNode, type Node, type XYPosition, useVueFlow } from "@vue-flow/core";
+import { ElMessage } from "element-plus";
+import { nextTick } from "vue";
+
+import { FlowApi } from "../api";
+import { useFlowStore } from "../stores/flow-store";
+import type { GroupBoundsUpdate, GroupInput, GroupNodeData, NodePositionUpdate } from "../types";
+
+export const GROUP_NODE_PREFIX = "group-";
+export const CUSTOM_NODE_TYPE = "custom-node";
+export const GROUP_NODE_TYPE = "group";
+
+// Box padding around members and header allowance. Groups auto-fit their contents
+// (no manual resize), so these define how tightly the box wraps its nodes.
+const GROUP_PADDING = 40;
+const GROUP_HEADER = 36;
+// Height of a collapsed group (header bar only).
+const GROUP_COLLAPSED_HEIGHT = 34;
+// Width of a collapsed group — a compact pill, independent of the expanded box width.
+const GROUP_COLLAPSED_WIDTH = 200;
+
+// Handle ids on the collapsed pill that boundary "proxy" edges attach to.
+export const GROUP_TARGET_HANDLE = "group-target";
+export const GROUP_SOURCE_HANDLE = "group-source";
+// Proxy edges are UI-only stand-ins shown while a group is collapsed: they reroute the
+// edges crossing the group boundary to the pill. Ids are prefixed so Canvas.vue can skip
+// backend persistence for them and so we can find/remove them on expand/ungroup.
+export const GROUP_PROXY_EDGE_PREFIX = "group-proxy-";
+export const GROUP_PROXY_EDGE_TYPE = "group-proxy";
+
+/** VueFlow node id for a backend group id (kept in a separate namespace from node ids). */
+export const groupNodeId = (groupId: number): string => `${GROUP_NODE_PREFIX}${groupId}`;
+export const isGroupNodeId = (vueId: string): boolean => vueId.startsWith(GROUP_NODE_PREFIX);
+export const groupBackendId = (vueId: string): number =>
+  Number(vueId.slice(GROUP_NODE_PREFIX.length));
+
+/** Absolute canvas position of a node, whether or not it is parented to a group. */
+export const absolutePosition = (node: GraphNode): XYPosition => ({
+  x: node.computedPosition.x,
+  y: node.computedPosition.y,
+});
+
+/** Build the VueFlow container node for a group (rendered behind its children). */
+export const buildGroupNode = (group: GroupInput): Node<GroupNodeData> => ({
+  id: groupNodeId(group.id),
+  type: GROUP_NODE_TYPE,
+  position: { x: group.x_position, y: group.y_position },
+  style: { width: `${group.width}px`, height: `${group.height}px` },
+  data: {
+    id: group.id,
+    label: group.name,
+    color: group.color ?? null,
+    collapsed: group.collapsed ?? false,
+  },
+  zIndex: 0,
+  connectable: false,
+  // Removed only via the explicit "ungroup" action — never by the generic delete path.
+  deletable: false,
+});
+
+export function useNodeGroups() {
+  const {
+    getSelectedNodes,
+    getNodes,
+    getEdges,
+    findNode,
+    addNodes,
+    addEdges,
+    removeNodes,
+    removeEdges,
+    updateNode,
+    updateNodeData,
+  } = useVueFlow();
+  const flowStore = useFlowStore();
+
+  const childNodesOf = (groupVueId: string): GraphNode[] =>
+    getNodes.value.filter((node) => node.parentNode === groupVueId);
+
+  /**
+   * While a group is collapsed its members are hidden, so VueFlow drops every edge that
+   * touches them. Re-show the connections crossing the group boundary as UI-only "proxy"
+   * edges routed to the collapsed pill: external→member becomes external→pill, and
+   * member→external becomes pill→external. Internal (member↔member) edges stay hidden.
+   */
+  const addGroupProxyEdges = (groupVueId: string): void => {
+    const groupId = groupBackendId(groupVueId);
+    const memberIds = new Set(childNodesOf(groupVueId).map((node) => node.id));
+    if (memberIds.size === 0) return;
+    const prefix = `${GROUP_PROXY_EDGE_PREFIX}${groupId}-`;
+    const proxies: Edge[] = [];
+    const seen = new Set<string>();
+    for (const edge of getEdges.value) {
+      const sourceIn = memberIds.has(edge.source);
+      const targetIn = memberIds.has(edge.target);
+      if (sourceIn === targetIn) continue; // internal or fully external — nothing to reroute
+      const proxy: Edge = targetIn
+        ? {
+            id: `${prefix}in-${edge.source}-${edge.sourceHandle ?? ""}`,
+            source: edge.source,
+            sourceHandle: edge.sourceHandle,
+            target: groupVueId,
+            targetHandle: GROUP_TARGET_HANDLE,
+            type: GROUP_PROXY_EDGE_TYPE,
+            selectable: false,
+            deletable: false,
+            focusable: false,
+            data: { isGroupProxy: true, groupId },
+          }
+        : {
+            id: `${prefix}out-${edge.target}-${edge.targetHandle ?? ""}`,
+            source: groupVueId,
+            sourceHandle: GROUP_SOURCE_HANDLE,
+            target: edge.target,
+            targetHandle: edge.targetHandle,
+            type: GROUP_PROXY_EDGE_TYPE,
+            selectable: false,
+            deletable: false,
+            focusable: false,
+            data: { isGroupProxy: true, groupId },
+          };
+      if (seen.has(proxy.id)) continue;
+      seen.add(proxy.id);
+      proxies.push(proxy);
+    }
+    if (proxies.length > 0) addEdges(proxies);
+  };
+
+  /** Remove the proxy edges created for a (now expanding/ungrouping) collapsed group. */
+  const removeGroupProxyEdges = (groupId: number): void => {
+    const prefix = `${GROUP_PROXY_EDGE_PREFIX}${groupId}-`;
+    const ids = getEdges.value.filter((edge) => edge.id.startsWith(prefix)).map((edge) => edge.id);
+    if (ids.length > 0) removeEdges(ids);
+  };
+
+  // Group nodes are deletable:false so the keyboard Delete key can't orphan their
+  // children. removeNodes() honors that flag, so the explicit ungroup path must flip
+  // it first to actually remove the box from the canvas.
+  const removeGroupNode = (groupVueId: string): void => {
+    updateNode(groupVueId, { deletable: true });
+    removeNodes([groupVueId]);
+  };
+
+  /** Reparent on-canvas nodes into a group, converting positions to parent-relative. */
+  const attachNodesToGroup = (group: GroupInput, nodeIds: number[]): void => {
+    const parentId = groupNodeId(group.id);
+    for (const nodeId of nodeIds) {
+      const node = findNode(String(nodeId));
+      if (!node) continue;
+      const abs = absolutePosition(node);
+      updateNode(String(nodeId), {
+        parentNode: parentId,
+        position: { x: abs.x - group.x_position, y: abs.y - group.y_position },
+      });
+    }
+  };
+
+  /** Restore a child to absolute coordinates, unhide it, and detach it from its group. */
+  const detachNodeToAbsolute = (node: GraphNode): void => {
+    const abs = absolutePosition(node);
+    updateNode(node.id, { parentNode: undefined, position: { x: abs.x, y: abs.y }, hidden: false });
+  };
+
+  /**
+   * Auto-fit a group's box to tightly wrap its members (+ padding/header), keeping the
+   * members visually fixed. Returns the new bounds and member absolute positions to
+   * persist — all computed from a single snapshot to avoid stale async dimension reads
+   * after the box origin moves.
+   */
+  const refitGroup = (
+    groupVueId: string,
+  ): { bounds: GroupBoundsUpdate; positions: NodePositionUpdate[] } | null => {
+    const children = childNodesOf(groupVueId);
+    if (children.length === 0) return null;
+    const snapshot = children.map((child) => {
+      const abs = absolutePosition(child);
+      return {
+        id: child.id,
+        x: abs.x,
+        y: abs.y,
+        w: child.dimensions.width || 0,
+        h: child.dimensions.height || 0,
+      };
+    });
+    const minX = Math.min(...snapshot.map((s) => s.x)) - GROUP_PADDING;
+    const minY = Math.min(...snapshot.map((s) => s.y)) - GROUP_PADDING - GROUP_HEADER;
+    const maxX = Math.max(...snapshot.map((s) => s.x + s.w)) + GROUP_PADDING;
+    const maxY = Math.max(...snapshot.map((s) => s.y + s.h)) + GROUP_PADDING;
+    const width = maxX - minX;
+    const height = maxY - minY;
+    // Move the box origin, then re-anchor each child relative to it (absolute unchanged).
+    updateNode(groupVueId, {
+      position: { x: minX, y: minY },
+      style: { width: `${width}px`, height: `${height}px` },
+    });
+    for (const item of snapshot) {
+      updateNode(item.id, { position: { x: item.x - minX, y: item.y - minY } });
+    }
+    return {
+      bounds: {
+        group_id: groupBackendId(groupVueId),
+        x_position: minX,
+        y_position: minY,
+        width,
+        height,
+      },
+      positions: snapshot.map((s) => ({ node_id: Number(s.id), pos_x: s.x, pos_y: s.y })),
+    };
+  };
+
+  /** Group the currently selected (non-group) nodes into a new auto-fitted container. */
+  const groupSelectedNodes = async (): Promise<void> => {
+    if (flowStore.flowId === null) return;
+    const selected = getSelectedNodes.value.filter((node) => node.type === CUSTOM_NODE_TYPE);
+    if (selected.length === 0) {
+      ElMessage.info("Select one or more nodes to group.");
+      return;
+    }
+    const nodeIds = selected.map((node) => Number(node.id));
+    const response = await FlowApi.createGroup(flowStore.flowId, {
+      node_ids: nodeIds,
+      name: "Group",
+    });
+    if (response.group) {
+      // Parent must exist before children reference it.
+      addNodes([buildGroupNode(response.group)]);
+      attachNodesToGroup(response.group, nodeIds);
+      // Tighten the box to the real rendered node sizes and persist those bounds.
+      const fit = refitGroup(groupNodeId(response.group.id));
+      if (fit) {
+        await FlowApi.updateLayout(flowStore.flowId, {
+          node_positions: [],
+          group_bounds: [fit.bounds],
+        });
+      }
+    }
+    flowStore.updateHistoryState(response.history);
+  };
+
+  /** Ungroup: detach children back to absolute coordinates, then delete the box. */
+  const ungroupNodes = async (groupId: number): Promise<void> => {
+    if (flowStore.flowId === null) return;
+    const parentId = groupNodeId(groupId);
+    removeGroupProxyEdges(groupId);
+    for (const child of childNodesOf(parentId)) {
+      detachNodeToAbsolute(child);
+    }
+    removeGroupNode(parentId);
+    const response = await FlowApi.deleteGroup(flowStore.flowId, groupId);
+    flowStore.updateHistoryState(response.history);
+  };
+
+  /** Remove the currently selected grouped nodes from their group(s). */
+  const removeSelectedFromGroup = async (): Promise<void> => {
+    if (flowStore.flowId === null) return;
+    const grouped = getSelectedNodes.value.filter(
+      (node) => node.type === CUSTOM_NODE_TYPE && node.parentNode,
+    );
+    if (grouped.length === 0) return;
+    const affectedGroups = new Set(grouped.map((node) => node.parentNode as string));
+    for (const node of grouped) {
+      detachNodeToAbsolute(node);
+    }
+    const response = await FlowApi.removeNodesFromGroup(
+      flowStore.flowId,
+      grouped.map((node) => Number(node.id)),
+    );
+    // Drop any group box left empty on the canvas (the backend already pruned it).
+    for (const groupVueId of affectedGroups) {
+      if (childNodesOf(groupVueId).length === 0) removeGroupNode(groupVueId);
+    }
+    flowStore.updateHistoryState(response.history);
+  };
+
+  /** Collapse/expand a group: hide/show members and shrink/refit the box. */
+  const setGroupCollapsed = async (groupId: number, collapsed: boolean): Promise<void> => {
+    if (flowStore.flowId === null) return;
+    const parentId = groupNodeId(groupId);
+    const group = findNode(parentId);
+    if (!group) return;
+    // Expanding: drop the proxy edges first so the real edges re-render once members unhide.
+    if (!collapsed) removeGroupProxyEdges(groupId);
+    for (const child of childNodesOf(parentId)) {
+      updateNode(child.id, { hidden: collapsed });
+    }
+    updateNodeData(parentId, { collapsed });
+    let bounds: GroupBoundsUpdate;
+    if (collapsed) {
+      updateNode(parentId, {
+        style: { width: `${GROUP_COLLAPSED_WIDTH}px`, height: `${GROUP_COLLAPSED_HEIGHT}px` },
+      });
+      bounds = {
+        group_id: groupId,
+        x_position: group.computedPosition.x,
+        y_position: group.computedPosition.y,
+        width: GROUP_COLLAPSED_WIDTH,
+        height: GROUP_COLLAPSED_HEIGHT,
+      };
+      // The pill's handles only render once `collapsed` is applied; wait a tick so the
+      // proxy edges have handles to attach to.
+      await nextTick();
+      addGroupProxyEdges(parentId);
+    } else {
+      const fit = refitGroup(parentId);
+      bounds = fit
+        ? fit.bounds
+        : {
+            group_id: groupId,
+            x_position: group.computedPosition.x,
+            y_position: group.computedPosition.y,
+            width: group.dimensions.width,
+            height: group.dimensions.height,
+          };
+    }
+    const response = await FlowApi.updateGroup(flowStore.flowId, groupId, {
+      collapsed,
+      x_position: bounds.x_position,
+      y_position: bounds.y_position,
+      width: bounds.width,
+      height: bounds.height,
+    });
+    flowStore.updateHistoryState(response.history);
+  };
+
+  /** Persist absolute positions for a set of nodes and/or bounds for a set of groups. */
+  const persistLayout = async (nodes: GraphNode[], groups: GraphNode[] = []): Promise<void> => {
+    if (flowStore.flowId === null) return;
+    const nodePositions: NodePositionUpdate[] = nodes.map((node) => {
+      const abs = absolutePosition(node);
+      return { node_id: Number(node.id), pos_x: abs.x, pos_y: abs.y };
+    });
+    const groupBounds: GroupBoundsUpdate[] = groups.map((group) => ({
+      group_id: groupBackendId(group.id),
+      x_position: group.computedPosition.x,
+      y_position: group.computedPosition.y,
+      width: group.dimensions.width,
+      height: group.dimensions.height,
+    }));
+    if (nodePositions.length === 0 && groupBounds.length === 0) return;
+    const response = await FlowApi.updateLayout(flowStore.flowId, {
+      node_positions: nodePositions,
+      group_bounds: groupBounds,
+    });
+    flowStore.updateHistoryState(response.history);
+  };
+
+  /**
+   * Persist a drag-end:
+   * - group moved → its bounds + every child's new absolute position;
+   * - grouped child moved → auto-fit the box and persist box + member positions;
+   * - free node moved → the dragged node, or all selected free nodes (multi-select).
+   */
+  const persistDrag = async (node: GraphNode): Promise<void> => {
+    if (flowStore.flowId === null) return;
+    if (node.type === GROUP_NODE_TYPE) {
+      await persistLayout(childNodesOf(node.id), [node]);
+      return;
+    }
+    if (node.parentNode) {
+      const fit = refitGroup(node.parentNode);
+      if (fit) {
+        const response = await FlowApi.updateLayout(flowStore.flowId, {
+          node_positions: fit.positions,
+          group_bounds: [fit.bounds],
+        });
+        flowStore.updateHistoryState(response.history);
+      }
+      return;
+    }
+    const selected = getSelectedNodes.value.filter(
+      (selectedNode) => selectedNode.type !== GROUP_NODE_TYPE && !selectedNode.parentNode,
+    );
+    const moved =
+      selected.length > 1 && selected.some((selectedNode) => selectedNode.id === node.id)
+        ? selected
+        : [node];
+    await persistLayout(moved);
+  };
+
+  return {
+    childNodesOf,
+    attachNodesToGroup,
+    detachNodeToAbsolute,
+    groupSelectedNodes,
+    ungroupNodes,
+    removeSelectedFromGroup,
+    setGroupCollapsed,
+    addGroupProxyEdges,
+    removeGroupProxyEdges,
+    persistLayout,
+    persistDrag,
+  };
+}

--- a/flowfile_frontend/src/renderer/app/composables/useNodes.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useNodes.ts
@@ -44,7 +44,7 @@ const componentCache: Map<string, Promise<DefineComponent>> = new Map();
  * Fetches node templates with caching to minimize API calls
  * Returns cached data if available, otherwise fetches from API
  */
-async function fetchNodeTemplates(): Promise<NodeTemplate[]> {
+export async function fetchNodeTemplates(): Promise<NodeTemplate[]> {
   // If we already have cached data, return it immediately
   if (nodeTemplatesCache !== null) {
     return nodeTemplatesCache;
@@ -60,9 +60,9 @@ async function fetchNodeTemplates(): Promise<NodeTemplate[]> {
   cachePromise = axios
     .get("/node_list")
     .then((response) => {
-      const allNodes = response.data as NodeTemplate[];
-      // Apply production filter if needed
-      nodeTemplatesCache = ENV.isProduction ? allNodes.filter((node) => node.prod_ready) : allNodes;
+      // Cache the full list; the production filter is applied per-consumer (palette
+      // in useNodes()) so by-item lookups still resolve nodes saved flows reference.
+      nodeTemplatesCache = response.data as NodeTemplate[];
       return nodeTemplatesCache;
     })
     .catch((error) => {
@@ -196,7 +196,8 @@ export const useNodes = () => {
     error.value = null;
 
     try {
-      nodes.value = await fetchNodeTemplates();
+      const all = await fetchNodeTemplates();
+      nodes.value = ENV.isProduction ? all.filter((node) => node.prod_ready) : all;
     } catch (err) {
       error.value = err as Error;
       nodes.value = [];

--- a/flowfile_frontend/src/renderer/app/features/designer/utils.ts
+++ b/flowfile_frontend/src/renderer/app/features/designer/utils.ts
@@ -1,6 +1,6 @@
-import axios from "axios";
 import { NodeTemplate } from "./types";
 import { flowfileCorebaseURL } from "../../../config/constants";
+import { fetchNodeTemplates } from "../../composables/useNodes";
 
 // List of built-in icons that are bundled with the app
 const BUILTIN_ICONS = new Set([
@@ -94,8 +94,4 @@ export const getCustomIconUrl = (name: string): string => {
   return `${flowfileCorebaseURL}user_defined_components/icon/${name}`;
 };
 
-export const fetchNodes = async (): Promise<NodeTemplate[]> => {
-  const response = await axios.get("/node_list");
-  const listNodes = response.data as NodeTemplate[];
-  return listNodes;
-};
+export const fetchNodes = async (): Promise<NodeTemplate[]> => fetchNodeTemplates();

--- a/flowfile_frontend/src/renderer/app/types/canvas.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/canvas.types.ts
@@ -57,7 +57,7 @@ export interface CursorPosition {
 
 export interface ContextMenuAction {
   actionId: string;
-  targetType: "node" | "edge" | "pane";
+  targetType: "node" | "edge" | "pane" | "selection";
   targetId: string;
   position: CursorPosition;
 }

--- a/flowfile_frontend/src/renderer/app/types/flow.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/flow.types.ts
@@ -244,6 +244,8 @@ export interface GroupBoundsUpdate {
 export interface UpdateLayoutRequest {
   node_positions: NodePositionUpdate[];
   group_bounds: GroupBoundsUpdate[];
+  // false -> apply layout without a new undo entry (fold into a preceding op's snapshot)
+  record_history?: boolean;
 }
 
 // mirrors routes.GroupOperationResponse

--- a/flowfile_frontend/src/renderer/app/types/flow.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/flow.types.ts
@@ -123,6 +123,7 @@ export interface NodeInput extends NodeTemplate {
   id: number;
   pos_x: number;
   pos_y: number;
+  group_id?: number | null;
   node_reference?: string;
 }
 
@@ -167,6 +168,85 @@ export interface EdgeInput {
 export interface VueFlowInput {
   node_edges: EdgeInput[];
   node_inputs: NodeInput[];
+  groups: GroupInput[];
+}
+
+// ============================================================================
+// Node Group Types (visual containers; organizational only)
+// Mirror flowfile_core/.../schemas.py field-for-field (no OpenAPI codegen).
+// ============================================================================
+
+// mirrors schemas.GroupColor
+export type GroupColor = "slate" | "blue" | "green" | "amber" | "rose" | "violet" | "cyan";
+
+// mirrors schemas.FlowfileGroup
+export interface GroupInput {
+  id: number;
+  name: string;
+  color?: GroupColor | null;
+  x_position: number;
+  y_position: number;
+  width: number;
+  height: number;
+  collapsed?: boolean;
+  parent_group_id?: number | null;
+}
+
+// VueFlow node `data` payload for a group container node.
+export interface GroupNodeData {
+  id: number;
+  label: string;
+  color?: GroupColor | null;
+  collapsed?: boolean;
+}
+
+// mirrors schemas.CreateGroupRequest
+export interface CreateGroupRequest {
+  node_ids: number[];
+  name?: string;
+  color?: GroupColor | null;
+  x_position?: number | null;
+  y_position?: number | null;
+  width?: number | null;
+  height?: number | null;
+}
+
+// mirrors schemas.UpdateGroupRequest
+export interface UpdateGroupRequest {
+  name?: string;
+  color?: GroupColor | null;
+  x_position?: number | null;
+  y_position?: number | null;
+  width?: number | null;
+  height?: number | null;
+  collapsed?: boolean | null;
+}
+
+// mirrors schemas.NodePositionUpdate
+export interface NodePositionUpdate {
+  node_id: number;
+  pos_x: number;
+  pos_y: number;
+}
+
+// mirrors schemas.GroupBoundsUpdate
+export interface GroupBoundsUpdate {
+  group_id: number;
+  x_position: number;
+  y_position: number;
+  width: number;
+  height: number;
+}
+
+// mirrors schemas.UpdateLayoutRequest
+export interface UpdateLayoutRequest {
+  node_positions: NodePositionUpdate[];
+  group_bounds: GroupBoundsUpdate[];
+}
+
+// mirrors routes.GroupOperationResponse
+export interface GroupOperationResponse extends OperationResponse {
+  group: GroupInput | null;
 }
 
 // ============================================================================

--- a/flowfile_frontend/src/renderer/app/types/flow.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/flow.types.ts
@@ -209,6 +209,8 @@ export interface CreateGroupRequest {
   y_position?: number | null;
   width?: number | null;
   height?: number | null;
+  parent_group_id?: number | null;
+  child_group_ids?: number[];
 }
 
 // mirrors schemas.UpdateGroupRequest

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
@@ -22,13 +22,22 @@ import {
   NodeComponent,
   EdgeComponent,
   Node,
+  NodeMouseEvent,
   useVueFlow,
   ConnectionMode,
 } from "@vue-flow/core";
 import { MiniMap } from "@vue-flow/minimap";
 
 import CustomNode from "../../components/nodes/NodeWrapper.vue";
+import GroupNode from "../../components/nodes/GroupNode.vue";
+import {
+  useNodeGroups,
+  isGroupNodeId,
+  GROUP_PROXY_EDGE_PREFIX,
+  GROUP_PROXY_EDGE_TYPE,
+} from "../../composables/useNodeGroups";
 import DeletableEdge from "./DeletableEdge.vue";
+import GroupProxyEdge from "./GroupProxyEdge.vue";
 import useDragAndDrop from "./useDnD";
 import {
   suppressedEdgeRemovals,
@@ -94,7 +103,9 @@ const editorStore = useEditorStore();
 const flowStore = useFlowStore();
 const aiStore = useAiStore();
 const rawCustomNode = markRaw(CustomNode);
+const rawGroupNode = markRaw(GroupNode);
 const rawDeletableEdge = markRaw(DeletableEdge);
+const rawGroupProxyEdge = markRaw(GroupProxyEdge);
 const { updateEdge, addEdges, fitView, screenToFlowCoordinate, addSelectedNodes, onPaneReady } =
   useVueFlow();
 
@@ -115,9 +126,11 @@ const isLoadingFlow = ref(false);
 const vueFlow = ref<InstanceType<typeof VueFlow>>();
 const nodeTypes: NodeTypesObject = {
   "custom-node": rawCustomNode as NodeComponent,
+  group: rawGroupNode as NodeComponent,
 };
 const edgeTypes = {
   default: rawDeletableEdge as EdgeComponent,
+  [GROUP_PROXY_EDGE_TYPE]: rawGroupProxyEdge as EdgeComponent,
 };
 const hoveredEdgeId = ref<string | null>(null);
 // Short delay before clearing on edge-leave so the cursor can cross the SVG→HTML
@@ -213,12 +226,20 @@ async function onNodeDragStop({ node }: { node: Node }) {
   const edgeId = nodeDragInsertCandidate;
   nodeDragInsertCandidate = null;
   markHoveredEdge(null);
-  if (!edgeId) return;
-  const template = (node.data as { nodeTemplate?: NodeTemplate } | undefined)?.nodeTemplate;
-  if (!template) return;
-  const response = await insertNodeOnEdge(flowStore.flowId, Number(node.id), template, edgeId);
-  if (response?.history) {
-    flowStore.updateHistoryState(response.history);
+  if (edgeId) {
+    const template = (node.data as { nodeTemplate?: NodeTemplate } | undefined)?.nodeTemplate;
+    if (!template) return;
+    const response = await insertNodeOnEdge(flowStore.flowId, Number(node.id), template, edgeId);
+    if (response?.history) {
+      flowStore.updateHistoryState(response.history);
+    }
+    return;
+  }
+  // No edge-splice: persist the new position(s). Also closes the long-standing gap
+  // where dragged node positions were never sent to the backend.
+  const graphNode = instance.findNode(node.id);
+  if (graphNode) {
+    await persistDrag(graphNode);
   }
 }
 const nodes = ref<Node[]>([]);
@@ -237,6 +258,7 @@ const {
   createManualInputFromClipboard,
   insertNodeOnEdge,
 } = useDragAndDrop();
+const { groupSelectedNodes, removeSelectedFromGroup, persistDrag } = useNodeGroups();
 const dataPreview = ref<InstanceType<typeof DataPreview>>();
 // 25 / 75 split of the canvas height between the bottom table preview and the
 // right-side node settings drawer. Initial-only — DraggableItem reads these
@@ -247,6 +269,9 @@ const selectedNodeIdInTable = ref(0);
 const showContextMenu = ref(false);
 const clickedPosition = ref<CursorPosition>({ x: 0, y: 0 });
 const contextMenuTarget = ref({ type: "pane", id: "" });
+// Whether the right-clicked node is currently inside a group (drives Group vs
+// Remove-from-group in the node context menu).
+const contextMenuTargetInGroup = ref(false);
 const emit = defineEmits<{
   (e: "save", flowId: number): void;
   (e: "run", flowId: number): void;
@@ -596,6 +621,9 @@ const handleNodeChange = async (nodeChangesEvent: any) => {
   let lastResponse: Awaited<ReturnType<typeof deleteNode>> | undefined;
   for (const nodeChange of nodeChanges) {
     if (nodeChange.type === "remove") {
+      // Group boxes are not real nodes — their removal is handled by the ungroup
+      // action (which calls deleteGroup). Skip them so we don't deleteNode(NaN).
+      if (isGroupNodeId(nodeChange.id)) continue;
       const nodeChangeId = Number(nodeChange.id);
       lastResponse = await deleteNode(flowStore.flowId, nodeChangeId);
     }
@@ -627,6 +655,11 @@ const handleEdgeChange = async (edgeChangesEvent: any) => {
   let lastResponse: Awaited<ReturnType<typeof deleteConnection>> | undefined;
   for (const edgeChange of edgeChanges) {
     if (edgeChange.type === "remove") {
+      // Proxy edges are UI-only stand-ins for a collapsed group; removing them on
+      // expand/ungroup must never touch the backend.
+      if (edgeChange.id.startsWith(GROUP_PROXY_EDGE_PREFIX)) {
+        continue;
+      }
       if (suppressedEdgeRemovals.delete(edgeChange.id)) {
         // Edge was already deleted on the backend by an in-flight operation
         // (e.g. drag-to-insert) — skip the redundant API call.
@@ -925,6 +958,10 @@ const handleContextMenuAction = async (actionData: ContextMenuAction) => {
     const question = await promptLineageQuestion(`node ${focusNodeId}`);
     if (!question) return;
     await aiStore.askLineageQuestion(flowStore.flowId, question, focusNodeId);
+  } else if (actionId === "group-selection") {
+    await groupSelectedNodes();
+  } else if (actionId === "remove-from-group") {
+    await removeSelectedFromGroup();
   }
 };
 
@@ -1018,10 +1055,38 @@ const handleContextMenu = (event: Event) => {
   event.preventDefault();
   let pointerEvent = event as PointerEvent;
 
+  contextMenuTarget.value = { type: "pane", id: "" };
+  contextMenuTargetInGroup.value = false;
   clickedPosition.value = {
     x: pointerEvent.x,
     y: pointerEvent.y,
   };
+  showContextMenu.value = true;
+};
+
+// Right-click on a node opens the context menu with node-target actions (incl.
+// grouping). The container "group" node has its own affordances, so skip it here.
+const handleNodeContextMenu = ({ event, node }: NodeMouseEvent) => {
+  event.preventDefault();
+  if (node.type === "group") return;
+  // Ensure the right-clicked node participates in the selection-based group action.
+  if (!node.selected) {
+    addSelectedNodes([node]);
+  }
+  const mouseEvent = event as MouseEvent;
+  contextMenuTarget.value = { type: "node", id: node.id };
+  contextMenuTargetInGroup.value = Boolean(node.parentNode);
+  clickedPosition.value = { x: mouseEvent.clientX, y: mouseEvent.clientY };
+  showContextMenu.value = true;
+};
+
+// Right-click on the multi-selection rectangle (the highlighted box around several
+// selected nodes) — VueFlow routes this here rather than to pane/node menus.
+const handleSelectionContextMenu = ({ event }: { event: MouseEvent }) => {
+  event.preventDefault();
+  contextMenuTarget.value = { type: "selection", id: "" };
+  contextMenuTargetInGroup.value = false;
+  clickedPosition.value = { x: event.clientX, y: event.clientY };
   showContextMenu.value = true;
 };
 
@@ -1227,6 +1292,8 @@ defineExpose({
         @nodes-change="handleNodeChange"
         @edges-change="handleEdgeChange"
         @pane-context-menu="handleContextMenu"
+        @node-context-menu="handleNodeContextMenu"
+        @selection-context-menu="handleSelectionContextMenu"
         @click="closeContextMenu"
         @selection-start="handleSelectionStart"
         @selection-end="handleSelectionEnd"
@@ -1241,6 +1308,7 @@ defineExpose({
         :y="clickedPosition.y"
         :target-type="contextMenuTarget.type"
         :target-id="contextMenuTarget.id"
+        :target-in-group="contextMenuTargetInGroup"
         :on-close="closeContextMenu"
         @action="handleContextMenuAction"
       />

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
@@ -490,6 +490,8 @@ function isValidConnection(connection: Connection): boolean {
   const source = connection.source;
   const target = connection.target;
   if (!source || !target) return false;
+  // Group-proxy edges (to/from a collapsed pill) are UI-only and can't be user-drawn.
+  if (isGroupNodeId(source) || isGroupNodeId(target)) return true;
   if (source === target) return rejectConnection("A node can't connect to itself");
 
   const currentEdges = instance.getEdges.value;
@@ -591,6 +593,7 @@ const NodeIsSelected = (nodeId: string) => {
 };
 
 const nodeClick = (mouseEvent: any) => {
+  if (isGroupNodeId(mouseEvent.node.id)) return; // groups have no node data to preview
   showTablePreview.value = true;
 
   nextTick().then(() => {
@@ -655,8 +658,7 @@ const handleEdgeChange = async (edgeChangesEvent: any) => {
   let lastResponse: Awaited<ReturnType<typeof deleteConnection>> | undefined;
   for (const edgeChange of edgeChanges) {
     if (edgeChange.type === "remove") {
-      // Proxy edges are UI-only stand-ins for a collapsed group; removing them on
-      // expand/ungroup must never touch the backend.
+      // UI-only proxy edges must not trigger a backend deleteConnection.
       if (edgeChange.id.startsWith(GROUP_PROXY_EDGE_PREFIX)) {
         continue;
       }

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
@@ -490,7 +490,9 @@ function isValidConnection(connection: Connection): boolean {
   const source = connection.source;
   const target = connection.target;
   if (!source || !target) return false;
-  // Group-proxy edges (to/from a collapsed pill) are UI-only and can't be user-drawn.
+  // A collapsed group's pill edges are added programmatically but still validated through
+  // here, so they must be accepted or they won't render. Users can't draw them by hand
+  // (group nodes are connectable:false); this only greenlights those UI-only proxy edges.
   if (isGroupNodeId(source) || isGroupNodeId(target)) return true;
   if (source === target) return rejectConnection("A node can't connect to itself");
 

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/ContextMenu.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/ContextMenu.vue
@@ -64,38 +64,38 @@ const ICONS: Record<string, string> = {
 // inconsistency, fixing it is out of scope for.
 const getMenuActions = () => {
   const baseActions = [
-    { id: "fit-view", label: "Fit View", icon: "🔍" },
-    { id: "zoom-in", label: "Zoom In", icon: "🔍+" },
-    { id: "zoom-out", label: "Zoom Out", icon: "🔍-" },
-    { id: "paste-node", label: "Paste Node", icon: "📋" },
+    { id: "fit-view", label: "Fit View", icon: "fitView" },
+    { id: "zoom-in", label: "Zoom In", icon: "zoomIn" },
+    { id: "zoom-out", label: "Zoom Out", icon: "zoomOut" },
+    { id: "paste-node", label: "Paste Node", icon: "paste" },
   ];
   if (props.targetType === "pane") {
     baseActions.push({
       id: "group-selection",
       label: "Group selected nodes",
-      icon: "🗂️",
+      icon: "group",
     });
     baseActions.push({
       id: "generate-documentation",
       label: "Generate documentation",
-      icon: "📝",
+      icon: "document",
     });
     baseActions.push({
       id: "add-descriptions-all",
       label: "Add description to all nodes",
-      icon: "✨",
+      icon: "sparkles",
     });
     baseActions.push({
       id: "ask-lineage",
       label: "Ask about lineage…",
-      icon: "🔎",
+      icon: "lineage",
     });
   }
   if (props.targetType === "selection") {
     baseActions.push({
       id: "group-selection",
       label: "Group selected nodes",
-      icon: "🗂️",
+      icon: "group",
     });
   }
   if (props.targetType === "node") {
@@ -103,19 +103,19 @@ const getMenuActions = () => {
       baseActions.push({
         id: "remove-from-group",
         label: "Remove from group",
-        icon: "🗂️",
+        icon: "ungroup",
       });
     } else {
       baseActions.push({
         id: "group-selection",
         label: "Group selected nodes",
-        icon: "🗂️",
+        icon: "group",
       });
     }
     baseActions.push({
       id: "ask-lineage-node",
       label: "Ask about this node's lineage…",
-      icon: "🔎",
+      icon: "lineage",
     });
   }
   return baseActions;
@@ -181,7 +181,21 @@ onUnmounted(() => {
         class="context-menu-item"
         @click="handleAction(action.id)"
       >
-        <span class="context-menu-icon">{{ action.icon }}</span>
+        <!-- eslint-disable vue/no-v-html -- ICONS is a trusted internal constant of static SVG paths -->
+        <span class="context-menu-icon" aria-hidden="true">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            v-html="ICONS[action.icon]"
+          ></svg>
+        </span>
+        <!-- eslint-enable vue/no-v-html -->
         <span>{{ action.label }}</span>
       </div>
     </div>
@@ -193,5 +207,12 @@ onUnmounted(() => {
 /* Component-specific overrides only */
 .context-menu {
   min-width: 200px;
+}
+
+.context-menu-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 </style>

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/ContextMenu.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/ContextMenu.vue
@@ -14,11 +14,15 @@ const props = defineProps({
   targetType: {
     type: String,
     required: true,
-    validator: (value: string) => ["node", "edge", "pane"].includes(value),
+    validator: (value: string) => ["node", "edge", "pane", "selection"].includes(value),
   },
   targetId: {
     type: String,
     default: "",
+  },
+  targetInGroup: {
+    type: Boolean,
+    default: false,
   },
   onClose: {
     type: Function,
@@ -45,6 +49,11 @@ const getMenuActions = () => {
   ];
   if (props.targetType === "pane") {
     baseActions.push({
+      id: "group-selection",
+      label: "Group selected nodes",
+      icon: "🗂️",
+    });
+    baseActions.push({
       id: "generate-documentation",
       label: "Generate documentation",
       icon: "📝",
@@ -60,7 +69,27 @@ const getMenuActions = () => {
       icon: "🔎",
     });
   }
+  if (props.targetType === "selection") {
+    baseActions.push({
+      id: "group-selection",
+      label: "Group selected nodes",
+      icon: "🗂️",
+    });
+  }
   if (props.targetType === "node") {
+    if (props.targetInGroup) {
+      baseActions.push({
+        id: "remove-from-group",
+        label: "Remove from group",
+        icon: "🗂️",
+      });
+    } else {
+      baseActions.push({
+        id: "group-selection",
+        label: "Group selected nodes",
+        icon: "🗂️",
+      });
+    }
     baseActions.push({
       id: "ask-lineage-node",
       label: "Ask about this node's lineage…",
@@ -73,7 +102,7 @@ const getMenuActions = () => {
 const handleAction = (actionId: string): void => {
   emit("action", {
     actionId,
-    targetType: props.targetType as "node" | "edge" | "pane",
+    targetType: props.targetType as "node" | "edge" | "pane" | "selection",
     targetId: props.targetId,
     position: { x: props.x, y: props.y },
   } as ContextMenuAction);

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/ContextMenu.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/ContextMenu.vue
@@ -34,6 +34,28 @@ const emit = defineEmits(["action"]);
 
 const menuRef = ref<HTMLElement | null>(null);
 
+// Lucide-style line icons (inner <svg> markup) drawn into a shared svg wrapper.
+const ICONS: Record<string, string> = {
+  fitView:
+    '<path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/>',
+  zoomIn:
+    '<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/>',
+  zoomOut:
+    '<circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/>',
+  paste:
+    '<rect x="8" y="2" width="8" height="4" rx="1" ry="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>',
+  group:
+    '<path d="M5 3a2 2 0 0 0-2 2"/><path d="M19 3a2 2 0 0 1 2 2"/><path d="M21 19a2 2 0 0 1-2 2"/><path d="M5 21a2 2 0 0 1-2-2"/><path d="M9 3h1"/><path d="M9 21h1"/><path d="M14 3h1"/><path d="M14 21h1"/><path d="M3 9v1"/><path d="M21 9v1"/><path d="M3 14v1"/><path d="M21 14v1"/>',
+  ungroup:
+    '<rect width="8" height="6" x="5" y="4" rx="1"/><rect width="8" height="6" x="11" y="14" rx="1"/>',
+  document:
+    '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><line x1="10" y1="9" x2="8" y2="9"/>',
+  sparkles:
+    '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/>',
+  lineage:
+    '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>',
+};
+
 // Define menu actions based on the target type. Pane-only entries pick up
 // the "Generate documentation" affordance and the new "Ask about
 // lineage" affordance; the per-node "Ask about this node's lineage"

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/GroupProxyEdge.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/GroupProxyEdge.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+// UI-only edge shown while a group is collapsed: it reroutes a boundary connection to the
+// collapsed pill. Non-interactive (no delete button, no label) and never persisted — see
+// useNodeGroups.addGroupProxyEdges. Rendered dashed/muted to read as a proxy, not a real wire.
+import { computed } from "vue";
+import { BaseEdge, getBezierPath } from "@vue-flow/core";
+import type { EdgeProps } from "@vue-flow/core";
+
+const props = defineProps<EdgeProps>();
+
+const path = computed(
+  () =>
+    getBezierPath({
+      sourceX: props.sourceX,
+      sourceY: props.sourceY,
+      sourcePosition: props.sourcePosition,
+      targetX: props.targetX,
+      targetY: props.targetY,
+      targetPosition: props.targetPosition,
+    })[0],
+);
+</script>
+
+<template>
+  <BaseEdge
+    :id="props.id"
+    :path="path"
+    :marker-end="props.markerEnd"
+    :style="{ stroke: '#94a3b8', strokeWidth: 1.5, strokeDasharray: '5 4' }"
+  />
+</template>

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/GroupProxyEdge.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/GroupProxyEdge.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-// UI-only edge shown while a group is collapsed: it reroutes a boundary connection to the
-// collapsed pill. Non-interactive (no delete button, no label) and never persisted — see
-// useNodeGroups.addGroupProxyEdges. Rendered dashed/muted to read as a proxy, not a real wire.
+// UI-only dashed edge for a collapsed group's rerouted connection.
 import { computed } from "vue";
 import { BaseEdge, getBezierPath } from "@vue-flow/core";
 import type { EdgeProps } from "@vue-flow/core";

--- a/flowfile_worker/flowfile_worker/external_sources/sql_source/main.py
+++ b/flowfile_worker/flowfile_worker/external_sources/sql_source/main.py
@@ -9,9 +9,7 @@ from flowfile_worker.external_sources.sql_source.models import (
     DatabaseWriteSettings,
 )
 
-# Default ports per database type for a fast pre-flight connectivity check, so an
-# unreachable database raises in seconds instead of waiting out connectorx's ~30s
-# connection-pool timeout.
+# Default ports per database type for the pre-flight connectivity check.
 _DEFAULT_DB_PORTS = {
     "postgresql": 5432,
     "postgres": 5432,

--- a/flowfile_worker/flowfile_worker/external_sources/sql_source/main.py
+++ b/flowfile_worker/flowfile_worker/external_sources/sql_source/main.py
@@ -1,8 +1,47 @@
+import socket
 from io import BytesIO
 
 import polars as pl
 
-from flowfile_worker.external_sources.sql_source.models import DatabaseReadSettings, DatabaseWriteSettings
+from flowfile_worker.external_sources.sql_source.models import (
+    DataBaseConnection,
+    DatabaseReadSettings,
+    DatabaseWriteSettings,
+)
+
+# Default ports per database type for a fast pre-flight connectivity check, so an
+# unreachable database raises in seconds instead of waiting out connectorx's ~30s
+# connection-pool timeout.
+_DEFAULT_DB_PORTS = {
+    "postgresql": 5432,
+    "postgres": 5432,
+    "redshift": 5439,
+    "mysql": 3306,
+    "mariadb": 3306,
+    "mssql": 1433,
+    "sqlserver": 1433,
+    "oracle": 1521,
+}
+
+
+def verify_database_reachable(connection: DataBaseConnection, timeout: float = 3.0) -> None:
+    """Fail fast if the database host:port can't be reached.
+
+    connectorx/r2d2 retries a refused or unreachable connection for ~30s before
+    giving up; a short TCP pre-check surfaces the failure immediately. Best-effort:
+    skips file-based (sqlite) and url-based connections where host/port is unknown.
+    """
+    if connection.url or connection.database_type.lower() == "sqlite":
+        return
+    host = connection.host
+    port = connection.port or _DEFAULT_DB_PORTS.get(connection.database_type.lower())
+    if not host or not port:
+        return
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            pass
+    except OSError as e:
+        raise ConnectionError(f"Cannot connect to database at {host}:{port}: {e}") from e
 
 
 def write_df_to_database(df: pl.DataFrame, database_write_settings: DatabaseWriteSettings):
@@ -54,6 +93,7 @@ def read_sql_source(database_read_settings: DatabaseReadSettings):
     Returns:
         pl.DataFrame: The resulting Polars DataFrame.
     """
+    verify_database_reachable(database_read_settings.connection)
     # Read the query into a DataFrame
     df = read_query_as_pd_df(database_read_settings.query, database_read_settings.connection.create_uri())
     return df

--- a/flowfile_worker/tests/external_sources/test_sql_source.py
+++ b/flowfile_worker/tests/external_sources/test_sql_source.py
@@ -1,8 +1,12 @@
+import socket
+import time
+
 import polars as pl
 import pytest
 
 from flowfile_worker.external_sources.sql_source.main import (
     read_sql_source,
+    verify_database_reachable,
     write_df_to_database,
     write_serialized_df_to_database,
 )
@@ -30,6 +34,42 @@ def test_database_connection_uri_parsing(pw):
     result_uri = database_connection.create_uri()
     expected_uri = 'postgresql://testuser:testpass@localhost:5433'
     assert result_uri == expected_uri, f"Expected URI: {expected_uri}, but got: {result_uri}"
+
+
+def _free_port() -> int:
+    """Return a TCP port that is (almost certainly) not listening."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def test_verify_database_reachable_raises_fast_on_closed_port():
+    connection = DataBaseConnection(host="127.0.0.1", port=_free_port(), database_type="postgresql",
+                                    username="x", database="d")
+    start = time.perf_counter()
+    with pytest.raises(ConnectionError):
+        verify_database_reachable(connection, timeout=3.0)
+    # connectorx would retry for ~30s; the pre-check must surface it immediately.
+    assert time.perf_counter() - start < 5.0
+
+
+def test_verify_database_reachable_skips_sqlite_and_url():
+    # File-based and url-based connections have no usable host/port: must not raise.
+    verify_database_reachable(DataBaseConnection(database_type="sqlite", database="sqlite:///x.db"))
+    verify_database_reachable(DataBaseConnection(database_type="postgresql",
+                                                 url="postgresql://u:p@unreachable-host:5432/d"))
+
+
+def test_read_sql_source_fails_fast_on_unreachable_db():
+    connection = DataBaseConnection(host="127.0.0.1", port=_free_port(), database_type="postgresql",
+                                    username="testuser", database="testdb")
+    settings = DatabaseReadSettings(connection=connection, query="SELECT 1")
+    start = time.perf_counter()
+    with pytest.raises(ConnectionError):
+        read_sql_source(settings)
+    assert time.perf_counter() - start < 5.0
 
 
 @pytest.mark.skipif(not is_docker_available(), reason="Docker is not available or not running so database connection cannot be established")


### PR DESCRIPTION
This pull request introduces comprehensive support for visual "groups" (organizational containers or boxes) in the flow graph system. Groups are purely for UI organization and do not affect execution. The changes add group management APIs, persist group data in snapshots and Vue flow input, and ensure group membership and bounds are updated in response to node or layout changes. Additionally, there are minor improvements to node execution state handling.

**Visual Grouping Support**

* Added a group registry (`self._groups`) and group management methods to `flow_graph.py`, including creation, updating, deletion, membership management, and bounds computation for visual groups. Groups are organizational only and never affect execution. [[1]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R904-R908) [[2]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R1162-R1405)
* Groups and their membership are now persisted in snapshots, `FlowfileData`, and `VueFlowInput`, ensuring that group structure survives save/load and is available to the frontend. Orphaned groups (with no members or sub-groups) are pruned. [[1]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R1078) [[2]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R4776) [[3]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R4796-R4808) [[4]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48L4768-R5041)
* Node group membership is tracked via a `group_id` attribute on each node's `setting_input`, and this is set/restored in all relevant flows (including IO and node info methods). [[1]](diffhunk://#diff-993e18bf8895e3f28e1f3af04ced412bcc607f860061c12acd43dc2d71183106R516) [[2]](diffhunk://#diff-993e18bf8895e3f28e1f3af04ced412bcc607f860061c12acd43dc2d71183106R1680) [[3]](diffhunk://#diff-dbf2223090ac75a1e4904f08ae306ffc7e56b8360d0fa341ea2d082b38774057R175) [[4]](diffhunk://#diff-dbf2223090ac75a1e4904f08ae306ffc7e56b8360d0fa341ea2d082b38774057R217)

**Group Consistency and Layout**

* When node positions are changed (e.g., via layout or drag), group bounds are recomputed to ensure boxes fit their members. Deleting a node will remove its group if the group has no remaining members or sub-groups. [[1]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R1502-R1504) [[2]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R3077) [[3]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R3099-R3106)

**Execution State Improvements**

* Node execution state now properly resets the `is_canceled` flag before each run and after a reset, and raises an exception if execution is attempted while canceled. [[1]](diffhunk://#diff-f9da040453b4c32cacdbca3aef757bfe9d5fb005f7473fac6ae832fb737ce6ceR341) [[2]](diffhunk://#diff-993e18bf8895e3f28e1f3af04ced412bcc607f860061c12acd43dc2d71183106R830-R831) [[3]](diffhunk://#diff-993e18bf8895e3f28e1f3af04ced412bcc607f860061c12acd43dc2d71183106R1362)

**Other Minor Improvements**

* The schema callback is now persisted on the node to survive resets.