### PR TITLE
Improve Connections UX: Secrets landing, GA setup clarity & cancel tracking

### DIFF
--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/googleAnalyticsReader/GoogleAnalyticsReader.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/googleAnalyticsReader/GoogleAnalyticsReader.vue
@@ -31,12 +31,31 @@
                 </template>
               </option>
             </select>
+            <div v-if="gaConnections.length === 0" class="connection-cta">
+              <i class="fa-solid fa-circle-info"></i>
+              <div class="connection-cta-body">
+                <span>No Google Analytics connections yet — set one up to use this node.</span>
+                <button
+                  type="button"
+                  class="btn btn-primary cta-button"
+                  @click="goToConnectionSetup"
+                >
+                  <i class="fa-solid fa-up-right-from-square"></i>
+                  Set up a connection
+                </button>
+              </div>
+            </div>
             <div
-              v-if="!nodeGaReader.google_analytics_settings.ga_connection_name"
+              v-else-if="!nodeGaReader.google_analytics_settings.ga_connection_name"
               class="helper-text"
             >
               <i class="fa-solid fa-info-circle"></i>
-              <span>Create a Google Analytics connection in the Connections manager first.</span>
+              <span>
+                Select a connection above, or
+                <button type="button" class="link-button" @click="goToConnectionSetup">
+                  set up a new one</button
+                >.
+              </span>
             </div>
             <div v-else-if="connectionDefaultPropertyId" class="helper-text">
               <i class="fa-solid fa-info-circle"></i>
@@ -451,6 +470,7 @@
 //   - SortBuilder.vue: sort rows (~lines 366-441)
 import { CodeLoader } from "vue-content-loader";
 import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
 import { ElMessage, ElOption, ElOptionGroup, ElSelect } from "element-plus";
 import GenericNodeSettings from "../../../baseNode/genericNodeSettings.vue";
 import { useNodeStore } from "../../../../../stores/node-store";
@@ -495,6 +515,16 @@ const { saveSettings, pushNodeData, handleGenericSettingsUpdate } = useNodeSetti
     }
   },
 });
+
+const router = useRouter();
+
+// When there's no connection to pick, the node is a dead end. Save any
+// in-progress edits, then jump straight to the GA connection setup with the
+// Add Connection dialog already open.
+const goToConnectionSetup = async () => {
+  await saveSettings();
+  router.push({ name: "connections", query: { tab: "google_analytics", action: "add" } });
+};
 
 const gaConnections = ref<GoogleAnalyticsConnectionInterface[]>([]);
 const connectionsAreLoading = ref(false);
