### PR TITLE
fix(ai): bundle libgomp1 so the on-device model boots in Docker

### DIFF
--- a/docs/ai/providers.md
+++ b/docs/ai/providers.md
@@ -115,6 +115,9 @@ The picked model doesn't support tools. Check the *Tools* column in the [provide
 **`404` from `POST /ai/providers/{name}`.**
 Provider name typo. The supported names are exactly: `anthropic`, `openai`, `google`, `groq`, `openrouter`, `ollama` (lowercase, no dashes).
 
+**On-device (local) model exits on startup in Docker / "no CPU backend found".**
+The bundled `llama-server` loads CPU compute backends (`libggml-cpu-*.so`) that need the OpenMP runtime, `libgomp1`. The official `flowfile-core` image bundles it; a custom or older image may not — add it (Debian/Ubuntu: `apt-get install -y libgomp1`) and restart. The startup error now names the cause: `no CPU backend found` / `exit code 127` → missing `libgomp1`; `killed by SIGKILL` → out of memory (give the container more RAM, or pick the 1.5B model / a smaller context in **Settings → AI**); `killed by SIGILL` → the image's architecture doesn't match the host CPU.
+
 **Credential `Test` returns `ok=false` with an authentication error.**
 Key is wrong, expired, or missing required scopes. The error message from the upstream provider is surfaced in the `error` field of the test result.
 

--- a/flowfile_core/Dockerfile
+++ b/flowfile_core/Dockerfile
@@ -46,6 +46,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    libgomp1 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 

--- a/flowfile_core/flowfile_core/ai/local_model/manager.py
+++ b/flowfile_core/flowfile_core/ai/local_model/manager.py
@@ -24,6 +24,7 @@ import logging
 import os
 import platform
 import shutil
+import signal
 import socket
 import subprocess
 import sys
@@ -511,6 +512,25 @@ def _health_ok(port: int) -> bool:
         return False
 
 
+def _describe_exit(rc: int) -> str:
+    """Cause for a llama-server exit. Negative ``rc`` is a POSIX signal: SIGKILL
+    is almost always the OOM killer, SIGILL the binary using CPU instructions
+    this host/arch lacks (incl. cross-arch qemu emulation in Docker)."""
+    if rc >= 0:
+        if rc == 127:
+            return "exit code 127 (a shared library is missing, e.g. libgomp.so.1)"
+        return f"exit code {rc}"
+    try:
+        sig = signal.Signals(-rc)
+    except ValueError:
+        return f"killed by signal {-rc}"
+    if sig == getattr(signal, "SIGKILL", None):
+        return f"killed by {sig.name} (likely out of memory)"
+    if sig == getattr(signal, "SIGILL", None):
+        return f"killed by {sig.name} (binary needs CPU instructions this host/arch lacks)"
+    return f"killed by {sig.name}"
+
+
 def _spawn(binary: Path, model: Path, model_id: str) -> _RunningServer:
     port = _free_port()
     cmd = [
@@ -525,12 +545,11 @@ def _spawn(binary: Path, model: Path, model_id: str) -> _RunningServer:
         str(get_ctx_size()),
         "--threads",
         str(_num_threads()),
-        "--log-disable",
     ]
     creationflags = 0x08000000 if sys.platform.startswith("win") else 0  # CREATE_NO_WINDOW
-    # Capture stderr to a temp file so a startup failure carries the real dyld /
-    # llama.cpp error instead of a bare "exited during startup" (the exact gap
-    # that hid the missing-dylib-symlink bug).
+    # Capture stderr to a temp file so a startup failure carries the real ggml /
+    # dyld error (no --log-disable, which would suppress those lines). A read-only
+    # temp dir disables capture; that fact is surfaced so it isn't a blind spot.
     try:
         err_fh = tempfile.TemporaryFile()
     except OSError:
@@ -547,9 +566,9 @@ def _spawn(binary: Path, model: Path, model_id: str) -> _RunningServer:
             err_fh.close()
         raise LocalModelError(f"Failed to start llama-server: {exc}") from exc
 
-    def _read_stderr_tail() -> str:
+    def _stderr_suffix() -> str:
         if err_fh is None:
-            return ""
+            return " (stderr capture unavailable — temp dir not writable)"
         try:
             err_fh.seek(0)
             raw = err_fh.read().decode("utf-8", errors="replace").strip()
@@ -557,21 +576,20 @@ def _spawn(binary: Path, model: Path, model_id: str) -> _RunningServer:
             return ""
         if not raw:
             return ""
-        tail = raw.splitlines()[-3:]
-        return " | ".join(line.strip() for line in tail if line.strip())
+        tail = " | ".join(line.strip() for line in raw.splitlines()[-3:] if line.strip())
+        return f": {tail}" if tail else ""
 
     try:
         deadline = time.monotonic() + _HEALTH_TIMEOUT
         while time.monotonic() < deadline:
-            if proc.poll() is not None:
-                detail = _read_stderr_tail()
-                suffix = f": {detail}" if detail else " (no error output captured)."
-                raise LocalModelError(f"llama-server exited during startup{suffix}")
+            rc = proc.poll()
+            if rc is not None:
+                raise LocalModelError(f"llama-server exited during startup ({_describe_exit(rc)}){_stderr_suffix()}")
             if _health_ok(port):
                 return _RunningServer(proc=proc, port=port, model_id=model_id)
             time.sleep(0.25)
         _kill_proc(proc)
