### PR TITLE
Improve notebook experience

### DIFF
--- a/flowfile_core/flowfile_core/kernel/manager.py
+++ b/flowfile_core/flowfile_core/kernel/manager.py
@@ -1161,7 +1161,10 @@ class KernelManager:
 
     async def start_kernel(self, kernel_id: str) -> KernelInfo:
         kernel = self._get_kernel_or_raise(kernel_id)
-        if kernel.state == KernelState.IDLE:
+        # Treat STARTING as a no-op too: a kernel already mid-start must not be
+        # started again (a concurrent call would create a second container with
+        # the same name and 409). _ensure_running waits on STARTING separately.
+        if kernel.state in (KernelState.IDLE, KernelState.STARTING):
             return kernel
 
         base_image = _resolve_image(kernel.image_flavour, kernel.custom_image, self._docker)
@@ -1221,7 +1224,10 @@ class KernelManager:
     def start_kernel_sync(self, kernel_id: str, flow_logger: FlowLogger | None = None) -> KernelInfo:
         """Synchronous version of start_kernel() for use from non-async code."""
         kernel = self._get_kernel_or_raise(kernel_id)
-        if kernel.state == KernelState.IDLE:
+        # Treat STARTING as a no-op too: a kernel already mid-start must not be
+        # started again (a concurrent call would create a second container with
+        # the same name and 409). _ensure_running waits on STARTING separately.
+        if kernel.state in (KernelState.IDLE, KernelState.STARTING):
             return kernel
 
         base_image = _resolve_image(kernel.image_flavour, kernel.custom_image, self._docker)

--- a/flowfile_core/flowfile_core/kernel/manager.py
+++ b/flowfile_core/flowfile_core/kernel/manager.py
@@ -1203,6 +1203,7 @@ class KernelManager:
         try:
             env = self._build_kernel_env(kernel_id, kernel)
             run_kwargs = self._build_run_kwargs(kernel_id, kernel, env)
+            self._remove_stale_container(kernel_id)
             container = self._docker.containers.run(image, **run_kwargs)
             kernel.container_id = container.id
             await self._wait_for_healthy(kernel_id, timeout=kernel.health_timeout)
@@ -1261,6 +1262,7 @@ class KernelManager:
         try:
             env = self._build_kernel_env(kernel_id, kernel)
             run_kwargs = self._build_run_kwargs(kernel_id, kernel, env)
+            self._remove_stale_container(kernel_id)
             container = self._docker.containers.run(image, **run_kwargs)
             kernel.container_id = container.id
             self._wait_for_healthy_sync(kernel_id, timeout=kernel.health_timeout)
@@ -1821,6 +1823,30 @@ class KernelManager:
             pass
         except (docker.errors.APIError, docker.errors.DockerException) as exc:
             logger.warning("Error cleaning up container for kernel '%s': %s", kernel_id, exc)
+
+    def _remove_stale_container(self, kernel_id: str) -> None:
+        """Remove any pre-existing container occupying this kernel's name.
+
+        Container names (``flowfile-kernel-<id>``) are unique per kernel, so the
+        only container with that name is this kernel's. A stopped one left over
+        from a previous core session keeps its name reserved, which makes
+        ``containers.run`` fail with a 409 ("name already in use"). Running
+        containers are reclaimed elsewhere; by the time we reach the create path
+        the kernel is not idle, so clearing a same-named container is safe.
+        """
+        name = f"flowfile-kernel-{kernel_id}"
+        try:
+            existing = self._docker.containers.get(name)
+        except docker.errors.NotFound:
+            return
+        except (docker.errors.APIError, docker.errors.DockerException) as exc:
+            logger.debug("Could not check for existing container '%s': %s", name, exc)
+            return
+        try:
+            existing.remove(force=True)
+            logger.info("Removed stale container '%s' before starting kernel '%s'", name, kernel_id)
+        except (docker.errors.APIError, docker.errors.DockerException) as exc:
+            logger.warning("Could not remove stale container '%s': %s", name, exc)
 
     async def _wait_for_healthy(self, kernel_id: str, timeout: int = _HEALTH_TIMEOUT) -> None:
         kernel = self._get_kernel_or_raise(kernel_id)

--- a/flowfile_core/flowfile_core/kernel/manager.py
+++ b/flowfile_core/flowfile_core/kernel/manager.py
@@ -1724,6 +1724,25 @@ class KernelManager:
             response.raise_for_status()
             return response.json()
 
+    async def get_api_schema(self, kernel_id: str) -> list:
+        """Return the kernel's introspected API schema for editor type hints.
+
+        Returns an empty list when the kernel isn't running so the editor can
+        fall back to its built-in static completions.
+        """
+        kernel = self._get_kernel_or_raise(kernel_id)
+        if kernel.state not in (KernelState.IDLE, KernelState.EXECUTING):
+            return []
+
+        url = f"{self._kernel_url(kernel)}/api_schema"
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+                return response.json()
+        except (httpx.HTTPError, OSError):
+            return []
+
     # ------------------------------------------------------------------
     # Queries
     # ------------------------------------------------------------------

