### PR TITLE
fix(groups): show proxy edges for nested group members when an ancestor collapses

### DIFF
--- a/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useNodeGroups.ts
@@ -126,7 +126,7 @@ export function useNodeGroups() {
   /** Reroute the collapsed group's boundary edges to the pill as UI-only proxy edges. */
   const addGroupProxyEdges = (groupVueId: string): void => {
     const groupId = groupBackendId(groupVueId);
-    const memberIds = new Set(childNodesOf(groupVueId).map((node) => node.id));
+    const memberIds = new Set(descendantsOf(groupVueId).map((node) => node.id));
     if (memberIds.size === 0) return;
     const prefix = `${GROUP_PROXY_EDGE_PREFIX}${groupId}-`;
     const proxies: Edge[] = [];


### PR DESCRIPTION
## What

When a group node is collapsed into a pill, every edge crossing the group boundary should be rerouted to the pill as a dotted **proxy edge**. This one-line fix makes that work when the boundary edge's inside endpoint lives in a **nested** group, not just a direct child.

## Why

`addGroupProxyEdges` built its member set from `childNodesOf` (direct children only):

```ts
const memberIds = new Set(childNodesOf(groupVueId).map((node) => node.id));
```

Collapse a parent group whose children are *nested groups* (e.g. `Raw data` → `Combine` → a join that connects out to an external node) and the join node is a child of `group-Combine`, not of `group-Raw data`. Neither endpoint landed in `memberIds`, the loop skipped the edge via `if (sourceIn === targetIn) continue;`, and no dotted line was drawn — the connection looked severed.

The fix swaps in the existing cycle-guarded `descendantsOf` helper (defined just above, already used elsewhere in the file), which walks the full subtree:

```ts
const memberIds = new Set(descendantsOf(groupVueId).map((node) => node.id));
```

## Scope & safety

- **Single function, both paths.** `addGroupProxyEdges` is the only proxy-edge builder; the change fixes both interactive collapse (`setGroupCollapsed`) and saved-flow load (`importFlow`).
- **No flat-group regression.** With no nesting, `descendantsOf` returns the same set as `childNodesOf`.
- **Internal edges still skipped**, and nested-collapsed-inside-collapsed stays consistent (duplicate proxy ids dedupe via the existing `seen` set; the inner proxy's endpoint is hidden so nothing renders twice).

## Testing

Verified by inspection (types line up — both helpers return `GraphNode[]`; `childNodesOf` is still used in 8 other spots so no unused-symbol issue). The frontend linter couldn't run in this worktree (no `node_modules`; global ESLint v10 rejects the pinned v8 `.eslintrc.js`).

Manual repro for a reviewer:
1. Nest a child group inside a parent group, with a node in the child connected to an external node.
2. Collapse the **parent** only → a dotted proxy edge should run from the pill to the external node (before this change: no line).
3. Expand → dotted edge clears, real edge returns.
4. Reload the saved collapsed flow → proxy edge present on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)