### PR TITLE
Fix styling dark mode in SettingsSection.vue

### DIFF
--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/graphSolver/SettingsSection.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/graphSolver/SettingsSection.vue
@@ -40,7 +40,8 @@ const emitRemove = (item: string) => {
   display: flex;
   align-items: center;
   padding: 5px 10px;
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-background-secondary);
+  color: var(--color-text-primary);
   border-radius: 4px;
   font-size: 12px; /* Font size set to 12px */
   position: relative;

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pivot/Pivot.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pivot/Pivot.vue
@@ -279,30 +279,3 @@ onUnmounted(() => {
   window.removeEventListener("click", handleClickOutside);
 });
 </script>
-
-<style scoped>
-.context-menu {
-  position: fixed;
-  z-index: 1000;
-  border: 1px solid #ccc;
-  background-color: var(--color-background-primary);
-  padding: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-  border-radius: 4px;
-}
-
-.context-menu ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.context-menu li {
-  padding: 8px 16px;
-  cursor: pointer;
-}
-
-.context-menu li:hover {
-  background-color: #f0f0f0;
-}
-</style>

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pivot/SettingsSection.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pivot/SettingsSection.vue
@@ -42,7 +42,8 @@ const emitRemove = (item: string) => {
   display: flex;
   align-items: center;
   padding: 5px 10px;
-  background-color: #f0f0f0;
+  background-color: var(--color-background-secondary);
+  color: var(--color-text-primary);
   border-radius: 4px;
   font-size: 12px; /* Font size set to 12px */
   position: relative;

--- a/flowfile_frontend/src/renderer/styles/main.css
+++ b/flowfile_frontend/src/renderer/styles/main.css
@@ -233,6 +233,23 @@ button {
   background-color: var(--color-accent-subtle) !important;
 }
 
+/* Element Plus dark theme isn't imported — theme multiselect tags explicitly.
+   Scoped to .el-select so standalone status tags (success/danger/info) stay colored. */
+[data-theme="dark"] .el-select .el-tag {
+  background-color: var(--color-background-secondary);
+  border-color: var(--color-border-primary);
+  color: var(--color-text-primary);
+}
+
+[data-theme="dark"] .el-select .el-tag .el-tag__close {
+  color: var(--color-text-secondary);
+}
+
+[data-theme="dark"] .el-select .el-tag .el-tag__close:hover {
+  background-color: var(--color-text-secondary);
+  color: var(--color-background-primary);
+}
+
 /* ========== Element Plus Notification ========== */
 .el-notification {
   font-family: var(--font-family-base);


### PR DESCRIPTION

This pull request improves visual consistency and theme support across several UI components by standardizing the use of CSS variables for colors, particularly for dark mode. The changes affect tag backgrounds, text color, and component styling, and also remove some unused or redundant styles.

**Theme and color standardization:**

* Updated `SettingsSection.vue` in both `graphSolver` and `pivot` node types to use CSS variables (`var(--color-background-secondary)` and `var(--color-text-primary)`) for background and text colors, replacing hardcoded values for better theme support. [[1]](diffhunk://#diff-dd988d0314ea3493f6632a39aff2e4b7fae3e2867ad0cecd945fbb794565dc42L43-R44) [[2]](diffhunk://#diff-97e975894baa5eb1d7de62a1461254deecb5fd1c7ee53f6ee2552f96e3082eacL45-R46)
* Added explicit dark theme styles for Element Plus multiselect tags in `main.css`, ensuring tags are styled consistently in dark mode by setting background, border, and text colors based on theme variables.

**Code cleanup:**

* Removed the unused `.context-menu` style block from `Pivot.vue`, cleaning up redundant CSS.

Fixes #362 