### PR TITLE
Bump version to 0.11.0 and fix desktop documentation link

### DIFF
--- a/flowfile/flowfile/__init__.py
+++ b/flowfile/flowfile/__init__.py
@@ -12,7 +12,7 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("Flowfile")
 except PackageNotFoundError:
-    __version__ = "0.5.0"
+    __version__ = "0.11.0"
 
 import logging
 import os

--- a/flowfile_core/flowfile_core/__init__.py
+++ b/flowfile_core/flowfile_core/__init__.py
@@ -22,6 +22,6 @@ class ServerRun:
 try:
     __version__ = version("Flowfile")
 except PackageNotFoundError:
-    __version__ = "0.5.0"
+    __version__ = "0.11.0"
 
 flow_file_handler = FlowfileHandler()

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -139,7 +139,7 @@ from shared.storage_config import storage
 try:
     __version__ = version("Flowfile")
 except PackageNotFoundError:
-    __version__ = "0.5.0"
+    __version__ = "0.11.0"
 
 
 def represent_list_json(dumper, data):

--- a/flowfile_frame/flowfile_frame/__init__.py
+++ b/flowfile_frame/flowfile_frame/__init__.py
@@ -155,4 +155,4 @@ DataFrame = FlowFrame  # Alias for compatibility with generated code
 try:
     __version__ = version("Flowfile")
 except PackageNotFoundError:
-    __version__ = "0.5.0"
+    __version__ = "0.11.0"

--- a/flowfile_frontend/package-lock.json
+++ b/flowfile_frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Flowfile",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Flowfile",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^31.1.1",
         "@ag-grid-community/core": "^31.1.1",

--- a/flowfile_frontend/package.json
+++ b/flowfile_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Flowfile",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "A tool for designing and executing data flows",
   "scripts": {
     "dev": "tauri dev",

--- a/flowfile_frontend/src-tauri/Cargo.lock
+++ b/flowfile_frontend/src-tauri/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "flowfile"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/flowfile_frontend/src-tauri/Cargo.toml
+++ b/flowfile_frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowfile"
-version = "0.10.1"
+version = "0.11.0"
 description = "Flowfile — visual ETL platform"
 authors = ["Edwardvaneechoud"]
 license = "MIT"

--- a/flowfile_frontend/src-tauri/src/menu.rs
+++ b/flowfile_frontend/src-tauri/src/menu.rs
@@ -4,7 +4,7 @@ use tauri::menu::AboutMetadata;
 use tauri::{AppHandle, Manager, Runtime};
 use tauri_plugin_opener::OpenerExt;
 
-const DOCS_URL: &str = "https://github.com/Edwardvaneechoud/Flowfile#readme";
+const DOCS_URL: &str = "https://edwardvaneechoud.github.io/Flowfile/";
 const ISSUES_URL: &str = "https://github.com/Edwardvaneechoud/Flowfile/issues";
 const REPO_URL: &str = "https://github.com/Edwardvaneechoud/Flowfile";
 

--- a/flowfile_frontend/src-tauri/tauri.conf.json
+++ b/flowfile_frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Flowfile",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "identifier": "com.flowfile.app",
   "build": {
     "frontendDist": "../build/renderer",

--- a/flowfile_worker/flowfile_worker/__init__.py
+++ b/flowfile_worker/flowfile_worker/__init__.py
@@ -9,7 +9,7 @@ from shared.storage_config import storage
 try:
     __version__ = version("Flowfile")
 except PackageNotFoundError:
-    __version__ = "0.5.0"
+    __version__ = "0.11.0"
 multiprocessing.set_start_method("spawn", force=True)
 
 from multiprocessing import get_context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Flowfile"
-version = "0.10.1"
+version = "0.11.0"
 description = "Project combining flowfile core (backend) and flowfile_worker (compute offloader) and flowfile_frame (api)"
 readme = "readme-pypi.md"
 authors = ["Edward van Eechoud <evaneechoud@gmail.com>"]


### PR DESCRIPTION
## Summary

Two small release-prep changes:

1. **Fix the desktop Documentation link.** The Tauri **Help → Documentation** menu item opened the GitHub repo README (`…/Flowfile#readme`) instead of the documentation site. It now points to `https://edwardvaneechoud.github.io/Flowfile/`, matching the in-app `DocumentationView` (production mode) and the `site_url` in `mkdocs.yml`.
2. **Bump the project version `0.10.1` → `0.11.0`.**

## Version bump details

**Canonical declarations (`0.10.1` → `0.11.0`):**
- `pyproject.toml` — root Poetry project (single project covering the whole Python backend)
- `flowfile_frontend/package.json` + `package-lock.json`
- `flowfile_frontend/src-tauri/tauri.conf.json`
- `flowfile_frontend/src-tauri/Cargo.toml` + `Cargo.lock` (the `flowfile` package entry)

**Stale Python `__version__` fallbacks (`0.5.0` → `0.11.0`)** — used only when package metadata isn't installed:
- `flowfile_core` (`__init__.py` + `flowfile/flow_graph.py`), `flowfile_worker`, `flowfile_frame`, `flowfile`

## Left unchanged (intentional)

- Independently-versioned packages: `kernel_runtime` (0.3.0 / 0.2.2), `flowfile_wasm` (0.1.0), `test_utils` (0.1.0), `tools/migrate` (1.0.0)
- The third-party `core-foundation` crate in `Cargo.lock` (coincidentally also `0.10.1`)
- `CLAUDE.md`'s header still reads `Version: 0.9.1` — pre-existing doc drift, left as-is

## Notes for reviewers

- The lockfiles (`package-lock.json`, `Cargo.lock`) were hand-edited only at the project's own version entry; `npm install` / `cargo build` would produce the identical one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)