### PR TITLE
fix(output node): allow changing file type when filename has an extension

### DIFF
--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/output/Output.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/output/Output.vue
@@ -37,7 +37,6 @@
           class="m-2"
           placeholder="Select"
           size="small"
-          :disabled="hasFileExtension"
           @change="handleFileTypeChange"
         >
           <el-option
@@ -99,7 +98,7 @@
   </div>
 </template>
 <script lang="ts" setup>
-import { ref, computed } from "vue";
+import { ref } from "vue";
 import {
   NodeOutput,
   isOutputCsvTable,
@@ -139,10 +138,6 @@ const { saveSettings, pushNodeData } = useNodeSettings({
 const showFileSelectionModal = ref(false);
 const selectedDirectoryExists = ref<boolean | null>(null);
 const localFileInfos = ref<LocalFileInfo[]>([]);
-
-const hasFileExtension = computed(() => {
-  return nodeOutput.value?.output_settings.name?.includes(".") ?? false;
-});
 
 function getWriteOptions(fileType: string): string[] {
   return fileType === "csv" ? ["overwrite", "new file", "append"] : ["overwrite", "new file"];
@@ -220,7 +215,9 @@ function handleFileTypeChange() {
     parquet: ".parquet",
   };
 
-  const baseName = nodeOutput.value.output_settings.name.split(".")[0];
+  const currentName = nodeOutput.value.output_settings.name;
+  const lastDot = currentName.lastIndexOf(".");
+  const baseName = lastDot > 0 ? currentName.slice(0, lastDot) : currentName;
   nodeOutput.value.output_settings.name =
     baseName + (fileExtMap[nodeOutput.value.output_settings.file_type] || "");
 
@@ -314,9 +311,9 @@ defineExpose({
   background-color: var(--color-button-secondary);
   border: 1px solid transparent;
   border-radius: 4px;
-  padding: 10px 20px;
+  padding: 5px 12px;
   color: var(--color-text-inverse);
-  font-size: 16px;
+  font-size: 13px;
   cursor: pointer;
   transition: all 0.3s ease;
 }


### PR DESCRIPTION
## What
- The **File type** dropdown in the Output node was disabled whenever the filename contained a `.`, locking users to the auto-detected type (e.g. `output.csv` could not be switched to parquet/excel). It's now always selectable — picking a type still rewrites the filename's extension via `handleFileTypeChange`.
- Extension stripping now uses the **last** `.` instead of `split(".")[0]`, so `my.data.csv` → `my.data.parquet` rather than `my.parquet`.
- Shrunk the oversized "Folder" upload button (padding `10px 20px` → `5px 12px`, font `16px` → `13px`) to line up with the adjacent `size="small"` inputs.

## Why
The disable made the type effectively read-only once a filename had an extension, which surprised users. Auto-detection on filename change still works; this just lets the dropdown override it too.

## Notes for reviewer
- Frontend-only, single file: `flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/output/Output.vue`. No backend changes.
- No new reactive loop: `handleFileTypeChange`/`detectFileType` fire on user `@change`/`@select` events, not on programmatic v-model writes.