### PR TITLE
Fix mismatch in trailing slashes in endpoints

### DIFF
--- a/flowfile_frontend/src/renderer/app/api/flow.api.ts
+++ b/flowfile_frontend/src/renderer/app/api/flow.api.ts
@@ -69,7 +69,7 @@ export class FlowApi {
    * Update flow settings
    */
   static async updateFlowSettings(flowSettings: FlowSettings): Promise<null> {
-    const response = await axios.post("/flow_settings/", flowSettings, {
+    const response = await axios.post("/flow_settings", flowSettings, {
       headers: { accept: "application/json" },
     });
     if (response.status === 200) {
@@ -86,7 +86,7 @@ export class FlowApi {
     name: string | null = null,
   ): Promise<number> {
     const response = await axios.post(
-      "/editor/create_flow",
+      "/editor/create_flow/",
       {},
       {
         headers: { accept: "application/json" },
@@ -228,7 +228,7 @@ export class FlowApi {
     flowIdToCopyFrom: number,
     nodePromise: NodePromise,
   ): Promise<OperationResponse> {
-    const response = await axios.post<OperationResponse>("editor/copy_node/", nodePromise, {
+    const response = await axios.post<OperationResponse>("editor/copy_node", nodePromise, {
       params: {
         node_id_to_copy_from: nodeIdToCopyFrom,
         flow_id_to_copy_from: flowIdToCopyFrom,

--- a/flowfile_frontend/src/renderer/app/api/node.api.ts
+++ b/flowfile_frontend/src/renderer/app/api/node.api.ts
@@ -127,7 +127,7 @@ export class NodeApi {
    */
   static async updateUserDefinedSettings(nodeType: string, inputData: any): Promise<any> {
     const response = await axios.post(
-      "/user_defined_components/update_user_defined_node/",
+      "/user_defined_components/update_user_defined_node",
       inputData,
       {
         params: { node_type: nodeType },

--- a/flowfile_frontend/src/renderer/app/components/nodes/nodeLogic.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/nodeLogic.ts
@@ -88,7 +88,7 @@ export const getNodeData = async (flow_id: number, node_id: number): Promise<Ref
 };
 
 export const addNodeSettings = async (node_type: string, nodeSettings: any) => {
-  const response = await axios.post("update_settings", nodeSettings, {
+  const response = await axios.post("update_settings/", nodeSettings, {
     params: { node_type: node_type },
   });
   console.log(response);

--- a/flowfile_frontend/src/renderer/app/stores/ai-ghost-node-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/ai-ghost-node-store.ts
@@ -156,7 +156,7 @@ export const useAiGhostNodeStore = defineStore("aiGhostNode", () => {
         flow_id: flowId,
         node_id: newNodeId,
       };
-      await axios.post("update_settings", settingsBody, {
+      await axios.post("update_settings/", settingsBody, {
         params: { node_type: suggestion.nodeType },
         headers: { "Content-Type": "application/json", accept: "application/json" },
       });


### PR DESCRIPTION
This pull request standardizes the usage of trailing slashes in API endpoint URLs throughout the frontend codebase. The changes ensure consistency in how endpoints are called, which can help prevent routing issues and improve maintainability.

**API Endpoint URL Standardization:**

* Removed trailing slash from the `"/flow_settings/"` endpoint in `updateFlowSettings` to make it `"/flow_settings"` (`flowfile_frontend/src/renderer/app/api/flow.api.ts`)
* Added trailing slash to the `"/editor/create_flow"` endpoint in `createFlow` to make it `"/editor/create_flow/"` (`flowfile_frontend/src/renderer/app/api/flow.api.ts`)
* Removed trailing slash from the `"editor/copy_node/"` endpoint in `copyNodeFromOtherFlow` to make it `"editor/copy_node"` (`flowfile_frontend/src/renderer/app/api/flow.api.ts`)
* Removed trailing slash from the `"/user_defined_components/update_user_defined_node/"` endpoint in `updateUserDefinedSettings` to make it `"/user_defined_components/update_user_defined_node"` (`flowfile_frontend/src/renderer/app/api/node.api.ts`)

**Consistency in Node Settings Endpoints:**

* Added trailing slash to the `"update_settings"` endpoint in both `addNodeSettings` and the AI ghost node store to make it `"update_settings/"` (`flowfile_frontend/src/renderer/app/components/nodes/nodeLogic.ts`, `flowfile_frontend/src/renderer/app/stores/ai-ghost-node-store.ts`) [[1]](diffhunk://#diff-61575043214e7140bf0606d27461bf7fa4adec550fb7acc9e393b353aabae275L91-R91) [[2]](diffhunk://#diff-a7eb4469acd23ee49fd678a446619c53d4af6c159acc3f4e08725a5a954a77d8L159-R159)