### PR TITLE
fix(ga-oauth): derive OAuth redirect URI from deployment origin

### DIFF
--- a/flowfile_frontend/src/renderer/app/views/GoogleAnalyticsConnectionView/GoogleAnalyticsConnectionView.vue
+++ b/flowfile_frontend/src/renderer/app/views/GoogleAnalyticsConnectionView/GoogleAnalyticsConnectionView.vue
@@ -247,13 +247,14 @@ import GoogleAnalyticsConnectionSettings from "./GoogleAnalyticsConnectionSettin
 import GoogleOAuthClientCard from "./GoogleOAuthClientCard.vue";
 import SetupLink from "./SetupLink.vue";
 import { desktop, isDesktop } from "../../../lib/desktop";
+import { gaOAuthCallbackUrl } from "../../../config/constants";
 
 const connections = ref<GoogleAnalyticsConnectionInterface[]>([]);
 const isLoading = ref(true);
 const dialogVisible = ref(false);
 const deleteDialogVisible = ref(false);
 const setupGuideVisible = ref(false);
-const redirectUri = "http://localhost:63578/ga_connections/oauth/callback";
+const redirectUri = gaOAuthCallbackUrl;
 
 const copyRedirectUri = async () => {
   try {

--- a/flowfile_frontend/src/renderer/app/views/GoogleAnalyticsConnectionView/GoogleOAuthClientCard.vue
+++ b/flowfile_frontend/src/renderer/app/views/GoogleAnalyticsConnectionView/GoogleOAuthClientCard.vue
@@ -69,7 +69,7 @@
             v-model="form.redirectUri"
             type="text"
             class="form-input"
-            placeholder="http://localhost:63578/ga_connections/oauth/callback"
+            :placeholder="gaOAuthCallbackUrl"
             required
           />
           <p class="hint-text">
@@ -105,11 +105,12 @@ import {
   fetchGoogleOAuthConfig,
   saveGoogleOAuthConfig,
 } from "./oauthClientApi";
+import { gaOAuthCallbackUrl } from "../../../config/constants";
 
 const form = reactive({
   clientId: "",
   clientSecret: "",
-  redirectUri: "http://localhost:63578/ga_connections/oauth/callback",
+  redirectUri: gaOAuthCallbackUrl,
 });
 
 const isConfigured = ref(false);

--- a/flowfile_frontend/src/renderer/config/constants.ts
+++ b/flowfile_frontend/src/renderer/config/constants.ts
@@ -41,3 +41,11 @@ function resolveCorePort(): number {
 export const flowfileCorebaseURL = isDesktop
   ? `http://127.0.0.1:${resolveCorePort()}/`
   : `${window.location.origin}/api/`;
+
+// GA OAuth callback Google redirects to after consent. Must be browser-reachable
+// and registered verbatim in the Google Cloud console. Desktop: the system
+// browser hits the local core directly. Web/Docker: <origin>/api/ (nginx forwards
+// to core), so it tracks whatever host serves the app — e.g. a Cloudflare domain.
+export const gaOAuthCallbackUrl = isDesktop
+  ? `http://localhost:${DEFAULT_CORE_PORT}/ga_connections/oauth/callback`
+  : `${window.location.origin}/api/ga_connections/oauth/callback`;


### PR DESCRIPTION
## What

The Google Analytics OAuth **redirect URI** was hardcoded to `http://localhost:63578/ga_connections/oauth/callback` in three frontend spots. This makes the connect flow show/register the wrong URL on any non-localhost deployment.

A new `gaOAuthCallbackUrl` in `constants.ts` now derives it from the actual deployment:

- **Web / Docker:** `${window.location.origin}/api/ga_connections/oauth/callback` — same-origin, and the frontend nginx forwards `/api/*` → `flowfile-core:63578/*`.
- **Desktop:** unchanged — keeps the stable `http://localhost:63578/...` loopback so it stays registerable with Google.

It's used for the OAuth client card default + placeholder and the "How to set up" guide text.

## Why

Behind a reverse proxy (Docker/nginx) or a Cloudflare tunnel (e.g. `getflowfile.com`), `localhost:63578` is core's **internal** address — it only exists on the Docker bridge network. After Google consent the browser was redirected to that unreachable URL and the flow dead-ended. The correct, browser-reachable callback is `https://<host>/api/ga_connections/oauth/callback`, which routes back to core's existing `/ga_connections/oauth/callback` route.

## Reviewer notes

- **No backend change.** The callback handler already uses whatever `redirect_uri` is stored in the user's OAuth config (`routes/ga_connections.py`), so only the frontend default/display was wrong.
- **Desktop is byte-identical** (`localhost:${DEFAULT_CORE_PORT}` == the old literal). A dynamic loopback port can't be pre-registered with Google, so the stable default is intentional.
- **Existing installs** that already saved a `localhost` redirect URI must update it in the Google OAuth card — `loadConfig()` prefers the stored value over this new default. This PR fixes fresh setups and the copy-this-URL guidance.
- No CORS change needed: `/oauth/start` is same-origin, the callback is a top-level navigation, and `postMessage` isn't CORS-governed.

## Verification

- `vue-tsc --noEmit` — passed.
- `eslint` — clean on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)