@@ -827,6 +857,53 @@ select.form-control {
 
 .helper-text-warning > i {
   color: #d69e2e;
+}
+
+.connection-cta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background: #ebf8ff;
+  border: 1px solid #bee3f8;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  color: #2c5282;
+}
+
+.connection-cta > i {
+  color: #3182ce;
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+}
+
+.connection-cta-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+  line-height: 1.45;
+}
+
+.cta-button {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.link-button {
+  padding: 0;
+  background: none;
+  border: none;
+  color: #4299e1;
+  text-decoration: underline;
+  font-size: inherit;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.link-button:hover {
+  color: #2b6cb0;
 }
 
 .required {

--- a/flowfile_frontend/src/renderer/app/views/GoogleAnalyticsConnectionView/GoogleAnalyticsConnectionView.vue
+++ b/flowfile_frontend/src/renderer/app/views/GoogleAnalyticsConnectionView/GoogleAnalyticsConnectionView.vue
@@ -122,12 +122,26 @@
 
         <ol class="setup-steps">
           <li>
-            <strong>Create (or pick) a Google Cloud project.</strong>
-            Go to
-            <SetupLink href="https://console.cloud.google.com/projectcreate">
-              console.cloud.google.com/projectcreate
-            </SetupLink>
-            and create a project, or select any existing one from the project picker.
+            <strong>Choose your Google Cloud project.</strong>
+            <ul class="setup-substeps">
+              <li>
+                <strong>Already use Google Cloud?</strong>
+                Open the
+                <SetupLink href="https://console.cloud.google.com/projectselector2/home/dashboard">
+                  project selector
+                </SetupLink>
+                and pick the project you want to use, then skip ahead to <strong>step 4</strong> to
+                create the OAuth client. First confirm the Analytics Data API is enabled (step 2)
+                and your OAuth consent screen is configured (step 3) — do those if you haven't yet.
+              </li>
+              <li>
+                <strong>New to Google Cloud?</strong>
+                <SetupLink href="https://console.cloud.google.com/projectcreate">
+                  Create a project
+                </SetupLink>
+                , then continue with step 2 below.
+              </li>
+            </ul>
           </li>
           <li>
             <strong>Enable the Google Analytics Data API.</strong>
@@ -186,6 +200,12 @@
             Click <em>Add Connection</em>, name it, then <em>Connect Google Account</em>. Sign in
             with a Google account that has Viewer access to your GA4 property. Flowfile stores only
             the refresh token, encrypted with your user-derived key.
+            <div class="setup-action">
+              <button type="button" class="btn btn-primary btn-sm" @click="openAddFromGuide">
+                <i class="fa-solid fa-plus"></i>
+                Open Add Connection
+              </button>
+            </div>
           </li>
         </ol>
 
@@ -232,6 +252,7 @@
 
 <script lang="ts" setup>
 import { ref, onMounted, onBeforeUnmount } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import { ElDialog, ElButton, ElMessage, ElPopover } from "element-plus";
 import {
   deleteGoogleAnalyticsConnection,
@@ -247,6 +268,9 @@ import GoogleAnalyticsConnectionSettings from "./GoogleAnalyticsConnectionSettin
 import GoogleOAuthClientCard from "./GoogleOAuthClientCard.vue";
 import SetupLink from "./SetupLink.vue";
 import { desktop, isDesktop } from "../../../lib/desktop";
+
+const route = useRoute();
+const router = useRouter();
 
 const connections = ref<GoogleAnalyticsConnectionInterface[]>([]);
 const isLoading = ref(true);
@@ -283,6 +307,18 @@ const stopGaOauthPolling = () => {
   }
 };
 
+// Web OAuth opens a popup we control. If the user closes that window before
+// Google redirects back (i.e. cancels), no message ever arrives — this timer
+// watches for the close so we reset state instead of hanging on "connecting".
+let oauthPopupCloseTimer: ReturnType<typeof setInterval> | null = null;
+
+const stopOauthPopupWatch = () => {
+  if (oauthPopupCloseTimer !== null) {
+    clearInterval(oauthPopupCloseTimer);
+    oauthPopupCloseTimer = null;
+  }
+};
+
 // After opening the browser, refresh the connection list until the target
 // connection shows a linked Google account (the callback upserts it), or we
 // hit the timeout. Reports success only for a freshly-linked connection so a
@@ -290,11 +326,18 @@ const stopGaOauthPolling = () => {
 const pollForGaOauthCompletion = (connectionName: string, wasLinkedBefore: boolean) => {
   stopGaOauthPolling();
   const deadline = Date.now() + 3 * 60 * 1000;
+  let consecutiveErrors = 0;
+  const giveUp = (message: string) => {
+    stopGaOauthPolling();
+    isConnecting.value = false;
+    ElMessage.warning(message);
+  };
   const tick = async () => {
     gaOauthPollTimer = null;
     try {
       const latest = await fetchGoogleAnalyticsConnections();
       connections.value = latest;
+      consecutiveErrors = 0;
       const match = latest.find((c) => c.connectionName === connectionName && c.oauthUserEmail);
       if (match && !wasLinkedBefore) {
         isConnecting.value = false;
@@ -304,14 +347,17 @@ const pollForGaOauthCompletion = (connectionName: string, wasLinkedBefore: boole
       }
     } catch (error) {
       console.error("Error polling GA connections:", error);
+      consecutiveErrors += 1;
+      if (consecutiveErrors >= 5) {
+        giveUp("Lost contact with the server while finishing Google sign-in. Please try again.");
+        return;
+      }
     }
-    // TODO(E): silent failure. The desktop system-browser OAuth flow can't
-    // postMessage back, so we poll here. If the backend callback never completes,
-    // this just stops after 3 min with no user feedback (and the caught poll
-    // error above is console-only). Surface an ElMessage on timeout — and on
-    // repeated poll errors — so the user knows the connection didn't link.
+    // The system-browser OAuth flow can't postMessage back, so a true cancel
+    // emits no signal — on timeout we can only report that sign-in never
+    // completed (rather than reset silently and leave the user guessing).
     if (Date.now() > deadline) {
-      isConnecting.value = false;
+      giveUp("Google sign-in wasn't completed — the connection wasn't linked. Try again.");
       return;
     }
     gaOauthPollTimer = setTimeout(tick, 2000);
@@ -335,6 +381,11 @@ const showAddModal = () => {
   isEditing.value = false;
   activeConnection.value = undefined;
   dialogVisible.value = true;
+};
+
+const openAddFromGuide = () => {
+  setupGuideVisible.value = false;
+  showAddModal();
 };
 
 const showEditModal = (connection: GoogleAnalyticsConnectionInterface) => {
@@ -389,6 +440,17 @@ const handleConnectOAuth = async (metadata: GoogleAnalyticsConnectionMetadata) =
     if (!oauthPopup) {
       ElMessage.error("Popup blocked — allow popups for this site and try again");
       isConnecting.value = false;
+    } else {
+      // A manual popup close is the only cancel signal we get — watch for it.
+      stopOauthPopupWatch();
+      oauthPopupCloseTimer = setInterval(() => {
+        if (oauthPopup && oauthPopup.closed) {
+          stopOauthPopupWatch();
+          oauthPopup = null;
+          isConnecting.value = false;
+          ElMessage.info("Google sign-in was cancelled");
+        }
+      }, 500);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -406,6 +468,9 @@ const handleOAuthMessage = async (event: MessageEvent) => {
   if (!oauthPopup || event.source !== oauthPopup) return;
   const data = event.data;
   if (!data || data.source !== "flowfile-ga-oauth") return;
+  // A result arrived — stop the close-watch so the popup auto-closing (500ms
+  // after it postMessages) isn't mistaken for a cancellation.
+  stopOauthPopupWatch();
   isConnecting.value = false;
   if (data.status === "ok") {
     await fetchConnections();
@@ -447,11 +512,21 @@ const handleCloseDeleteDialog = (done: () => void) => {
 onMounted(() => {
   fetchConnections();
   window.addEventListener("message", handleOAuthMessage);
+  // Deep link (from the GA reader node or the setup guide): open the Add
+  // Connection dialog straight away, then drop the param so a refresh or
+  // tab-switch doesn't reopen it.
+  if (route.query.action === "add") {
+    showAddModal();
+    const query = { ...route.query };
+    delete query.action;
+    router.replace({ query });
+  }
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener("message", handleOAuthMessage);
   stopGaOauthPolling();
+  stopOauthPopupWatch();
 });
 </script>
 
@@ -494,6 +569,19 @@ onBeforeUnmount(() => {
 
 .setup-steps li {
   line-height: 1.55;
+}
+
+.setup-substeps {
+  margin: var(--spacing-2) 0 0;
+  padding-left: var(--spacing-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  list-style: disc;
+}
+
+.setup-action {
+  margin-top: var(--spacing-3);
 }
 
 .setup-steps code {

--- a/flowfile_frontend/src/renderer/app/views/SecretsView/SecretsView.vue
+++ b/flowfile_frontend/src/renderer/app/views/SecretsView/SecretsView.vue
@@ -1,132 +1,206 @@
 <template>
   <div class="secret-manager-container">
-    <div class="mb-3">
-      <h2 class="page-title">Secret Manager</h2>
-      <p class="page-description">Securely store and manage credentials for your integrations</p>
+    <!-- Intro / landing screen -->
+    <div v-if="viewMode === 'intro'" class="secrets-intro">
+      <div class="intro-header">
+        <div class="intro-icon"><i class="fa-solid fa-key"></i></div>
+        <div>
+          <h2 class="page-title">Secrets</h2>
+          <p class="page-description">
+            Encrypted credentials you store once and reuse across your flows and connections.
+          </p>
+        </div>
+      </div>
+
+      <div class="card mb-3">
+        <div class="card-content">
+          <div class="intro-info-box">
+            <i class="fa-solid fa-shield-halved"></i>
+            <div>
+              <p><strong>What are secrets?</strong></p>
+              <p>
+                Secrets are sensitive values — API keys, passwords, tokens — that you store once and
+                reference <strong>by name</strong>. Each value is encrypted at rest with your master
+                key and is never shown again after you save it.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card mb-3">
+        <div class="card-header">
+          <h3 class="card-title">How to use a secret</h3>
+        </div>
+        <div class="card-content">
+          <ol class="intro-steps">
+            <li>
+              <strong>Add a secret.</strong> Give it a name (for example <code>api_key</code>) and a
+              value. It's encrypted the moment you save it.
+            </li>
+            <li>
+              <strong>Reference it by name.</strong> Pick the secret in a node's secret field, or
+              when you set up a Database, Cloud Storage, or Kafka connection — you never paste the
+              raw value again.
+            </li>
+            <li>
+              <strong>Run your flow.</strong> Flowfile decrypts the secret on demand at run time.
+              The value never appears in flow files, logs, or the UI.
+            </li>
+          </ol>
+        </div>
+      </div>
+
+      <div class="intro-cta">
+        <button type="button" class="btn btn-primary" @click="goToManage">
+          <i class="fa-solid fa-key"></i>
+          Manage secrets
+          <i class="fa-solid fa-arrow-right"></i>
+        </button>
+        <span v-if="secrets.length > 0" class="intro-cta-hint">
+          You have {{ secrets.length }} secret{{ secrets.length === 1 ? "" : "s" }} stored.
+        </span>
+      </div>
     </div>
 
-    <!-- Add Secret Card -->
-    <div class="card mb-3">
-      <div class="card-header">
-        <h3 class="card-title">Add New Secret</h3>
+    <!-- Management screen -->
+    <template v-else>
+      <div class="manage-header mb-3">
+        <button type="button" class="overview-link" @click="goToIntro">
+          <i class="fa-solid fa-arrow-left"></i>
+          Overview
+        </button>
+        <div>
+          <h2 class="page-title">Secrets</h2>
+          <p class="page-description">
+            Securely store and manage credentials for your integrations.
+          </p>
+        </div>
       </div>
-      <div class="card-content">
-        <form class="form" @submit.prevent="handleAddSecret">
-          <div class="form-grid">
-            <div class="form-field">
-              <label for="secret-name" class="form-label">Secret Name</label>
-              <input
-                id="secret-name"
-                v-model="newSecret.name"
-                type="text"
-                class="form-input"
-                placeholder="api_key, database_password, etc."
-                required
-              />
-            </div>
 
-            <div class="form-field">
-              <label for="secret-value" class="form-label">Secret Value</label>
-              <div class="password-field">
+      <!-- Add Secret Card -->
+      <div class="card mb-3">
+        <div class="card-header">
+          <h3 class="card-title">Add New Secret</h3>
+        </div>
+        <div class="card-content">
+          <form class="form" @submit.prevent="handleAddSecret">
+            <div class="form-grid">
+              <div class="form-field">
+                <label for="secret-name" class="form-label">Secret Name</label>
                 <input
-                  id="secret-value"
-                  v-model="newSecret.value"
-                  :type="showNewSecret ? 'text' : 'password'"
+                  id="secret-name"
+                  v-model="newSecret.name"
+                  type="text"
                   class="form-input"
-                  placeholder="Enter secret value"
+                  placeholder="api_key, database_password, etc."
                   required
                 />
+              </div>
+
+              <div class="form-field">
+                <label for="secret-value" class="form-label">Secret Value</label>
+                <div class="password-field">
+                  <input
+                    id="secret-value"
+                    v-model="newSecret.value"
+                    :type="showNewSecret ? 'text' : 'password'"
+                    class="form-input"
+                    placeholder="Enter secret value"
+                    required
+                  />
+                  <button
+                    type="button"
+                    class="toggle-visibility"
+                    aria-label="Toggle new secret visibility"
+                    @click="showNewSecret = !showNewSecret"
+                  >
+                    <i :class="showNewSecret ? 'fa-solid fa-eye-slash' : 'fa-solid fa-eye'"></i>
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-actions">
+              <button
+                type="submit"
+                class="btn btn-primary"
+                :disabled="!newSecret.name || !newSecret.value || isSubmitting"
+              >
+                <i class="fa-solid fa-plus"></i>
+                {{ isSubmitting ? "Adding..." : "Add Secret" }}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <div class="card mb-3">
+        <div class="card-header">
+          <h3 class="card-title">Your Secrets ({{ filteredSecrets.length }})</h3>
+          <div v-if="secrets.length > 0" class="search-container">
+            <input
+              v-model="searchTerm"
+              type="text"
+              placeholder="Search secrets..."
+              class="search-input"
+              aria-label="Search secrets"
+            />
+            <i class="fa-solid fa-search search-icon"></i>
+          </div>
+        </div>
+        <div class="card-content">
+          <div v-if="isLoading" class="loading-state">
+            <div class="loading-spinner"></div>
+            <p>Loading secrets...</p>
+          </div>
+
+          <div v-else-if="!isLoading && secrets.length === 0" class="empty-state">
+            <i class="fa-solid fa-lock"></i>
+            <p class="empty-state__title">No secrets configured yet</p>
+            <p class="empty-state__subtitle">
+              Add a secret above to securely store credentials for your integrations and flows.
+            </p>
+          </div>
+
+          <!-- Secrets List -->
+          <div v-else-if="filteredSecrets.length > 0" class="secrets-list">
+            <div v-for="secret in filteredSecrets" :key="secret.name" class="secret-item">
+              <div class="secret-name">
+                <i class="fa-solid fa-key"></i>
+                <span>{{ secret.name }}</span>
+              </div>
+              <div class="secret-value">
+                <input
+                  type="password"
+                  value="••••••••••••••••"
+                  readonly
+                  class="form-input"
+                  aria-label="Masked secret value"
+                />
+              </div>
+              <div class="secret-actions">
                 <button
                   type="button"
-                  class="toggle-visibility"
-                  aria-label="Toggle new secret visibility"
-                  @click="showNewSecret = !showNewSecret"
+                  class="btn btn-danger"
+                  :aria-label="`Delete secret ${secret.name}`"
+                  @click="handleConfirmDelete(secret.name)"
                 >
-                  <i :class="showNewSecret ? 'fa-solid fa-eye-slash' : 'fa-solid fa-eye'"></i>
+                  <i class="fa-solid fa-trash-alt"></i>
+                  <span>Delete</span>
                 </button>
               </div>
             </div>
           </div>
 
-          <div class="form-actions">
-            <button
-              type="submit"
-              class="btn btn-primary"
-              :disabled="!newSecret.name || !newSecret.value || isSubmitting"
-            >
-              <i class="fa-solid fa-plus"></i>
-              {{ isSubmitting ? "Adding..." : "Add Secret" }}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-
-    <div class="card mb-3">
-      <div class="card-header">
-        <h3 class="card-title">Your Secrets ({{ filteredSecrets.length }})</h3>
-        <div v-if="secrets.length > 0" class="search-container">
-          <input
-            v-model="searchTerm"
-            type="text"
-            placeholder="Search secrets..."
-            class="search-input"
-            aria-label="Search secrets"
-          />
-          <i class="fa-solid fa-search search-icon"></i>
-        </div>
-      </div>
-      <div class="card-content">
-        <div v-if="isLoading" class="loading-state">
-          <div class="loading-spinner"></div>
-          <p>Loading secrets...</p>
-        </div>
-
-        <div v-else-if="!isLoading && secrets.length === 0" class="empty-state">
-          <i class="fa-solid fa-lock"></i>
-          <p class="empty-state__title">No secrets configured yet</p>
-          <p class="empty-state__subtitle">
-            Add a secret above to securely store credentials for your integrations and flows.
-          </p>
-        </div>
-
-        <!-- Secrets List -->
-        <div v-else-if="filteredSecrets.length > 0" class="secrets-list">
-          <div v-for="secret in filteredSecrets" :key="secret.name" class="secret-item">
-            <div class="secret-name">
-              <i class="fa-solid fa-key"></i>
-              <span>{{ secret.name }}</span>
-            </div>
-            <div class="secret-value">
-              <input
-                type="password"
-                value="••••••••••••••••"
-                readonly
-                class="form-input"
-                aria-label="Masked secret value"
-              />
-            </div>
-            <div class="secret-actions">
-              <button
-                type="button"
-                class="btn btn-danger"
-                :aria-label="`Delete secret ${secret.name}`"
-                @click="handleConfirmDelete(secret.name)"
-              >
-                <i class="fa-solid fa-trash-alt"></i>
-                <span>Delete</span>
-              </button>
-            </div>
+          <!-- No Results State -->
+          <div v-else class="empty-state">
+            <i class="fa-solid fa-search"></i>
+            <p>No secrets found matching "{{ searchTerm }}"</p>
           </div>
         </div>
-
-        <!-- No Results State -->
-        <div v-else class="empty-state">
-          <i class="fa-solid fa-search"></i>
-          <p>No secrets found matching "{{ searchTerm }}"</p>
-        </div>
       </div>
-    </div>
+    </template>
 
     <!-- Delete Confirmation Modal -->
     <div v-if="showDeleteModal" class="modal-overlay" @click="cancelDelete">
@@ -166,6 +240,25 @@ import { useSecretManager } from "./useSecretManager";
 // Use our secrets composable
 const { secrets, filteredSecrets, isLoading, searchTerm, loadSecrets, addSecret, deleteSecret } =
   useSecretManager();
+
+// Landing screen vs. management screen. First visit always lands on the intro;
+// once a user moves on (or returns to the overview) we remember their choice so
+// they aren't re-greeted every time.
+const VIEW_MODE_KEY = "secrets-view-mode";
+type ViewMode = "intro" | "manage";
+const viewMode = ref<ViewMode>(
+  localStorage.getItem(VIEW_MODE_KEY) === "manage" ? "manage" : "intro",
+);
+
+const goToManage = () => {
+  viewMode.value = "manage";
+  localStorage.setItem(VIEW_MODE_KEY, "manage");
+};
+
+const goToIntro = () => {
+  viewMode.value = "intro";
+  localStorage.setItem(VIEW_MODE_KEY, "intro");
+};
 
 // Local component state
 const newSecret = ref<SecretInput>({ name: "", value: "" });
@@ -232,6 +325,126 @@ onMounted(() => {
 </script>
 
 <style scoped>
+/* Intro / landing screen */
+.secrets-intro {
+  max-width: 760px;
+}
+
+.intro-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+  margin-bottom: var(--spacing-4);
+}
+
+.intro-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+  border-radius: var(--border-radius-lg);
+  background-color: var(--color-accent-subtle);
+  color: var(--color-accent);
+  font-size: var(--font-size-xl);
+}
+
+.intro-info-box {
+  display: flex;
+  gap: var(--spacing-4);
+  padding: var(--spacing-4);
+  background-color: var(--color-background-muted);
+  border-left: 4px solid var(--color-accent);
+  border-radius: var(--border-radius-md);
+}
+
+.intro-info-box i {
+  color: var(--color-accent);
+  font-size: var(--font-size-2xl);
+  margin-top: var(--spacing-1);
+}
+
+.intro-info-box p {
+  margin: 0 0 var(--spacing-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.55;
+}
+
+.intro-info-box p:last-child {
+  margin-bottom: 0;
+}
+
+.intro-info-box p strong {
+  color: var(--color-text-primary);
+}
+
+.intro-steps {
+  margin: 0;
+  padding-left: var(--spacing-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+
+.intro-steps li {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  line-height: 1.55;
+}
+
+.intro-steps strong {
+  color: var(--color-text-primary);
+}
+
+.intro-steps code {
+  background: var(--color-background-muted);
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+.intro-cta {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-3);
+}
+
+.intro-cta .btn i + span,
+.intro-cta .btn .fa-arrow-right {
+  margin-left: var(--spacing-1);
+}
+
+.intro-cta-hint {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-tertiary);
+}
+
+/* Management screen header */
+.manage-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.overview-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  align-self: flex-start;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.overview-link:hover {
+  color: var(--color-accent);
+}
+
 /* Override global styles to ensure horizontal layout */
 .secret-item {
   display: flex;


### PR DESCRIPTION
## Why

Several rough edges in the **Connections** area, all observed running from Docker (web mode):

1. **Secrets had no orientation** — the tab opened straight into the "Add New Secret" form with no explanation of what a secret is or how it's used.
2. **The Google Analytics "How to set up" guide was confusing** — step 1 linked only to the *new-project* page and told existing-account users to "pick" a project with no link, so people who already use Google Cloud got stuck on a create-account screen.
3. **Internal (in-app) links weren't obvious** — setup guidance referred to in-app actions as plain prose.
4. **A cancelled GA sign-in wasn't tracked** — closing the OAuth popup left the dialog hung on "connecting…" forever.
5. **The GA reader node was a dead end** — with no connection configured it showed plain text "create one first" and no way to get there.

## What changed

**Secrets** (`SecretsView.vue`)
- Added a separate intro/landing screen: a "What are secrets?" explainer + a numbered "How to use a secret" guide, with a **Manage secrets →** CTA.
- The intro-vs-manage choice persists in `localStorage` (`secrets-view-mode`) — first visit always shows the intro; repeat users aren't re-greeted. A **← Overview** link returns to it.

**Google Analytics setup guide** (`GoogleAnalyticsConnectionView.vue`)
- Step 1 is now two explicit paths: **Already use Google Cloud?** → opens the **project selector** (the previously-missing link) and points ahead to step 4, with a note to confirm steps 2–3 first; **New to Google Cloud?** → create a project, continue at step 2.
- Step 7 gained an **Open Add Connection** button that closes the guide and opens the dialog.

**GA OAuth cancellation** (`GoogleAnalyticsConnectionView.vue`)
- Web/Docker popup path: watches `oauthPopup.closed`; if the popup is closed before a result arrives, it reports **"Google sign-in was cancelled"** and resets state (the watch is cleared on a real result so a normal completion isn't mistaken for a cancel).
- Desktop system-browser path: the 3-minute poll now surfaces a warning on timeout / repeated errors instead of resetting silently (resolves the existing `TODO(E)`).

**Deep-linking** (`GoogleAnalyticsConnectionView.vue` + `GoogleAnalyticsReader.vue`)
- Added an `action=add` query param: navigating to `connections?tab=google_analytics&action=add` auto-opens the Add Connection dialog (param is stripped after).
- The GA reader node's no-connection state is now a **Set up a connection** button that saves the node and deep-links straight there.

## Reviewer notes
- No backend, router-config, or new-component changes — three Vue files only.
- The OAuth redirect URI remains hardcoded to `localhost:63578`, which is correct for local Docker accessed via localhost; remote-host Docker is a separate config concern, out of scope here.
- `eslint --fix` passes on all three files. A full `vue-tsc` wasn't run from this worktree (no local `node_modules`); the edits were type-checked by review.

## How to verify
`docker compose up -d` (or `npm run dev:web` + backend), then: open Connections → **Secrets** (intro → Manage → Overview, persisted across reload); **Google Analytics → How to set up** (step 1 two paths, project-selector link, step 7 button); start "Connect Google Account" and **close the popup** (expect a cancelled toast, no hang); add a **Google Analytics** node with no connections and use its **Set up a connection** button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