-        raise LocalModelError(f"llama-server did not become ready within {int(_HEALTH_TIMEOUT)}s.")
+        raise LocalModelError(f"llama-server did not become ready within {int(_HEALTH_TIMEOUT)}s{_stderr_suffix()}.")
     finally:
         if err_fh is not None:
             err_fh.close()

--- a/flowfile_core/tests/ai/test_local_model.py
+++ b/flowfile_core/tests/ai/test_local_model.py
@@ -297,6 +297,55 @@ def test_set_active_model_recycles_running_server(_tmp_storage, monkeypatch):  #
 
 
 # --------------------------------------------------------------------------- #
+# _spawn failure diagnostics                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_describe_exit_decodes_signals_and_127():
+    import signal as s
+
+    assert "SIGKILL" in manager._describe_exit(-int(s.SIGKILL))
+    assert "out of memory" in manager._describe_exit(-int(s.SIGKILL))
+    assert "SIGILL" in manager._describe_exit(-int(s.SIGILL))
+    assert "libgomp" in manager._describe_exit(127)
+    assert manager._describe_exit(1) == "exit code 1"
+
+
+def test_spawn_reports_exit_code_with_empty_stderr(monkeypatch):  # type: ignore[no-untyped-def]
+    """A clean non-zero exit with no captured stderr still names the code, instead
+    of the old opaque '(no error output captured)'."""
+
+    class _DeadProc:
+        def poll(self):  # type: ignore[no-untyped-def]
+            return 1  # exited 1, wrote nothing to stderr
+
+    monkeypatch.setattr(manager, "_free_port", lambda: 12345)
+    monkeypatch.setattr(manager.subprocess, "Popen", lambda *a, **k: _DeadProc())
+
+    with pytest.raises(manager.LocalModelError, match="exit code 1"):
+        manager._spawn(manager.Path("llama-server"), manager.Path("m.gguf"), "qwen2.5-coder-3b")
+
+
+def test_spawn_names_unavailable_stderr_capture(monkeypatch):  # type: ignore[no-untyped-def]
+    """A read-only temp dir disables capture; the failure says so rather than
+    silently hiding the real error."""
+
+    class _DeadProc:
+        def poll(self):  # type: ignore[no-untyped-def]
+            return 1
+
+    def no_tmp(*a, **k):  # type: ignore[no-untyped-def]
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(manager, "_free_port", lambda: 12345)
+    monkeypatch.setattr(manager.tempfile, "TemporaryFile", no_tmp)
+    monkeypatch.setattr(manager.subprocess, "Popen", lambda *a, **k: _DeadProc())
+
+    with pytest.raises(manager.LocalModelError, match="stderr capture unavailable"):
+        manager._spawn(manager.Path("llama-server"), manager.Path("m.gguf"), "qwen2.5-coder-3b")
+
+
+# --------------------------------------------------------------------------- #
 # Provider unification — local resolvable on read-only surfaces               #
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## Problem

On a Docker/server deployment, selecting the on-device AI provider and chatting fails immediately with:

> `LocalModelError: llama-server exited during startup (no error output captured).`

Confirmed on a live box (x86_64, i3-1220P, 8 GB+): the binary itself runs (`--version` works), but real startup dies with `make_cpu_buft_list: no CPU backend found`, and `ldd` shows **every** `libggml-cpu-*.so` → `libgomp.so.1 => not found`.

## Root cause

The pinned llama.cpp `b9305` build ships CPU compute as dynamically-loaded backends (`libggml-cpu-*.so`), each linking `libgomp.so.1` (OpenMP). The `python:3.12-slim` runtime image installed only `curl`, so every backend's `dlopen` failed → ggml had no CPU backend → `llama-server` exited 1. `--log-disable` suppressed the explaining ggml lines and `_spawn` discarded the exit code, so it surfaced as the opaque "(no error output captured)".

## Changes

- **`flowfile_core/Dockerfile`** — add `libgomp1` to the core runtime image. ~300 KB, no new transitive deps (its deps `libc6`/`gcc-12-base` are already present via `libgcc-s1`). This is the actual fix.
- **`manager._spawn`** — drop `--log-disable` (it hid the errors that explained the failure) and always report the exit code, decoding signals (`SIGKILL`→OOM, `SIGILL`→CPU/arch) and the read-only-`/tmp` capture-unavailable case; stderr handling folded into one `_stderr_suffix()` reused on the timeout path. The same failure now reads `…(exit code 1): … no CPU backend found …`.
- **tests** — `_describe_exit` decoding, exit-code-with-empty-stderr, capture-unavailable message.
- **docs** — `docs/ai/providers.md` troubleshooting entry mapping each new error string to a remedy.

## Reviewer notes

- `_describe_exit` guards `signal.SIGKILL`/`SIGILL` with `getattr` since `SIGKILL` doesn't exist on the Windows desktop build.
- Dropping `--log-disable` is deliberate — this incident is the case for it; steady-state logging goes to an anonymous temp file the parent reads only on failure (negligible, bounded by server recycling).
- Only the **core** image needs the lib (the manager + `llama-server` run in core; the worker never spawns it).
- Published-image deployments pick this up via the next core release; in the interim, operators can `apt-get install -y libgomp1` in the container or use a 2-line overlay image.

## Verification

- `ruff check` + `ruff format --check` on `manager.py` — clean.
- `pytest flowfile_core/tests/ai/test_local_model.py` — 27 passed (24 existing + 3 new).
- Live: `apt-get install -y libgomp1` in the core container made `ldd …alderlake.so` resolve and the model load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