--- a/flowfile_core/flowfile_core/kernel/routes.py
+++ b/flowfile_core/flowfile_core/kernel/routes.py
@@ -381,6 +381,25 @@ async def get_display_outputs(
         return []
 
 
+@router.get("/{kernel_id}/api_schema")
+async def get_api_schema(kernel_id: str, current_user=Depends(get_current_active_user)):
+    """Introspected API schema (flowfile_ctx + polars) for editor type hints.
+
+    Returns an empty list when the kernel isn't running so the editor falls
+    back to its built-in static completions.
+    """
+    manager = _get_manager()
+    kernel = await manager.get_kernel(kernel_id)
+    if kernel is None:
+        raise HTTPException(status_code=404, detail=f"Kernel '{kernel_id}' not found")
+    if manager.get_kernel_owner(kernel_id) != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to access this kernel")
+    try:
+        return await manager.get_api_schema(kernel_id)
+    except Exception:
+        return []
+
+
 # ---------------------------------------------------------------------------
 # Artifact Persistence & Recovery endpoints
 # ---------------------------------------------------------------------------

--- a/flowfile_core/flowfile_core/main.py
+++ b/flowfile_core/flowfile_core/main.py
@@ -25,6 +25,7 @@ from flowfile_core.configs.settings import (
 )
 from flowfile_core.kernel import router as kernel_router
 from flowfile_core.ml import router as ml_router
+from flowfile_core.notebook import router as notebook_router
 from flowfile_core.routes.auth import router as auth_router
 from flowfile_core.routes.catalog import router as catalog_router
 from flowfile_core.routes.cloud_connections import router as cloud_connections_router
@@ -139,6 +140,7 @@ app.include_router(ga_connections_router, prefix="/ga_connections", tags=["ga_co
 app.include_router(kafka_router)
 app.include_router(user_defined_components_router, prefix="/user_defined_components", tags=["user_defined_components"])
 app.include_router(kernel_router, tags=["kernels"])
+app.include_router(notebook_router, tags=["notebooks"])
 app.include_router(file_manager_router, prefix="/file_manager", tags=["file_manager"])
 app.include_router(ai_router, prefix="/ai", tags=["ai"])
 # AI feature-flag admin endpoint. Mounted on /system (NOT /ai) so admins

--- a/flowfile_core/flowfile_core/notebook/__init__.py
+++ b/flowfile_core/flowfile_core/notebook/__init__.py
@@ -1,0 +1,3 @@
+from flowfile_core.notebook.routes import router
+
+__all__ = ["router"]

--- a/flowfile_core/flowfile_core/notebook/models.py
+++ b/flowfile_core/flowfile_core/notebook/models.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class NotebookCell(BaseModel):
+    """A single code cell in a standalone notebook."""
+
+    id: str
+    source: str = ""
+    cell_type: str = "code"
+
+
+class NotebookSummary(BaseModel):
+    """Lightweight notebook metadata for list views."""
+
+    id: str
+    name: str
+    # Synthetic, notebook-scoped flow id used as the kernel namespace key so
+    # each notebook keeps its own isolated set of variables/imports across
+    # cells (see flowfile_core/notebook/store.py).
+    flow_id: int
+    kernel_id: str | None = None
+    created_at: str
+    modified_at: str
+
+
+class Notebook(NotebookSummary):
+    """A full notebook including its cells."""
+
+    cells: list[NotebookCell] = Field(default_factory=list)
+
+
+class NotebookCreate(BaseModel):
+    name: str = "Untitled notebook"
+    kernel_id: str | None = None
+
+
+class NotebookUpdate(BaseModel):
+    name: str | None = None
+    kernel_id: str | None = None
+    cells: list[NotebookCell] | None = None

--- a/flowfile_core/flowfile_core/notebook/routes.py
+++ b/flowfile_core/flowfile_core/notebook/routes.py
@@ -1,0 +1,68 @@
+"""REST API for standalone (flow-independent) Python notebooks.
+
+Notebooks are persisted as ``.ipynb`` files per user. Cell *execution* is not
+handled here — the frontend runs cells through the existing ``/kernels`` API,
+using each notebook's ``flow_id`` as the kernel namespace key and ``node_id=0``
+(so the kernel skips upstream-path resolution).
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from flowfile_core.auth.jwt import get_current_active_user
+from flowfile_core.notebook import store
+from flowfile_core.notebook.models import Notebook, NotebookCreate, NotebookSummary, NotebookUpdate
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/notebooks", dependencies=[Depends(get_current_active_user)])
+
+
+def _require_notebook(user_id: int, notebook_id: str) -> Notebook:
+    if not store.is_valid_id(notebook_id):
+        raise HTTPException(status_code=400, detail="Invalid notebook id")
+    notebook = store.get_notebook(user_id, notebook_id)
+    if notebook is None:
+        raise HTTPException(status_code=404, detail=f"Notebook '{notebook_id}' not found")
+    return notebook
+
+
+@router.get("/", response_model=list[NotebookSummary])
+async def list_notebooks(current_user=Depends(get_current_active_user)):
+    return store.list_notebooks(current_user.id)
+
+
+@router.post("/", response_model=Notebook)
+async def create_notebook(payload: NotebookCreate, current_user=Depends(get_current_active_user)):
+    return store.create_notebook(current_user.id, payload.name, payload.kernel_id)
+
+
+@router.get("/{notebook_id}", response_model=Notebook)
+async def get_notebook(notebook_id: str, current_user=Depends(get_current_active_user)):
+    return _require_notebook(current_user.id, notebook_id)
+
+
+@router.put("/{notebook_id}", response_model=Notebook)
+async def update_notebook(
+    notebook_id: str,
+    payload: NotebookUpdate,
+    current_user=Depends(get_current_active_user),
+):
+    notebook = _require_notebook(current_user.id, notebook_id)
+    return store.save_notebook(
+        current_user.id,
+        notebook,
+        name=payload.name,
+        kernel_id=payload.kernel_id,
+        cells=payload.cells,
+    )
+
+
+@router.delete("/{notebook_id}")
+async def delete_notebook(notebook_id: str, current_user=Depends(get_current_active_user)):
+    if not store.is_valid_id(notebook_id):
+        raise HTTPException(status_code=400, detail="Invalid notebook id")
+    if not store.delete_notebook(current_user.id, notebook_id):
+        raise HTTPException(status_code=404, detail=f"Notebook '{notebook_id}' not found")
+    return {"status": "deleted", "id": notebook_id}

--- a/flowfile_core/flowfile_core/notebook/store.py
+++ b/flowfile_core/flowfile_core/notebook/store.py
@@ -1,0 +1,168 @@
+"""Disk persistence for standalone notebooks (Jupyter ``.ipynb`` format).
+
+Notebooks are flow-independent and stored per-user under
+``storage.notebooks_directory / <user_id> / <notebook_id>.ipynb``. Using the
+``.ipynb`` schema keeps them interoperable with Jupyter / VS Code while a
+small ``metadata.flowfile`` block carries the Flowfile-specific fields.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from shared.storage_config import storage
+
+from flowfile_core.notebook.models import Notebook, NotebookCell
+
+# Synthetic notebook flow ids live in a high range so they never collide with
+# real (small, autoincrement) FlowRegistration ids or kernel scratch flows.
+_FLOW_ID_BASE = 2_000_000_000
+_FLOW_ID_SPAN = 1_000_000_000
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _new_flow_id() -> int:
+    return _FLOW_ID_BASE + secrets.randbelow(_FLOW_ID_SPAN)
+
+
+def is_valid_id(notebook_id: str) -> bool:
+    """Guard against path traversal — ids are server-generated UUID4 strings."""
+    try:
+        uuid.UUID(notebook_id)
+    except (ValueError, AttributeError, TypeError):
+        return False
+    return True
+
+
+def _user_dir(user_id: int) -> Path:
+    directory = storage.notebooks_directory / str(user_id)
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _path(user_id: int, notebook_id: str) -> Path:
+    return _user_dir(user_id) / f"{notebook_id}.ipynb"
+
+
+def _to_ipynb(nb: Notebook) -> dict:
+    return {
+        "cells": [
+            {
+                "cell_type": cell.cell_type,
+                "metadata": {"id": cell.id},
+                "source": cell.source.splitlines(keepends=True),
+                "outputs": [],
+                "execution_count": None,
+            }
+            for cell in nb.cells
+        ],
+        "metadata": {
+            "flowfile": {
+                "id": nb.id,
+                "name": nb.name,
+                "flow_id": nb.flow_id,
+                "kernel_id": nb.kernel_id,
+                "created_at": nb.created_at,
+                "modified_at": nb.modified_at,
+            },
+            "kernelspec": {"name": "python3", "display_name": "Python 3", "language": "python"},
+            "language_info": {"name": "python"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _from_ipynb(data: dict) -> Notebook:
+    meta = (data.get("metadata") or {}).get("flowfile") or {}
+    cells: list[NotebookCell] = []
+    for raw in data.get("cells") or []:
+        source = raw.get("source", "")
+        if isinstance(source, list):
+            source = "".join(source)
+        cell_id = (raw.get("metadata") or {}).get("id") or str(uuid.uuid4())
+        cells.append(NotebookCell(id=cell_id, source=source, cell_type=raw.get("cell_type", "code")))
+    return Notebook(
+        id=meta["id"],
+        name=meta.get("name", "Untitled notebook"),
+        flow_id=meta.get("flow_id") or _new_flow_id(),
+        kernel_id=meta.get("kernel_id"),
+        created_at=meta.get("created_at") or _now(),
+        modified_at=meta.get("modified_at") or _now(),
+        cells=cells,
+    )
+
+
+def list_notebooks(user_id: int) -> list[Notebook]:
+    directory = _user_dir(user_id)
+    notebooks: list[Notebook] = []
+    for path in directory.glob("*.ipynb"):
+        try:
+            notebooks.append(_from_ipynb(json.loads(path.read_text())))
+        except (OSError, ValueError, KeyError):
+            continue
+    notebooks.sort(key=lambda n: n.modified_at, reverse=True)
+    return notebooks
+
+
+def get_notebook(user_id: int, notebook_id: str) -> Notebook | None:
+    path = _path(user_id, notebook_id)
+    if not path.exists():
+        return None
+    try:
+        return _from_ipynb(json.loads(path.read_text()))
+    except (OSError, ValueError, KeyError):
+        return None
+
+
+def create_notebook(user_id: int, name: str, kernel_id: str | None) -> Notebook:
+    notebook = Notebook(
+        id=str(uuid.uuid4()),
+        name=name or "Untitled notebook",
+        flow_id=_new_flow_id(),
+        kernel_id=kernel_id,
+        created_at=_now(),
+        modified_at=_now(),
+        cells=[NotebookCell(id=str(uuid.uuid4()), source="")],
+    )
+    _write(user_id, notebook)
+    return notebook
+
+
+def save_notebook(
+    user_id: int,
+    notebook: Notebook,
+    *,
+    name: str | None = None,
+    kernel_id: str | None = None,
+    cells: list[NotebookCell] | None = None,
+) -> Notebook:
+    if name is not None:
+        notebook.name = name
+    if kernel_id is not None:
+        notebook.kernel_id = kernel_id
+    if cells is not None:
+        notebook.cells = cells
+    notebook.modified_at = _now()
+    _write(user_id, notebook)
+    return notebook
+
+
+def delete_notebook(user_id: int, notebook_id: str) -> bool:
+    path = _path(user_id, notebook_id)
+    if not path.exists():
+        return False
+    path.unlink()
+    return True
+
+
+def _write(user_id: int, notebook: Notebook) -> None:
+    path = _path(user_id, notebook.id)
+    path.write_text(json.dumps(_to_ipynb(notebook), indent=1))

--- a/flowfile_core/tests/notebook/test_notebook_store.py
+++ b/flowfile_core/tests/notebook/test_notebook_store.py
@@ -1,0 +1,69 @@
+"""Tests for standalone notebook persistence (.ipynb round-trip + CRUD)."""
+
+import pytest
+
+from flowfile_core.notebook import store
+from flowfile_core.notebook.models import NotebookCell
+
+
+@pytest.fixture()
+def user_storage(tmp_path, monkeypatch):
+    """Point notebook storage at a temp dir for the duration of the test."""
+    from shared.storage_config import storage as _storage
+
+    monkeypatch.setattr(_storage, "_base_dir", tmp_path)
+    monkeypatch.setattr(_storage, "_user_data_dir", tmp_path)
+    return 42  # user_id
+
+
+def test_create_assigns_unique_synthetic_flow_id(user_storage):
+    nb1 = store.create_notebook(user_storage, "First", kernel_id=None)
+    nb2 = store.create_notebook(user_storage, "Second", kernel_id="k1")
+    assert nb1.flow_id != nb2.flow_id
+    # Synthetic ids live in the reserved high range (never collide with real flows)
+    assert nb1.flow_id >= store._FLOW_ID_BASE
+    assert nb2.kernel_id == "k1"
+    assert len(nb1.cells) == 1
+
+
+def test_round_trip_persists_cells_and_metadata(user_storage):
+    nb = store.create_notebook(user_storage, "RT", kernel_id=None)
+    cells = [
+        NotebookCell(id="a", source="import polars as pl\n"),
+        NotebookCell(id="b", source="pl.DataFrame({'x': [1, 2]})"),
+    ]
+    store.save_notebook(user_storage, nb, name="Renamed", kernel_id="k9", cells=cells)
+
+    reloaded = store.get_notebook(user_storage, nb.id)
+    assert reloaded is not None
+    assert reloaded.name == "Renamed"
+    assert reloaded.kernel_id == "k9"
+    assert reloaded.flow_id == nb.flow_id  # stable across saves
+    assert [c.source for c in reloaded.cells] == [c.source for c in cells]
+    assert [c.id for c in reloaded.cells] == ["a", "b"]
+
+
+def test_list_and_delete(user_storage):
+    a = store.create_notebook(user_storage, "A", kernel_id=None)
+    b = store.create_notebook(user_storage, "B", kernel_id=None)
+    ids = {n.id for n in store.list_notebooks(user_storage)}
+    assert {a.id, b.id} <= ids
+
+    assert store.delete_notebook(user_storage, a.id) is True
+    assert store.get_notebook(user_storage, a.id) is None
+    assert store.delete_notebook(user_storage, a.id) is False
+
+
+def test_invalid_id_rejected():
+    assert store.is_valid_id("../etc/passwd") is False
+    assert store.is_valid_id("not-a-uuid") is False
+    a = "11111111-1111-1111-1111-111111111111"
+    assert store.is_valid_id(a) is True
+
+
+def test_isolation_between_users(user_storage, tmp_path, monkeypatch):
+    nb = store.create_notebook(user_storage, "owned", kernel_id=None)
+    # A different user must not see or fetch another user's notebook.
+    other_user = 99
+    assert store.get_notebook(other_user, nb.id) is None
+    assert all(n.id != nb.id for n in store.list_notebooks(other_user))

--- a/flowfile_frontend/src/renderer/app/api/kernel.api.ts
+++ b/flowfile_frontend/src/renderer/app/api/kernel.api.ts
@@ -1,5 +1,6 @@
 import axios from "../services/axios.config";
 import type {
+  ApiSymbol,
   DisplayOutput,
   DockerStatus,
   ExecuteCellRequest,
@@ -181,6 +182,18 @@ export class KernelApi {
       );
       return response.data;
     } catch {
+      return [];
+    }
+  }
+
+  static async getApiSchema(kernelId: string): Promise<ApiSymbol[]> {
+    try {
+      const response = await axios.get<ApiSymbol[]>(
+        `${API_BASE_URL}/${encodeURIComponent(kernelId)}/api_schema`,
+      );
+      return response.data;
+    } catch {
+      // Editor falls back to its built-in static completions when unavailable.
       return [];
     }
   }

--- a/flowfile_frontend/src/renderer/app/components/kernel/KernelSelect.vue
+++ b/flowfile_frontend/src/renderer/app/components/kernel/KernelSelect.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="kernel-row">
+    <el-select
+      :model-value="modelValue"
+      placeholder="Select a kernel..."
+      class="kernel-select"
+      :size="size"
+      :loading="loading"
+      @update:model-value="onSelect"
+    >
+      <el-option
+        v-for="kernel in kernels"
+        :key="kernel.id"
+        :value="kernel.id"
+        :label="`${kernel.name} (${kernel.state})`"
+      >
+        <span class="kernel-option">
+          <span class="kernel-state-dot" :class="`kernel-state-dot--${kernel.state}`"></span>
+          <span>{{ kernel.name }}</span>
+          <span class="kernel-state-label">({{ kernel.state }})</span>
+        </span>
+      </el-option>
+    </el-select>
+    <router-link v-if="showManageLink" :to="{ name: 'kernelManager' }" class="manage-kernels-link">
+      Manage Kernels
+    </router-link>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { KernelInfo } from "../../types";
+
+interface Props {
+  modelValue: string | null;
+  kernels: KernelInfo[];
+  loading?: boolean;
+  showManageLink?: boolean;
+  size?: "small" | "default" | "large";
+}
+
+withDefaults(defineProps<Props>(), {
+  loading: false,
+  showManageLink: true,
+  size: "small",
+});
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string | null): void;
+  (e: "change", value: string | null): void;
+}>();
+
+const onSelect = (value: string | null) => {
+  emit("update:modelValue", value);
+  emit("change", value);
+};
+</script>
+
+<style scoped>
+.kernel-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.kernel-select {
+  flex: 1;
+}
+
+.manage-kernels-link {
+  font-size: 0.8rem;
+  color: var(--el-color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.manage-kernels-link:hover {
+  text-decoration: underline;
+}
+
+.kernel-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.kernel-state-label {
+  font-size: 0.8rem;
+  color: var(--el-text-color-secondary);
+}
+</style>
+
+<!-- Global (un-scoped) so the same state-dot styling applies wherever the
+     `.kernel-state-dot` class is used (e.g. the kernel indicator badge in the
+     Python script node's expanded editor), keeping the colors defined once. -->
+<style>
+.kernel-state-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.kernel-state-dot--idle {
+  background-color: #67c23a;
+}
+
+.kernel-state-dot--executing {
+  background-color: #e6a23c;
+}
+
+.kernel-state-dot--starting {
+  background-color: #409eff;
+}
+
+.kernel-state-dot--stopped {
+  background-color: #909399;
+}
+
+.kernel-state-dot--error {
+  background-color: #f56c6c;
+}
+</style>

--- a/flowfile_frontend/src/renderer/app/components/layout/Sidebar/NavigationRoutes.ts
+++ b/flowfile_frontend/src/renderer/app/components/layout/Sidebar/NavigationRoutes.ts
@@ -44,13 +44,6 @@ export default {
       },
     },
     {
-      name: "notebook",
-      displayName: "menu.notebook",
-      meta: {
-        icon: "fa-solid fa-book",
-      },
-    },
-    {
       name: "nodeDesigner",
       displayName: "menu.nodeDesigner",
       meta: {

--- a/flowfile_frontend/src/renderer/app/components/layout/Sidebar/NavigationRoutes.ts
+++ b/flowfile_frontend/src/renderer/app/components/layout/Sidebar/NavigationRoutes.ts
@@ -44,6 +44,13 @@ export default {
       },
     },
     {
+      name: "notebook",
+      displayName: "menu.notebook",
+      meta: {
+        icon: "fa-solid fa-book",
+      },
+    },
+    {
       name: "nodeDesigner",
       displayName: "menu.nodeDesigner",
       meta: {

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/NotebookCell.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/NotebookCell.vue
@@ -57,6 +57,7 @@ import { autocompletion, acceptCompletion } from "@codemirror/autocomplete";
 import { indentMore, indentLess } from "@codemirror/commands";
 
 import type { NotebookCell } from "../../../../../types/node.types";
+import { apiHoverTooltip } from "./apiSchema";
 import CellOutput from "./CellOutput.vue";
 import {
   catalogRefChainCompletions,
@@ -182,6 +183,7 @@ const cellExtensions: Extension[] = [
   pythonLanguage.data.of({ autocomplete: namedInputCompletions }),
   pythonLanguage.data.of({ autocomplete: columnCompletions }),
   pythonLanguage.data.of({ autocomplete: scopeCompletions }),
+  apiHoverTooltip,
   oneDark,
   cellEditorTheme,
   EditorState.tabSize.of(4),
@@ -281,5 +283,28 @@ const cellExtensions: Extension[] = [
   padding: 0.25rem 0.5rem;
   font-size: 0.75rem;
   color: var(--el-color-warning);
+}
+</style>
+
+<!-- Global (un-scoped): the hover tooltip is rendered outside the component tree by CodeMirror. -->
+<style>
+.cm-api-hover {
+  max-width: 480px;
+  padding: 0.4rem 0.55rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.cm-api-hover-sig {
+  font-family: "Fira Code", "Monaco", "Menlo", monospace;
+  font-weight: 600;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.cm-api-hover-doc {
+  margin-top: 0.35rem;
+  white-space: pre-wrap;
+  opacity: 0.85;
 }
 </style>

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/NotebookEditor.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/NotebookEditor.vue
@@ -48,9 +48,10 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import { KernelApi } from "../../../../../api/kernel.api";
 import type { NotebookCell } from "../../../../../types/node.types";
+import { loadApiSchema } from "./apiSchema";
 import NotebookCellComponent from "./NotebookCell.vue";
 import type { UpstreamColumn } from "./useUpstreamColumns";
 
@@ -75,6 +76,16 @@ const emit = defineEmits<{
 const executingCellId = ref<string | null>(null);
 const executionCounter = ref(1);
 const isAnyExecuting = computed(() => executingCellId.value !== null);
+
+// Fetch the kernel's introspected API schema so the editor can show real
+// signatures / docstrings and hover hints (falls back to static completions).
+watch(
+  () => props.kernelId,
+  (kernelId) => {
+    if (kernelId) void loadApiSchema(kernelId);
+  },
+  { immediate: true },
+);
 
 // ─── Cell Operations ──────────────────────────────────────────────────────────
 

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/PythonScript.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/PythonScript.vue
@@ -20,35 +20,12 @@
                 </span>
               </div>
             </template>
-            <div class="kernel-row">
-              <el-select
-                v-model="selectedKernelId"
-                placeholder="Select a kernel..."
-                class="kernel-select"
-                size="small"
-                :loading="kernelsLoading"
-                @change="handleKernelChange"
-              >
-                <el-option
-                  v-for="kernel in kernels"
-                  :key="kernel.id"
-                  :value="kernel.id"
-                  :label="`${kernel.name} (${kernel.state})`"
-                >
-                  <span class="kernel-option">
-                    <span
-                      class="kernel-state-dot"
-                      :class="`kernel-state-dot--${kernel.state}`"
-                    ></span>
-                    <span>{{ kernel.name }}</span>
-                    <span class="kernel-state-label">({{ kernel.state }})</span>
-                  </span>
-                </el-option>
-              </el-select>
-              <router-link :to="{ name: 'kernelManager' }" class="manage-kernels-link">
-                Manage Kernels
-              </router-link>
-            </div>
+            <KernelSelect
+              v-model="selectedKernelId"
+              :kernels="kernels"
+              :loading="kernelsLoading"
+              @change="handleKernelChange"
+            />
 
             <!-- Memory usage -->
             <div
@@ -285,6 +262,7 @@ import { KernelApi } from "../../../../../api/kernel.api";
 import { FlowApi } from "../../../../../api/flow.api";
 import { outputHandle } from "../../../../../utils/outputHandle";
 import GenericNodeSettings from "../../../baseNode/genericNodeSettings.vue";
+import KernelSelect from "../../../../kernel/KernelSelect.vue";
 import FlowfileApiHelp from "./FlowfileApiHelp.vue";
 import NotebookEditor from "./NotebookEditor.vue";
 import { createPythonScriptNode, DEFAULT_PYTHON_SCRIPT_CODE } from "./utils";
@@ -783,67 +761,6 @@ defineExpose({ loadNodeData, pushNodeData, saveSettings });
   font-weight: 500;
   font-size: 0.8rem;
   color: var(--el-text-color-primary);
-}
-
-/* ─── Kernel selection ───────────────────────────────────────────────────── */
-
-.kernel-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.kernel-select {
-  flex: 1;
-}
-
-.manage-kernels-link {
-  font-size: 0.8rem;
-  color: var(--el-color-primary);
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.manage-kernels-link:hover {
-  text-decoration: underline;
-}
-
-.kernel-option {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.kernel-state-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.kernel-state-dot--idle {
-  background-color: #67c23a;
-}
-
-.kernel-state-dot--executing {
-  background-color: #e6a23c;
-}
-
-.kernel-state-dot--starting {
-  background-color: #409eff;
-}
-
-.kernel-state-dot--stopped {
-  background-color: #909399;
-}
-
-.kernel-state-dot--error {
-  background-color: #f56c6c;
-}
-
-.kernel-state-label {
-  font-size: 0.8rem;
-  color: var(--el-text-color-secondary);
 }
 
 /* ─── Memory usage ────────────────────────────────────────────────────── */

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/apiSchema.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/apiSchema.ts
@@ -1,0 +1,156 @@
+/**
+ * Introspected API-schema overlay for the Python cell editor.
+ *
+ * Phase 1 of the "better type hints" work: the kernel exposes a runtime
+ * introspection of `flowfile_ctx` + polars at `/kernels/{id}/api_schema`. We
+ * fetch it once per kernel and use it to (a) enrich the hand-written static
+ * completions with real signatures / docstrings, and (b) power a hover tooltip.
+ *
+ * LSP-READY SEAM
+ * --------------
+ * Everything type-hint-related funnels through this module: the completion
+ * `enrich()` helper and the `apiHoverTooltip` extension. A future Pyright-based
+ * language client (e.g. `codemirror-languageserver` talking to
+ * `pyright-langserver` over a kernel websocket) can replace this module's
+ * provider without touching the cell component or the static completion
+ * sources — keep that boundary intact.
+ */
+import type { Completion } from "@codemirror/autocomplete";
+import { hoverTooltip } from "@codemirror/view";
+
+import { KernelApi } from "../../../../../api/kernel.api";
+import type { ApiSymbol } from "../../../../../types";
+
+const _key = (namespace: string, name: string) => `${namespace}:${name}`;
+
+let _byKey = new Map<string, ApiSymbol>();
+let _byName = new Map<string, ApiSymbol>(); // first symbol seen per bare name (for hover)
+let _loadedKernel: string | null = null;
+let _loading: Promise<void> | null = null;
+
+// Hover lookup prefers the most "interesting" namespace when a name is ambiguous.
+const _NAME_PRIORITY = ["flowfile_ctx", "pl", "LazyFrame", "DataFrame", "Expr"];
+
+export function isSchemaLoaded(): boolean {
+  return _byKey.size > 0;
+}
+
+/** Fetch + cache the API schema for a kernel. No-op if already loaded for it. */
+export async function loadApiSchema(kernelId: string | null | undefined): Promise<void> {
+  if (!kernelId || _loadedKernel === kernelId) return;
+  if (_loading) return _loading;
+  _loading = (async () => {
+    try {
+      const symbols = await KernelApi.getApiSchema(kernelId);
+      if (symbols.length === 0) return; // keep static fallback
+      const byKey = new Map<string, ApiSymbol>();
+      const byName = new Map<string, ApiSymbol>();
+      for (const s of symbols) {
+        byKey.set(_key(s.namespace, s.name), s);
+        const existing = byName.get(s.name);
+        if (!existing || _rank(s.namespace) < _rank(existing.namespace)) {
+          byName.set(s.name, s);
+        }
+      }
+      _byKey = byKey;
+      _byName = byName;
+      _loadedKernel = kernelId;
+    } finally {
+      _loading = null;
+    }
+  })();
+  return _loading;
+}
+
+function _rank(namespace: string): number {
+  const idx = _NAME_PRIORITY.indexOf(namespace);
+  return idx === -1 ? _NAME_PRIORITY.length : idx;
+}
+
+function _getSymbol(namespaces: string[], name: string): ApiSymbol | undefined {
+  for (const ns of namespaces) {
+    const s = _byKey.get(_key(ns, name));
+    if (s) return s;
+  }
+  return undefined;
+}
+
+/** Human-readable signature line, e.g. `read_input(name='main') -> pl.LazyFrame`. */
+function _signatureLine(s: ApiSymbol): string {
+  if (!s.signature) return s.name;
+  return `${s.name}${s.signature.replace(/^\(self,?\s*/, "(")}`;
+}
+
+function _infoText(s: ApiSymbol): string {
+  const sig = _signatureLine(s);
+  return s.doc ? `${sig}\n\n${s.doc}` : sig;
+}
+
+function _toCompletion(s: ApiSymbol): Completion {
+  const apply = s.kind === "function" ? `${s.name}()` : s.name;
+  return {
+    label: s.name,
+    type: s.kind === "function" ? "function" : s.kind === "property" ? "property" : s.kind,
+    detail: s.signature ? _signatureLine(s) : undefined,
+    info: _infoText(s),
+    apply: s.kind === "function" ? apply : undefined,
+  };
+}
+
+/**
+ * Merge introspected signatures/docs into a static completion list and append
+ * any introspected-only symbols for the given namespaces. Returns the input
+ * unchanged when no schema is loaded (offline / kernel not running).
+ */
+export function enrich(options: Completion[], namespaces: string[]): Completion[] {
+  if (_byKey.size === 0) return options;
+  const seen = new Set(options.map((o) => o.label));
+  const merged = options.map((o) => {
+    const s = _getSymbol(namespaces, String(o.label));
+    if (!s) return o;
+    return {
+      ...o,
+      detail: s.signature ? _signatureLine(s) : o.detail,
+      info: _infoText(s) || o.info,
+    };
+  });
+  for (const [, s] of _byKey) {
+    if (!namespaces.includes(s.namespace) || seen.has(s.name)) continue;
+    merged.push(_toCompletion(s));
+    seen.add(s.name);
+  }
+  return merged;
+}
+
+/**
+ * CodeMirror hover tooltip showing the introspected signature + doc for the
+ * identifier under the cursor. Silent when the symbol is unknown.
+ */
+export const apiHoverTooltip = hoverTooltip((view, pos) => {
+  const range = view.state.wordAt(pos);
+  if (!range) return null;
+  const { from, to } = range;
+  const text = view.state.sliceDoc(from, to);
+  const s = text ? _byName.get(text) : undefined;
+  if (!s) return null;
+  return {
+    pos: from,
+    end: to,
+    above: true,
+    create() {
+      const dom = document.createElement("div");
+      dom.className = "cm-api-hover";
+      const sig = document.createElement("div");
+      sig.className = "cm-api-hover-sig";
+      sig.textContent = `${s.namespace === "flowfile_ctx" ? "flowfile_ctx." : ""}${_signatureLine(s)}`;
+      dom.appendChild(sig);
+      if (s.doc) {
+        const doc = document.createElement("div");
+        doc.className = "cm-api-hover-doc";
+        doc.textContent = s.doc;
+        dom.appendChild(doc);
+      }
+      return { dom };
+    },
+  };
+});

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/flowfileCompletions.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/flowfileCompletions.ts
@@ -1,5 +1,6 @@
 import type { Completion, CompletionSource } from "@codemirror/autocomplete";
 
+import { enrich } from "./apiSchema";
 import type { UpstreamColumn } from "./useUpstreamColumns";
 
 // ─── Static entries ──────────────────────────────────────────────────────────
@@ -629,7 +630,7 @@ export const flowfileApiCompletions: CompletionSource = (context) => {
   const dotPos = match.from + match.text.indexOf(".") + 1;
   return {
     from: dotPos,
-    options: FLOWFILE_API_ENTRIES,
+    options: enrich(FLOWFILE_API_ENTRIES, ["flowfile_ctx"]),
     validFor: /^\w*$/,
   };
 };
@@ -644,7 +645,7 @@ export const polarsModuleCompletions: CompletionSource = (context) => {
   const dotPos = match.from + match.text.indexOf(".") + 1;
   return {
     from: dotPos,
-    options: POLARS_MODULE_ENTRIES,
+    options: enrich(POLARS_MODULE_ENTRIES, ["pl"]),
     validFor: /^\w*$/,
   };
 };
@@ -744,7 +745,7 @@ export function createPolarsExprCompletions(getPriorCellCodes: () => string[]): 
 
     return {
       from: match.from + 1,
-      options: POLARS_METHOD_ENTRIES,
+      options: enrich(POLARS_METHOD_ENTRIES, ["LazyFrame", "DataFrame", "Expr"]),
       validFor: /^\w*$/,
     };
   };

--- a/flowfile_frontend/src/renderer/app/i18n/locales/gb.json
+++ b/flowfile_frontend/src/renderer/app/i18n/locales/gb.json
@@ -339,6 +339,7 @@
     "connections": "Connections",
     "nodeDesigner": "Node Designer",
     "kernelManager": "Kernel Manager",
+    "notebook": "Notebook",
     "fileManager": "File Manager",
     "admin": "User Management",
     "popovers": "Popovers",

--- a/flowfile_frontend/src/renderer/app/i18n/locales/gb.json
+++ b/flowfile_frontend/src/renderer/app/i18n/locales/gb.json
@@ -339,7 +339,6 @@
     "connections": "Connections",
     "nodeDesigner": "Node Designer",
     "kernelManager": "Kernel Manager",
-    "notebook": "Notebook",
     "fileManager": "File Manager",
     "admin": "User Management",
     "popovers": "Popovers",

--- a/flowfile_frontend/src/renderer/app/router/index.ts
+++ b/flowfile_frontend/src/renderer/app/router/index.ts
@@ -87,6 +87,11 @@ const routes: Array<RouteRecordRaw> = [
         component: () => import("../views/CatalogView/CatalogView.vue"),
       },
       {
+        name: "notebook",
+        path: "notebook",
+        component: () => import("../views/NotebookView/NotebookView.vue"),
+      },
+      {
         name: "dashboard-new",
         path: "dashboards/new",
         component: () => import("../views/DashboardsView/DashboardEditorView.vue"),

--- a/flowfile_frontend/src/renderer/app/router/index.ts
+++ b/flowfile_frontend/src/renderer/app/router/index.ts
@@ -87,11 +87,6 @@ const routes: Array<RouteRecordRaw> = [
         component: () => import("../views/CatalogView/CatalogView.vue"),
       },
       {
-        name: "notebook",
-        path: "notebook",
-        component: () => import("../views/NotebookView/NotebookView.vue"),
-      },
-      {
         name: "dashboard-new",
         path: "dashboards/new",
         component: () => import("../views/DashboardsView/DashboardEditorView.vue"),

--- a/flowfile_frontend/src/renderer/app/stores/notebook-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/notebook-store.ts
@@ -1,0 +1,143 @@
+import { defineStore } from "pinia";
+
+import { KernelApi } from "../api/kernel.api";
+import type { KernelInfo, Notebook, NotebookCellData, NotebookSummary } from "../types";
+import { NotebookApi } from "../views/NotebookView/api";
+
+interface NotebookState {
+  notebooks: NotebookSummary[];
+  active: Notebook | null;
+  kernels: KernelInfo[];
+  selectedKernelId: string | null;
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+}
+
+// Non-reactive debounce handle for cell persistence.
+let _saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+export const useNotebookStore = defineStore("notebook", {
+  state: (): NotebookState => ({
+    notebooks: [],
+    active: null,
+    kernels: [],
+    selectedKernelId: null,
+    loading: false,
+    saving: false,
+    error: null,
+  }),
+
+  getters: {
+    activeCells: (state): NotebookCellData[] => state.active?.cells ?? [],
+    selectedKernel: (state): KernelInfo | null =>
+      state.kernels.find((k) => k.id === state.selectedKernelId) ?? null,
+    kernelReady(): boolean {
+      const k = this.selectedKernel;
+      return !!k && (k.state === "idle" || k.state === "executing");
+    },
+  },
+
+  actions: {
+    async loadNotebooks(): Promise<void> {
+      this.loading = true;
+      this.error = null;
+      try {
+        this.notebooks = await NotebookApi.list();
+      } catch (e) {
+        this.error = e instanceof Error ? e.message : "Failed to load notebooks";
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async loadKernels(): Promise<void> {
+      try {
+        this.kernels = await KernelApi.getAll();
+      } catch {
+        this.kernels = [];
+      }
+    },
+
+    async openNotebook(id: string): Promise<void> {
+      this.loading = true;
+      this.error = null;
+      try {
+        const notebook = await NotebookApi.get(id);
+        this.active = notebook;
+        this.selectedKernelId =
+          notebook.kernel_id ??
+          this.kernels.find((k) => k.state === "idle")?.id ??
+          this.kernels[0]?.id ??
+          null;
+      } catch (e) {
+        this.error = e instanceof Error ? e.message : "Failed to open notebook";
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async createNotebook(name?: string): Promise<Notebook | null> {
+      try {
+        const notebook = await NotebookApi.create({ name, kernel_id: this.selectedKernelId });
+        await this.loadNotebooks();
+        this.active = notebook;
+        return notebook;
+      } catch (e) {
+        this.error = e instanceof Error ? e.message : "Failed to create notebook";
+        return null;
+      }
+    },
+
+    async deleteNotebook(id: string): Promise<void> {
+      await NotebookApi.remove(id);
+      if (this.active?.id === id) this.active = null;
+      await this.loadNotebooks();
+    },
+
+    /** Update cells locally and persist (debounced) so typing stays snappy. */
+    persistCells(cells: NotebookCellData[]): void {
+      if (!this.active) return;
+      this.active.cells = cells;
+      const id = this.active.id;
+      if (_saveTimer) clearTimeout(_saveTimer);
+      _saveTimer = setTimeout(() => {
+        void this._save(id, { cells });
+      }, 600);
+    },
+
+    async selectKernel(kernelId: string | null): Promise<void> {
+      this.selectedKernelId = kernelId;
+      if (this.active) await this._save(this.active.id, { kernel_id: kernelId });
+    },
+
+    async renameActive(name: string): Promise<void> {
+      if (!this.active) return;
+      this.active.name = name;
+      await this._save(this.active.id, { name });
+    },
+
+    async startSelectedKernel(): Promise<void> {
+      if (!this.selectedKernelId) return;
+      try {
+        await KernelApi.start(this.selectedKernelId);
+      } finally {
+        await this.loadKernels();
+      }
+    },
+
+    async _save(
+      id: string,
+      payload: { cells?: NotebookCellData[]; kernel_id?: string | null; name?: string },
+    ): Promise<void> {
+      this.saving = true;
+      try {
+        await NotebookApi.update(id, payload);
+      } catch (e) {
+        this.error = e instanceof Error ? e.message : "Failed to save notebook";
+      } finally {
+        this.saving = false;
+      }
+    },
+  },
+});

--- a/flowfile_frontend/src/renderer/app/stores/notebook-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/notebook-store.ts
@@ -1,13 +1,13 @@
 import { defineStore } from "pinia";
 
-import { KernelApi } from "../api/kernel.api";
-import type { KernelInfo, Notebook, NotebookCellData, NotebookSummary } from "../types";
+import type { Notebook, NotebookCellData, NotebookSummary } from "../types";
 import { NotebookApi } from "../views/NotebookView/api";
 
 interface NotebookState {
   notebooks: NotebookSummary[];
   active: Notebook | null;
-  kernels: KernelInfo[];
+  // Kernel bound to the active notebook (persisted to its .ipynb metadata).
+  // The kernel *list* lives in the shared useKernelManager composable.
   selectedKernelId: string | null;
   loading: boolean;
   saving: boolean;
@@ -21,7 +21,6 @@ export const useNotebookStore = defineStore("notebook", {
   state: (): NotebookState => ({
     notebooks: [],
     active: null,
-    kernels: [],
     selectedKernelId: null,
     loading: false,
     saving: false,
@@ -30,12 +29,6 @@ export const useNotebookStore = defineStore("notebook", {
 
   getters: {
     activeCells: (state): NotebookCellData[] => state.active?.cells ?? [],
-    selectedKernel: (state): KernelInfo | null =>
-      state.kernels.find((k) => k.id === state.selectedKernelId) ?? null,
-    kernelReady(): boolean {
-      const k = this.selectedKernel;
-      return !!k && (k.state === "idle" || k.state === "executing");
-    },
   },
 
   actions: {
@@ -51,25 +44,13 @@ export const useNotebookStore = defineStore("notebook", {
       }
     },
 
-    async loadKernels(): Promise<void> {
-      try {
-        this.kernels = await KernelApi.getAll();
-      } catch {
-        this.kernels = [];
-      }
-    },
-
     async openNotebook(id: string): Promise<void> {
       this.loading = true;
       this.error = null;
       try {
         const notebook = await NotebookApi.get(id);
         this.active = notebook;
-        this.selectedKernelId =
-          notebook.kernel_id ??
-          this.kernels.find((k) => k.state === "idle")?.id ??
-          this.kernels[0]?.id ??
-          null;
+        this.selectedKernelId = notebook.kernel_id ?? null;
       } catch (e) {
         this.error = e instanceof Error ? e.message : "Failed to open notebook";
       } finally {
@@ -82,6 +63,7 @@ export const useNotebookStore = defineStore("notebook", {
         const notebook = await NotebookApi.create({ name, kernel_id: this.selectedKernelId });
         await this.loadNotebooks();
         this.active = notebook;
+        this.selectedKernelId = notebook.kernel_id ?? this.selectedKernelId;
         return notebook;
       } catch (e) {
         this.error = e instanceof Error ? e.message : "Failed to create notebook";
@@ -115,15 +97,6 @@ export const useNotebookStore = defineStore("notebook", {
       if (!this.active) return;
       this.active.name = name;
       await this._save(this.active.id, { name });
-    },
-
-    async startSelectedKernel(): Promise<void> {
-      if (!this.selectedKernelId) return;
-      try {
-        await KernelApi.start(this.selectedKernelId);
-      } finally {
-        await this.loadKernels();
-      }
     },
 
     async _save(

--- a/flowfile_frontend/src/renderer/app/types/catalog.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/catalog.types.ts
@@ -344,7 +344,8 @@ export type CatalogTab =
   | "runs"
   | "schedules"
   | "sql"
-  | "visuals";
+  | "visuals"
+  | "notebooks";
 
 // ============================================================================
 // SQL Query types

--- a/flowfile_frontend/src/renderer/app/types/index.ts
+++ b/flowfile_frontend/src/renderer/app/types/index.ts
@@ -9,4 +9,5 @@ export * from "./secrets.types";
 export * from "./kernel.types";
 export * from "./catalog.types";
 export * from "./dashboard.types";
+export * from "./notebook.types";
 

--- a/flowfile_frontend/src/renderer/app/types/kernel.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/kernel.types.ts
@@ -132,3 +132,13 @@ export interface KernelMemoryInfo {
   limit_bytes: number;
   usage_percent: number;
 }
+
+/** A single introspected symbol from the kernel API, used for editor type hints. */
+export interface ApiSymbol {
+  name: string;
+  kind: string; // "function" | "class" | "property" | "variable"
+  namespace: string; // "flowfile_ctx" | "pl" | "LazyFrame" | "Expr" | ...
+  signature: string;
+  return_type: string;
+  doc: string;
+}

--- a/flowfile_frontend/src/renderer/app/types/notebook.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/notebook.types.ts
@@ -1,0 +1,32 @@
+// Standalone (flow-independent) notebook types — mirror flowfile_core.notebook.models
+
+export interface NotebookCellData {
+  id: string;
+  source: string;
+  cell_type?: string;
+}
+
+export interface NotebookSummary {
+  id: string;
+  name: string;
+  // Synthetic, notebook-scoped flow id used as the kernel namespace key.
+  flow_id: number;
+  kernel_id: string | null;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface Notebook extends NotebookSummary {
+  cells: NotebookCellData[];
+}
+
+export interface NotebookCreate {
+  name?: string;
+  kernel_id?: string | null;
+}
+
+export interface NotebookUpdate {
+  name?: string;
+  kernel_id?: string | null;
+  cells?: NotebookCellData[];
+}

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -232,6 +232,8 @@
           v-else-if="catalogStore.activeTab === 'visuals'"
           @view-table="selectTable($event)"
         />
+        <!-- Notebooks (standalone, kernel-backed) -->
+        <NotebookView v-else-if="catalogStore.activeTab === 'notebooks'" />
         <!-- Stats overview -->
         <StatsPanel
           v-else
@@ -415,6 +417,7 @@ import CreateSyncModal from "./CreateSyncModal.vue";
 import CreateVirtualTableModal from "./CreateVirtualTableModal.vue";
 import SqlEditorPanel from "./SqlEditorPanel.vue";
 import VisualsPanel from "./VisualsPanel.vue";
+import NotebookView from "../NotebookView/NotebookView.vue";
 import VisualizationViewer from "./VisualizationViewer.vue";
 import { useGraphicWalkerAppearance } from "../../composables/useGraphicWalkerAppearance";
 import type {
@@ -466,6 +469,12 @@ const tabs = computed(() => [
     key: "visuals" as CatalogTab,
     label: "Visuals",
     icon: "fa-solid fa-chart-pie",
+    badge: null,
+  },
+  {
+    key: "notebooks" as CatalogTab,
+    label: "Notebooks",
+    icon: "fa-solid fa-book",
     badge: null,
   },
 ]);

--- a/flowfile_frontend/src/renderer/app/views/NotebookView/NotebookView.vue
+++ b/flowfile_frontend/src/renderer/app/views/NotebookView/NotebookView.vue
@@ -36,41 +36,30 @@
           <input
             v-model="nameDraft"
             class="notebook-title-input"
-            :title="'Rename notebook'"
+            title="Rename notebook"
             @change="onRename"
           />
           <div class="header-spacer"></div>
 
           <label class="kernel-label">Kernel</label>
-          <select
-            class="kernel-select"
-            :value="store.selectedKernelId ?? ''"
+          <KernelSelect
+            class="header-kernel-select"
+            :model-value="store.selectedKernelId"
+            :kernels="kernels"
             @change="onKernelChange"
-          >
-            <option value="" disabled>Select a kernel…</option>
-            <option v-for="k in store.kernels" :key="k.id" :value="k.id">
-              {{ k.name }} ({{ k.state }})
-            </option>
-          </select>
+          />
           <button
-            v-if="store.selectedKernelId && !store.kernelReady"
+            v-if="store.selectedKernelId && !kernelReady"
             class="start-btn"
             title="Start the selected kernel"
-            @click="store.startSelectedKernel()"
+            @click="onStartKernel"
           >
             <i class="fa-solid fa-play"></i> Start
           </button>
-          <router-link
-            v-if="store.kernels.length === 0"
-            :to="{ name: 'kernelManager' }"
-            class="kernel-link"
-          >
-            Create a kernel
-          </router-link>
           <span class="save-state">{{ store.saving ? "Saving…" : "Saved" }}</span>
         </header>
 
-        <div v-if="!store.kernelReady" class="kernel-warning">
+        <div v-if="!kernelReady" class="kernel-warning">
           <i class="fa-solid fa-circle-info"></i>
           Select and start a kernel to run cells. Code uses <code>flowfile_ctx</code> and
           <code>pl</code> (Polars).
@@ -80,7 +69,7 @@
           <NotebookEditor
             :key="store.active.id"
             :cells="editorCells"
-            :kernel-id="store.kernelReady ? store.selectedKernelId : null"
+            :kernel-id="kernelReady ? store.selectedKernelId : null"
             :flow-id="store.active.flow_id"
             :node-id="0"
             :depending-on-ids="[]"
@@ -102,9 +91,14 @@ import { computed, onMounted, ref, watch } from "vue";
 
 import type { NotebookCell as EditorCell } from "../../types/node.types";
 import { useNotebookStore } from "../../stores/notebook-store";
+import { useKernelManager } from "../KernelManagerView/useKernelManager";
+import KernelSelect from "../../components/kernel/KernelSelect.vue";
 import NotebookEditor from "../../components/nodes/node-types/elements/pythonScript/NotebookEditor.vue";
 
 const store = useNotebookStore();
+// Reuse the shared kernel composable (list + polling + start) rather than
+// re-implementing kernel loading in the notebook store.
+const { kernels, startKernel } = useKernelManager();
 const nameDraft = ref("");
 
 // The reused NotebookEditor speaks the in-node cell shape ({ id, code }); the
@@ -112,6 +106,14 @@ const nameDraft = ref("");
 const editorCells = computed<EditorCell[]>(() =>
   store.activeCells.map((c) => ({ id: c.id, code: c.source, output: null })),
 );
+
+const selectedKernel = computed(
+  () => kernels.value.find((k) => k.id === store.selectedKernelId) ?? null,
+);
+const kernelReady = computed(() => {
+  const k = selectedKernel.value;
+  return !!k && (k.state === "idle" || k.state === "executing");
+});
 
 watch(
   () => store.active?.name,
@@ -121,8 +123,17 @@ watch(
   { immediate: true },
 );
 
-onMounted(async () => {
-  await Promise.all([store.loadKernels(), store.loadNotebooks()]);
+// Default the kernel selection (in-memory only) when opening a notebook that
+// hasn't bound one yet — explicit changes are persisted via selectKernel().
+watch([() => store.active?.id, kernels], () => {
+  if (store.active && !store.selectedKernelId && kernels.value.length) {
+    store.selectedKernelId =
+      kernels.value.find((k) => k.state === "idle")?.id ?? kernels.value[0].id;
+  }
+});
+
+onMounted(() => {
+  void store.loadNotebooks();
 });
 
 const onCellsUpdate = (cells: EditorCell[]) => {
@@ -143,9 +154,12 @@ const onRename = () => {
   if (nameDraft.value.trim()) void store.renameActive(nameDraft.value.trim());
 };
 
-const onKernelChange = (event: Event) => {
-  const value = (event.target as HTMLSelectElement).value;
-  void store.selectKernel(value || null);
+const onKernelChange = (id: string | null) => {
+  void store.selectKernel(id);
+};
+
+const onStartKernel = () => {
+  if (store.selectedKernelId) void startKernel(store.selectedKernelId);
 };
 </script>
 
@@ -254,17 +268,11 @@ const onKernelChange = (event: Event) => {
   color: var(--el-text-color-secondary);
 }
 
-.kernel-select {
-  font-size: 0.8rem;
-  padding: 0.2rem 0.4rem;
-  border: 1px solid var(--el-border-color);
-  border-radius: 3px;
-  background: var(--el-bg-color);
-  color: var(--el-text-color-primary);
+.header-kernel-select {
+  min-width: 16rem;
 }
 
-.start-btn,
-.kernel-link {
+.start-btn {
   font-size: 0.75rem;
   padding: 0.2rem 0.5rem;
   border: 1px solid var(--el-border-color);
@@ -272,7 +280,6 @@ const onKernelChange = (event: Event) => {
   background: var(--el-bg-color);
   cursor: pointer;
   color: var(--el-text-color-regular);
-  text-decoration: none;
 }
 
 .save-state {

--- a/flowfile_frontend/src/renderer/app/views/NotebookView/NotebookView.vue
+++ b/flowfile_frontend/src/renderer/app/views/NotebookView/NotebookView.vue
@@ -51,10 +51,12 @@
           <button
             v-if="store.selectedKernelId && !kernelReady"
             class="start-btn"
-            title="Start the selected kernel"
+            :disabled="starting"
+            :title="starting ? 'Kernel is starting…' : 'Start the selected kernel'"
             @click="onStartKernel"
           >
-            <i class="fa-solid fa-play"></i> Start
+            <i :class="starting ? 'fa-solid fa-spinner fa-spin' : 'fa-solid fa-play'"></i>
+            {{ starting ? "Starting…" : "Start" }}
           </button>
           <span class="save-state">{{ store.saving ? "Saving…" : "Saved" }}</span>
         </header>
@@ -98,7 +100,7 @@ import NotebookEditor from "../../components/nodes/node-types/elements/pythonScr
 const store = useNotebookStore();
 // Reuse the shared kernel composable (list + polling + start) rather than
 // re-implementing kernel loading in the notebook store.
-const { kernels, startKernel } = useKernelManager();
+const { kernels, startKernel, isActionInProgress } = useKernelManager();
 const nameDraft = ref("");
 
 // Local source of truth for the editor — like PythonScript.vue, this keeps the
@@ -124,6 +126,13 @@ const selectedKernel = computed(
 const kernelReady = computed(() => {
   const k = selectedKernel.value;
   return !!k && (k.state === "idle" || k.state === "executing");
+});
+// True while a start is in flight (request pending or container booting) so the
+// Start button can be disabled — clicking it again would spawn a duplicate
+// container with the same name and fail.
+const starting = computed(() => {
+  const id = store.selectedKernelId;
+  return (!!id && isActionInProgress(id)) || selectedKernel.value?.state === "starting";
 });
 
 watch(
@@ -172,7 +181,7 @@ const onKernelChange = (id: string | null) => {
 };
 
 const onStartKernel = () => {
-  if (store.selectedKernelId) void startKernel(store.selectedKernelId);
+  if (store.selectedKernelId && !starting.value) void startKernel(store.selectedKernelId);
 };
 </script>
 

--- a/flowfile_frontend/src/renderer/app/views/NotebookView/NotebookView.vue
+++ b/flowfile_frontend/src/renderer/app/views/NotebookView/NotebookView.vue
@@ -1,0 +1,331 @@
+<template>
+  <div class="notebook-view">
+    <!-- Sidebar: saved notebooks -->
+    <aside class="notebook-sidebar">
+      <div class="sidebar-header">
+        <span>Notebooks</span>
+        <button class="icon-btn" title="New notebook" @click="onCreate">
+          <i class="fa-solid fa-plus"></i>
+        </button>
+      </div>
+      <div v-if="store.loading && store.notebooks.length === 0" class="sidebar-hint">Loading…</div>
+      <div v-else-if="store.notebooks.length === 0" class="sidebar-hint">
+        No notebooks yet. Create one to start writing code against
+        <code>flowfile_ctx</code>.
+      </div>
+      <ul v-else class="notebook-list">
+        <li
+          v-for="nb in store.notebooks"
+          :key="nb.id"
+          class="notebook-item"
+          :class="{ active: store.active?.id === nb.id }"
+          @click="onOpen(nb.id)"
+        >
+          <span class="notebook-name">{{ nb.name }}</span>
+          <button class="icon-btn danger" title="Delete" @click.stop="onDelete(nb.id)">
+            <i class="fa-solid fa-trash"></i>
+          </button>
+        </li>
+      </ul>
+    </aside>
+
+    <!-- Main area -->
+    <section class="notebook-main">
+      <template v-if="store.active">
+        <header class="notebook-header">
+          <input
+            v-model="nameDraft"
+            class="notebook-title-input"
+            :title="'Rename notebook'"
+            @change="onRename"
+          />
+          <div class="header-spacer"></div>
+
+          <label class="kernel-label">Kernel</label>
+          <select
+            class="kernel-select"
+            :value="store.selectedKernelId ?? ''"
+            @change="onKernelChange"
+          >
+            <option value="" disabled>Select a kernel…</option>
+            <option v-for="k in store.kernels" :key="k.id" :value="k.id">
+              {{ k.name }} ({{ k.state }})
+            </option>
+          </select>
+          <button
+            v-if="store.selectedKernelId && !store.kernelReady"
+            class="start-btn"
+            title="Start the selected kernel"
+            @click="store.startSelectedKernel()"
+          >
+            <i class="fa-solid fa-play"></i> Start
+          </button>
+          <router-link
+            v-if="store.kernels.length === 0"
+            :to="{ name: 'kernelManager' }"
+            class="kernel-link"
+          >
+            Create a kernel
+          </router-link>
+          <span class="save-state">{{ store.saving ? "Saving…" : "Saved" }}</span>
+        </header>
+
+        <div v-if="!store.kernelReady" class="kernel-warning">
+          <i class="fa-solid fa-circle-info"></i>
+          Select and start a kernel to run cells. Code uses <code>flowfile_ctx</code> and
+          <code>pl</code> (Polars).
+        </div>
+
+        <div class="notebook-editor-host">
+          <NotebookEditor
+            :key="store.active.id"
+            :cells="editorCells"
+            :kernel-id="store.kernelReady ? store.selectedKernelId : null"
+            :flow-id="store.active.flow_id"
+            :node-id="0"
+            :depending-on-ids="[]"
+            @update:cells="onCellsUpdate"
+          />
+        </div>
+      </template>
+
+      <div v-else class="empty-state">
+        <i class="fa-solid fa-book-open empty-icon"></i>
+        <p>Select or create a notebook to begin.</p>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, onMounted, ref, watch } from "vue";
+
+import type { NotebookCell as EditorCell } from "../../types/node.types";
+import { useNotebookStore } from "../../stores/notebook-store";
+import NotebookEditor from "../../components/nodes/node-types/elements/pythonScript/NotebookEditor.vue";
+
+const store = useNotebookStore();
+const nameDraft = ref("");
+
+// The reused NotebookEditor speaks the in-node cell shape ({ id, code }); the
+// stored notebook uses the .ipynb-friendly { id, source }. Map between them.
+const editorCells = computed<EditorCell[]>(() =>
+  store.activeCells.map((c) => ({ id: c.id, code: c.source, output: null })),
+);
+
+watch(
+  () => store.active?.name,
+  (name) => {
+    nameDraft.value = name ?? "";
+  },
+  { immediate: true },
+);
+
+onMounted(async () => {
+  await Promise.all([store.loadKernels(), store.loadNotebooks()]);
+});
+
+const onCellsUpdate = (cells: EditorCell[]) => {
+  store.persistCells(cells.map((c) => ({ id: c.id, source: c.code })));
+};
+
+const onOpen = (id: string) => store.openNotebook(id);
+
+const onCreate = async () => {
+  await store.createNotebook("Untitled notebook");
+};
+
+const onDelete = async (id: string) => {
+  await store.deleteNotebook(id);
+};
+
+const onRename = () => {
+  if (nameDraft.value.trim()) void store.renameActive(nameDraft.value.trim());
+};
+
+const onKernelChange = (event: Event) => {
+  const value = (event.target as HTMLSelectElement).value;
+  void store.selectKernel(value || null);
+};
+</script>
+
+<style scoped>
+.notebook-view {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  background: var(--el-bg-color);
+}
+
+.notebook-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--el-border-color);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.75rem;
+  font-weight: 600;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.sidebar-hint {
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--el-text-color-secondary);
+}
+
+.notebook-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.notebook-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  border-left: 3px solid transparent;
+}
+
+.notebook-item:hover {
+  background: var(--el-fill-color);
+}
+
+.notebook-item.active {
+  background: var(--el-color-primary-light-9);
+  border-left-color: var(--el-color-primary);
+}
+
+.notebook-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notebook-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.notebook-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.notebook-title-input {
+  font-size: 0.95rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: transparent;
+  padding: 0.2rem 0.4rem;
+  border-radius: 3px;
+  color: var(--el-text-color-primary);
+  min-width: 12rem;
+}
+
+.notebook-title-input:hover,
+.notebook-title-input:focus {
+  border-color: var(--el-border-color);
+  outline: none;
+}
+
+.header-spacer {
+  flex: 1;
+}
+
+.kernel-label {
+  font-size: 0.75rem;
+  color: var(--el-text-color-secondary);
+}
+
+.kernel-select {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.4rem;
+  border: 1px solid var(--el-border-color);
+  border-radius: 3px;
+  background: var(--el-bg-color);
+  color: var(--el-text-color-primary);
+}
+
+.start-btn,
+.kernel-link {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--el-border-color);
+  border-radius: 3px;
+  background: var(--el-bg-color);
+  cursor: pointer;
+  color: var(--el-text-color-regular);
+  text-decoration: none;
+}
+
+.save-state {
+  font-size: 0.7rem;
+  color: var(--el-text-color-secondary);
+  min-width: 3.5rem;
+  text-align: right;
+}
+
+.kernel-warning {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.78rem;
+  color: var(--el-text-color-secondary);
+  background: var(--el-fill-color-lighter);
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.notebook-editor-host {
+  flex: 1;
+  min-height: 0;
+  padding: 0.5rem 0.75rem;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--el-text-color-secondary);
+  padding: 0.2rem 0.35rem;
+  border-radius: 3px;
+}
+
+.icon-btn:hover {
+  background: var(--el-fill-color);
+  color: var(--el-text-color-primary);
+}
+
+.icon-btn.danger:hover {
+  color: var(--el-color-danger);
+}
+
+.empty-state {
+  margin: auto;
+  text-align: center;
+  color: var(--el-text-color-secondary);
+}
+
+.empty-icon {
+  font-size: 2.5rem;
+  margin-bottom: 0.75rem;
+  opacity: 0.5;
+}
+</style>

--- a/flowfile_frontend/src/renderer/app/views/NotebookView/NotebookView.vue
+++ b/flowfile_frontend/src/renderer/app/views/NotebookView/NotebookView.vue
@@ -68,7 +68,7 @@
         <div class="notebook-editor-host">
           <NotebookEditor
             :key="store.active.id"
-            :cells="editorCells"
+            :cells="cells"
             :kernel-id="kernelReady ? store.selectedKernelId : null"
             :flow-id="store.active.flow_id"
             :node-id="0"
@@ -101,10 +101,21 @@ const store = useNotebookStore();
 const { kernels, startKernel } = useKernelManager();
 const nameDraft = ref("");
 
-// The reused NotebookEditor speaks the in-node cell shape ({ id, code }); the
-// stored notebook uses the .ipynb-friendly { id, source }. Map between them.
-const editorCells = computed<EditorCell[]>(() =>
-  store.activeCells.map((c) => ({ id: c.id, code: c.source, output: null })),
+// Local source of truth for the editor — like PythonScript.vue, this keeps the
+// runtime `output` on each cell. (The store only persists { id, source }, so
+// deriving the editor cells from it would wipe cell output on every update.)
+// The NotebookEditor speaks the in-node cell shape ({ id, code }); the stored
+// notebook uses the .ipynb-friendly { id, source }.
+const cells = ref<EditorCell[]>([]);
+
+// (Re)load cells from the store only when switching notebooks, not on every
+// keystroke/run — otherwise persisted { id, source } would overwrite output.
+watch(
+  () => store.active?.id,
+  () => {
+    cells.value = store.activeCells.map((c) => ({ id: c.id, code: c.source, output: null }));
+  },
+  { immediate: true },
 );
 
 const selectedKernel = computed(
@@ -136,8 +147,10 @@ onMounted(() => {
   void store.loadNotebooks();
 });
 
-const onCellsUpdate = (cells: EditorCell[]) => {
-  store.persistCells(cells.map((c) => ({ id: c.id, source: c.code })));
+const onCellsUpdate = (updated: EditorCell[]) => {
+  // Keep output locally; persist only id + source (debounced) to the store.
+  cells.value = updated;
+  store.persistCells(updated.map((c) => ({ id: c.id, source: c.code })));
 };
 
 const onOpen = (id: string) => store.openNotebook(id);

--- a/flowfile_frontend/src/renderer/app/views/NotebookView/api.ts
+++ b/flowfile_frontend/src/renderer/app/views/NotebookView/api.ts
@@ -1,0 +1,30 @@
+import axios from "../../services/axios.config";
+import type { Notebook, NotebookCreate, NotebookSummary, NotebookUpdate } from "../../types";
+
+const BASE_URL = "/notebooks";
+
+export class NotebookApi {
+  static async list(): Promise<NotebookSummary[]> {
+    const response = await axios.get<NotebookSummary[]>(`${BASE_URL}/`);
+    return response.data;
+  }
+
+  static async create(payload: NotebookCreate): Promise<Notebook> {
+    const response = await axios.post<Notebook>(`${BASE_URL}/`, payload);
+    return response.data;
+  }
+
+  static async get(id: string): Promise<Notebook> {
+    const response = await axios.get<Notebook>(`${BASE_URL}/${encodeURIComponent(id)}`);
+    return response.data;
+  }
+
+  static async update(id: string, payload: NotebookUpdate): Promise<Notebook> {
+    const response = await axios.put<Notebook>(`${BASE_URL}/${encodeURIComponent(id)}`, payload);
+    return response.data;
+  }
+
+  static async remove(id: string): Promise<void> {
+    await axios.delete(`${BASE_URL}/${encodeURIComponent(id)}`);
+  }
+}

--- a/kernel_runtime/kernel_runtime/api_schema.py
+++ b/kernel_runtime/kernel_runtime/api_schema.py
@@ -1,0 +1,162 @@
+"""Introspection of the kernel's public Python API for editor type hints.
+
+The frontend code editor fetches this schema to provide signature-aware
+completions and hover docs for ``flowfile_ctx`` (the injected context object),
+the catalog reference chain, and the most common ``polars`` symbols.
+
+The schema is derived by runtime introspection (``inspect``) so it stays in
+sync with whatever version of ``flowfile_client`` / ``polars`` is baked into
+the running kernel image, instead of a hand-maintained list.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import polars as pl
+
+from kernel_runtime import flowfile_client
+
+
+def _summarize_doc(obj: Any) -> str:
+    """Return the first paragraph of an object's docstring (trimmed)."""
+    doc = inspect.getdoc(obj)
+    if not doc:
+        return ""
+    paragraph: list[str] = []
+    for line in doc.splitlines():
+        if not line.strip():
+            break
+        paragraph.append(line.strip())
+    return " ".join(paragraph)
+
+
+def _signature_str(obj: Any) -> str:
+    try:
+        return str(inspect.signature(obj))
+    except (TypeError, ValueError):
+        return ""
+
+
+def _return_type(obj: Any) -> str:
+    try:
+        ann = inspect.signature(obj).return_annotation
+    except (TypeError, ValueError):
+        return ""
+    if ann is inspect.Signature.empty:
+        return ""
+    if isinstance(ann, str):
+        return ann
+    return getattr(ann, "__name__", str(ann))
+
+
+def _kind(obj: Any) -> str:
+    if inspect.isclass(obj):
+        return "class"
+    if isinstance(obj, property):
+        return "property"
+    if inspect.isfunction(obj) or inspect.ismethod(obj) or inspect.isbuiltin(obj):
+        return "function"
+    if callable(obj):
+        return "function"
+    return "variable"
+
+
+def _entry(name: str, obj: Any, namespace: str) -> dict[str, str]:
+    return {
+        "name": name,
+        "kind": _kind(obj),
+        "namespace": namespace,
+        "signature": _signature_str(obj) if callable(obj) and not isinstance(obj, property) else "",
+        "return_type": _return_type(obj) if callable(obj) and not isinstance(obj, property) else "",
+        "doc": _summarize_doc(obj),
+    }
+
+
+def _public_members(container: Any, namespace: str, *, only_callables: bool = True) -> list[dict[str, str]]:
+    """Build entries for the public attributes of a module or class."""
+    entries: list[dict[str, str]] = []
+    for name in dir(container):
+        if name.startswith("_"):
+            continue
+        try:
+            obj = inspect.getattr_static(container, name) if inspect.isclass(container) else getattr(container, name)
+        except (AttributeError, Exception):  # noqa: BLE001 - introspection must never crash
+            continue
+        if only_callables and not (callable(obj) or isinstance(obj, property)):
+            continue
+        try:
+            entries.append(_entry(name, obj, namespace))
+        except Exception:  # noqa: BLE001 - skip anything that resists introspection
+            continue
+    return entries
+
+
+# Top-level polars symbols we surface (functions, readers, datatypes). Limiting
+# the polars surface keeps the payload focused on what notebook authors reach
+# for, while LazyFrame/DataFrame/Expr methods are introspected in full below.
+_POLARS_TOPLEVEL = (
+    "col", "lit", "when", "concat", "select", "sql_expr", "struct", "format",
+    "DataFrame", "LazyFrame", "Series", "Expr",
+    "read_csv", "read_parquet", "read_json", "read_ndjson", "read_database",
+    "scan_csv", "scan_parquet", "scan_ndjson", "scan_delta",
+    "from_dict", "from_dicts", "from_records", "from_pandas",
+    "all", "any", "sum", "min", "max", "mean", "median", "count", "first", "last",
+    "int_range", "date_range", "datetime_range",
+)
+
+
+def _polars_toplevel_entries() -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for name in _POLARS_TOPLEVEL:
+        obj = getattr(pl, name, None)
+        if obj is None:
+            continue
+        try:
+            entries.append(_entry(name, obj, "pl"))
+        except Exception:  # noqa: BLE001
+            continue
+    return entries
+
+
+def build_api_schema() -> list[dict[str, str]]:
+    """Introspect the kernel's public API into a flat list of symbol entries."""
+    entries: list[dict[str, str]] = []
+
+    # flowfile_ctx — the injected context module
+    entries.extend(_public_members(flowfile_client, "flowfile_ctx"))
+
+    # Catalog reference chain returned by flowfile_ctx helpers
+    for cls_name in ("CatalogRef", "SchemaRef", "TableRef"):
+        cls = getattr(flowfile_client, cls_name, None)
+        if cls is not None:
+            entries.extend(_public_members(cls, cls_name))
+
+    # polars surface
+    entries.extend(_polars_toplevel_entries())
+    entries.extend(_public_members(pl.LazyFrame, "LazyFrame"))
+    entries.extend(_public_members(pl.DataFrame, "DataFrame"))
+    entries.extend(_public_members(pl.Expr, "Expr"))
+
+    # De-duplicate on (namespace, name) while preserving first occurrence.
+    seen: set[tuple[str, str]] = set()
+    unique: list[dict[str, str]] = []
+    for entry in entries:
+        key = (entry["namespace"], entry["name"])
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(entry)
+    return unique
+
+
+_CACHED_SCHEMA: list[dict[str, str]] | None = None
+
+
+def get_api_schema() -> list[dict[str, str]]:
+    """Return the cached API schema, building it on first access."""
+    global _CACHED_SCHEMA
+    if _CACHED_SCHEMA is None:
+        _CACHED_SCHEMA = build_api_schema()
+    return _CACHED_SCHEMA

--- a/kernel_runtime/kernel_runtime/main.py
+++ b/kernel_runtime/kernel_runtime/main.py
@@ -742,3 +742,27 @@ async def health():
         "persistence": persistence_status,
         "recovery_mode": _recovery_mode.value,
     }
+
+
+class ApiSymbol(BaseModel):
+    """A single introspected symbol exposed to the editor for type hints."""
+
+    name: str
+    kind: str  # "function" | "class" | "property" | "variable"
+    namespace: str  # "flowfile_ctx" | "pl" | "LazyFrame" | "Expr" | ...
+    signature: str = ""
+    return_type: str = ""
+    doc: str = ""
+
+
+@app.get("/api_schema", response_model=list[ApiSymbol])
+async def api_schema():
+    """Introspected schema of the kernel's public API (flowfile_ctx + polars).
+
+    Powers signature-aware completions and hover docs in the code editor. The
+    schema reflects the libraries actually baked into this kernel image, so it
+    stays accurate across image flavours.
+    """
+    from kernel_runtime.api_schema import get_api_schema
+
+    return get_api_schema()

--- a/kernel_runtime/tests/test_api_schema.py
+++ b/kernel_runtime/tests/test_api_schema.py
@@ -1,0 +1,44 @@
+"""Tests for the editor API-schema introspection endpoint."""
+
+from fastapi.testclient import TestClient
+
+from kernel_runtime.api_schema import build_api_schema
+
+
+def _find(schema, namespace, name):
+    return next((e for e in schema if e["namespace"] == namespace and e["name"] == name), None)
+
+
+class TestBuildApiSchema:
+    def test_includes_flowfile_ctx_functions(self):
+        schema = build_api_schema()
+        read_input = _find(schema, "flowfile_ctx", "read_input")
+        assert read_input is not None
+        assert read_input["kind"] == "function"
+        assert "name" in read_input["signature"]
+        assert read_input["doc"]  # has a doc summary
+
+    def test_includes_polars_frame_and_expr_methods(self):
+        schema = build_api_schema()
+        assert _find(schema, "LazyFrame", "filter") is not None
+        assert _find(schema, "Expr", "alias") is not None
+        col = _find(schema, "pl", "col")
+        assert col is not None
+
+    def test_no_private_symbols_and_unique_keys(self):
+        schema = build_api_schema()
+        keys = [(e["namespace"], e["name"]) for e in schema]
+        assert all(not name.startswith("_") for _, name in keys)
+        assert len(keys) == len(set(keys))  # de-duplicated
+
+
+class TestApiSchemaEndpoint:
+    def test_endpoint_returns_symbols(self, client: TestClient):
+        resp = client.get("/api_schema")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+        sample = data[0]
+        assert {"name", "kind", "namespace", "signature", "return_type", "doc"} <= set(sample)
+        assert any(e["namespace"] == "flowfile_ctx" for e in data)

--- a/shared/storage_config.py
+++ b/shared/storage_config.py
@@ -16,6 +16,7 @@ DirectoryOptions = Literal[
     "cache_directory",
     "flows_directory",
     "user_defined_nodes_directory",
+    "notebooks_directory",
     "global_artifacts_directory",
     "artifact_staging_directory",
     "catalog_tables_directory",
@@ -102,6 +103,17 @@ class FlowfileStorage:
     def python_editor_flows_directory(self) -> Path:
         """Directory for Python-built flows registered via the FlowFrame API."""
         return self.flows_directory / "python_editor_flows"
+
+    @property
+    def notebooks_directory(self) -> Path:
+        """Directory for standalone Python notebooks (user-accessible).
+
+        Standalone notebooks are flow-independent ``.ipynb`` files authored in
+        the dedicated Notebook view and executed against a kernel.
+        """
+        if _is_docker_mode():
+            return self.user_data_directory / "notebooks"
+        return self.base_directory / "notebooks"
 
     @property
     def uploads_directory(self) -> Path:
@@ -251,6 +263,7 @@ class FlowfileStorage:
             self.flows_directory,
             self.unnamed_flows_directory,
             self.python_editor_flows_directory,
+            self.notebooks_directory,
             self.uploads_directory,
             self.outputs_directory,
             self.user_defined_nodes_directory,


### PR DESCRIPTION
This pull request introduces a new standalone notebook feature to the backend, enabling users to create, persist, and manage Jupyter-compatible notebooks independently of flows. It also adds a new `/api_schema` endpoint to the kernel API for improved editor type hints, and includes several robustness improvements to kernel container management. Key changes are grouped below.

**Standalone Notebook Support:**

* Added a new `notebook` module with REST API endpoints (`/notebooks`) for CRUD operations on standalone notebooks, persisted as `.ipynb` files per user. This includes models, storage logic, and route registration. [[1]](diffhunk://#diff-33857a5994bb91e20e9d4f208963d91d4b801f84f118252f226abed93f57264dR1-R68) [[2]](diffhunk://#diff-d06a4c4ecd6a160030817bc7856503ed00af4fd1aa61573ea77544ecf5585ca3R1-R42) [[3]](diffhunk://#diff-4e01acf4a641391161eb8bfc9c284d60eb79d4872e2bb6b2019f249b060a7e66R1-R168) [[4]](diffhunk://#diff-14bbfadfb7c1bf9c25265611aee5c1e5f1b987e64af4e4dfe44b25fcea10b376R1-R3) [[5]](diffhunk://#diff-309affc0fd27159e801a224ccd970b6ada99aba85443d8067f22e21c14846a1bR28) [[6]](diffhunk://#diff-309affc0fd27159e801a224ccd970b6ada99aba85443d8067f22e21c14846a1bR143)
* Added comprehensive tests for notebook storage, covering creation, updates, deletion, isolation, and id validation.

**Kernel API Improvements:**

* Introduced a new `/kernels/{kernel_id}/api_schema` endpoint to serve introspected API schemas for editor type hints, with backend support and frontend API method. [[1]](diffhunk://#diff-939fb76c76ac28ede0dd722f5c0c84b7d59ef86bd6480b61fa842b01286cef01R384-R402) [[2]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdR1735-R1753) [[3]](diffhunk://#diff-81858013ea09f68e96e58db958e70a472eb880bb38c6cc93cd20678cde77a184R3) [[4]](diffhunk://#diff-81858013ea09f68e96e58db958e70a472eb880bb38c6cc93cd20678cde77a184R189-R200)

**Kernel Container Robustness:**

* Improved kernel start logic to treat both `IDLE` and `STARTING` states as no-ops, preventing duplicate container creation. [[1]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdL1164-R1167) [[2]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdL1223-R1230)
* Added logic to remove stale containers before starting a new kernel, preventing name conflicts and 409 errors. [[1]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdR1209) [[2]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdR1271) [[3]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdR1833-R1856)

These changes collectively enhance user experience by supporting standalone notebooks, improving editor integration, and making kernel management more robust.