### PR TITLE
fix(kernel): deserialize json-format global artifacts

### DIFF
--- a/kernel_runtime/kernel_runtime/serialization.py
+++ b/kernel_runtime/kernel_runtime/serialization.py
@@ -7,6 +7,7 @@ object type.
 Supported formats:
 - parquet: For Polars and Pandas DataFrames
 - joblib: For scikit-learn models and numpy arrays
+- json: For JSON-serializable objects (e.g. ML model envelopes)
 - pickle: For general Python objects
 """
 
@@ -163,6 +164,8 @@ def serialize_to_file(obj: Any, path: str, format: str | None = None) -> str:
         _serialize_parquet(obj, path)
     elif format == "joblib":
         _serialize_joblib(obj, path)
+    elif format == "json":
+        _serialize_json(obj, path)
     else:
         _serialize_pickle(obj, path)
 
@@ -188,6 +191,10 @@ def serialize_to_bytes(obj: Any, format: str | None = None) -> tuple[bytes, str]
         import joblib
 
         joblib.dump(obj, buf)
+    elif format == "json":
+        import json
+
+        buf.write(json.dumps(obj).encode("utf-8"))
     else:
         cloudpickle.dump(obj, buf)
 
@@ -222,6 +229,11 @@ def deserialize_from_file(path: str, format: str) -> Any:
         import joblib
 
         return joblib.load(path)
+    elif format == "json":
+        import json
+
+        with open(path, "rb") as f:
+            return json.load(f)
     else:
         import pickle  # cloudpickle files are compatible with standard pickle.load
 
@@ -249,6 +261,10 @@ def deserialize_from_bytes(blob: bytes, format: str) -> Any:
         import joblib
 
         return joblib.load(buf)
+    elif format == "json":
+        import json
+
+        return json.loads(blob)
     else:
         import pickle  # cloudpickle files are compatible with standard pickle.load
 
@@ -343,6 +359,14 @@ def _serialize_joblib(obj: Any, path: Path) -> None:
     import joblib
 
     joblib.dump(obj, path)
+
+
+def _serialize_json(obj: Any, path: Path) -> None:
+    """Serialize a JSON-serializable object to a UTF-8 JSON file."""
+    import json
+
+    with open(path, "wb") as f:
+        f.write(json.dumps(obj).encode("utf-8"))
 
 
 def _serialize_pickle(obj: Any, path: Path) -> None:


### PR DESCRIPTION
## What

Adds a `json` branch to the kernel artifact (de)serializer so JSON-format global artifacts round-trip correctly.

## Why

ML model artifacts (e.g. `knn_classifier`) are stored with `serialization_format="json"` — the trainers in `shared/ml/trainers.py` declare `serialization_format = "json"` and `train()` returns `json.dumps(model).encode("utf-8")`. But `kernel_runtime/serialization.py` only handled `parquet` and `joblib`, falling through to `pickle.load()` for every other format.

So retrieving a model with `flowfile_ctx.get_global("<name>")` raised:

```
UnpicklingError: invalid load key, '{'
```

— pickle choking on the `{` that opens the JSON payload. (Not a missing-package issue; that would be `ModuleNotFoundError`.)

## Change

Symmetric `json` handling added to all four functions, plus a `_serialize_json` helper:

| Function | `format == "json"` before | after |
|---|---|---|
| `deserialize_from_file` | `pickle.load` 💥 | `json.load` |
| `deserialize_from_bytes` | `pickle.load` 💥 | `json.loads` |
| `serialize_to_file` | cloudpickle (mislabeled) | `_serialize_json` |
| `serialize_to_bytes` | cloudpickle (mislabeled) | `json.dumps(...).encode()` |

## Notes for reviewers

- **`detect_format()` is intentionally unchanged.** Generic objects still default to `pickle` (JSON is lossy for sets/datetimes/etc.). Only callers that opt into `serialization_format="json"` — currently the ML trainers — use this path.
- **No data migration / retrain needed.** Artifacts already on disk are valid JSON; only the *reader* was broken. Once the patched `kernel_runtime` is live (rebuild the Docker kernel image, or restart a local kernel — `get_global` runs inside the kernel sandbox), existing models load as-is.
- Verified: JSON round-trips through both the bytes and file paths, and the original `invalid load key, '{'` is reproduced by the old pickle path on the same bytes. `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)