### PR TITLE
Fix issue with opening flow from run history

### DIFF
--- a/flowfile_frontend/src-tauri/src/lib.rs
+++ b/flowfile_frontend/src-tauri/src/lib.rs
@@ -179,6 +179,9 @@ fn create_main_window(
         // column reorder, etc. We're not handling file drops in this app, so
         // disable the native capture and let the webview see the events.
         .disable_drag_drop_handler()
+        // macOS delivers the first click on an unfocused window to focus only;
+        // opt in so that click also reaches the page (no-op on other platforms).
+        .accept_first_mouse(true)
         .initialization_script(&init_script)
         .build()
 }

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -255,12 +255,15 @@
           :runs="catalogStore.runs"
           @view-run="handleViewRun"
           @view-flow="navigateToFlow($event)"
+          @view-schedule-runs="navigateToScheduleRuns"
+          @open-snapshot="openRunSnapshot($event)"
           @view-table="selectTable($event)"
           @create-schedule="showCreateSchedule = true"
           @toggle-schedule="handleToggleSchedule"
           @delete-schedule="handleDeleteSchedule"
           @run-now="handleRunNow"
           @cancel-schedule-run="handleCancelScheduleRun"
+          @select-schedule="selectSchedule"
           @open-tab="handleTabClick($event)"
         />
       </div>
@@ -447,7 +450,7 @@
 //   - 19 async handlers: move into catalog-store.ts as Pinia actions (~lines 657-927)
 //   - useRouteSync composable: applyRouteToStore (~lines 930-993)
 import { computed, h, onMounted, onUnmounted, ref, watch } from "vue";
-import { ElCheckbox, ElMessage, ElMessageBox } from "element-plus";
+import { ElCheckbox, ElLoading, ElMessage, ElMessageBox } from "element-plus";
 import { useRoute, useRouter } from "vue-router";
 import { useCatalogStore } from "../../stores/catalog-store";
 import { useFlowStore } from "../../stores/flow-store";
@@ -974,13 +977,23 @@ async function handleRenameFlow(flowId: number, newName: string) {
   }
 }
 
+let openingSnapshot = false;
+
 async function openRunSnapshot(runId: number) {
+  if (openingSnapshot) return;
+  openingSnapshot = true;
+  const loading = ElLoading.service({ text: "Opening flow version…" });
   try {
     const flowId = await CatalogApi.openRunSnapshot(runId);
     flowStore.setFlowId(flowId);
-    router.push({ name: "designer" });
+    const failure = await router.push({ name: "designer" });
+    if (failure) ElMessage.error("Could not open the designer");
   } catch (e: any) {
+    console.error("Failed to open run snapshot:", e);
     ElMessage.error(e?.response?.data?.detail ?? "Failed to open flow snapshot");
+  } finally {
+    loading.close();
+    openingSnapshot = false;
   }
 }
 
@@ -1574,6 +1587,7 @@ onUnmounted(() => {
 .catalog-view .flow-link {
   cursor: pointer;
   transition: color var(--transition-fast);
+  user-select: none;
 }
 
 .catalog-view .flow-link:hover {
@@ -1584,6 +1598,12 @@ onUnmounted(() => {
   color: var(--color-primary);
   cursor: pointer;
   font-size: var(--font-size-xs);
+  user-select: none;
+  /* Oversized hit target: sloppy trackpad clicks that drift a few px must
+     still release inside the element, or no click event fires at all. */
+  display: inline-block;
+  padding: var(--spacing-1) var(--spacing-2);
+  margin: calc(-1 * var(--spacing-1)) calc(-1 * var(--spacing-2));
 }
 
 .catalog-view .no-snapshot {

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/RunHistoryTable.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/RunHistoryTable.vue
@@ -363,6 +363,7 @@ function runStatusText(run: FlowRun): string {
   color: var(--color-primary);
   cursor: pointer;
   transition: opacity var(--transition-fast);
+  user-select: none;
 }
 
 .schedule-link:hover {

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/StatsPanel.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/StatsPanel.vue
@@ -153,6 +153,8 @@
       <RunOverviewPanel
         @view-run="$emit('viewRun', $event)"
         @view-flow="$emit('viewFlow', $event)"
+        @view-schedule-runs="$emit('viewScheduleRuns', $event)"
+        @open-snapshot="$emit('openSnapshot', $event)"
       />
     </div>
 
@@ -165,6 +167,7 @@
         @run-now="$emit('runNow', $event)"
         @cancel-schedule-run="$emit('cancelScheduleRun', $event)"
         @view-flow="$emit('viewFlow', $event)"
+        @select-schedule="$emit('selectSchedule', $event)"
       />
     </div>
 
@@ -323,12 +326,15 @@ const favoriteTables = computed((): CatalogTable[] => {
 defineEmits([
   "viewRun",
   "viewFlow",
+  "viewScheduleRuns",
+  "openSnapshot",
   "viewTable",
   "createSchedule",
   "toggleSchedule",
   "deleteSchedule",
   "runNow",
   "cancelScheduleRun",
+  "selectSchedule",
   "openTab",
 ]);
 


### PR DESCRIPTION
This pull request introduces several improvements to the Catalog view in the frontend, focusing on enhancing user interaction and feedback, especially around opening flow run snapshots and clickable UI elements. The most important changes include adding a loading indicator and error handling when opening run snapshots, propagating new events through component hierarchies, and improving the usability of clickable links in the UI.

**User Experience and Feedback Improvements:**

* Added a loading spinner and error handling to the `openRunSnapshot` function to provide feedback when opening a flow run snapshot; prevents duplicate actions and shows error messages on failure.
* Improved clickable areas for `.flow-link` and schedule links by increasing hit targets, disabling text selection, and ensuring better usability for mouse and trackpad users. [[1]](diffhunk://#diff-28f97ff2d8ee94dc7e78eb64c0ad9c6f3025b0f357f17c9c8a37a09e0defb991R1590) [[2]](diffhunk://#diff-28f97ff2d8ee94dc7e78eb64c0ad9c6f3025b0f357f17c9c8a37a09e0defb991R1601-R1606) [[3]](diffhunk://#diff-45260a447b439a46626d8f05de5c0e129a012593cadc8f3cdbb60764fae1540eR366)

**Component and Event Handling Enhancements:**

* Propagated new events (`view-schedule-runs`, `open-snapshot`, `select-schedule`) through `CatalogView` and `StatsPanel` components, enabling new interactions and better modularity. [[1]](diffhunk://#diff-28f97ff2d8ee94dc7e78eb64c0ad9c6f3025b0f357f17c9c8a37a09e0defb991R258-R266) [[2]](diffhunk://#diff-343a07cc989b8f1c9271323087b78961cc6b83842e4fab46dadfd3899e54bf75R156-R157) [[3]](diffhunk://#diff-343a07cc989b8f1c9271323087b78961cc6b83842e4fab46dadfd3899e54bf75R170) [[4]](diffhunk://#diff-343a07cc989b8f1c9271323087b78961cc6b83842e4fab46dadfd3899e54bf75R329-R337)

**Dependency and Platform Support:**

* Added `ElLoading` import to support the new loading spinner functionality.
* Enabled `accept_first_mouse` in the Tauri window for macOS, allowing the first mouse click on an unfocused window to register as a click (improves UX on macOS; no-op elsewhere).