### PR TITLE
Fix collapsing of nodes when searching

### DIFF
--- a/flowfile_frontend/src/renderer/app/views/DesignerView/NodeList.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/NodeList.vue
@@ -5,6 +5,7 @@
 
     <div
       v-for="(categoryInfo, category) in categories"
+      v-show="!searchQuery || filteredNodes[category]"
       :key="category"
       class="category-container"
       :data-tutorial-category="category"
@@ -13,14 +14,14 @@
       <button class="category-header" @click="toggleCategory(category as CategoryKey)">
         <span class="category-title">{{ categoryInfo.name }}</span>
         <el-icon class="category-icon">
-          <ArrowDown v-if="openCategories[category as CategoryKey]" />
+          <ArrowDown v-if="isCategoryOpen(category as CategoryKey)" />
           <ArrowRight v-else />
         </el-icon>
       </button>
 
       <!-- Category Content -->
       <div
-        v-if="openCategories[category as CategoryKey] && filteredNodes[category]"
+        v-if="isCategoryOpen(category as CategoryKey) && filteredNodes[category]"
         class="category-content"
       >
         <div
@@ -106,7 +107,13 @@ const filteredNodes = computed(() => {
   return filtered;
 });
 
+const isCategoryOpen = (category: CategoryKey) => {
+  if (searchQuery.value) return !!filteredNodes.value[category];
+  return openCategories.value[category];
+};
+
 const toggleCategory = (category: CategoryKey) => {
+  if (searchQuery.value) return;
   openCategories.value[category] = !openCategories.value[category];
 };
 


### PR DESCRIPTION
This pull request improves the usability of the node list in the `DesignerView` by refining how categories are displayed and toggled, especially when a search query is active. The changes ensure that only relevant categories are shown during searches and that category toggling behaves intuitively.

**Enhancements to category display and toggling:**

* Categories are now only shown if they contain nodes matching the current search query, making the list more relevant during searches.
* The logic for determining whether a category is open has been refactored into a new `isCategoryOpen` function, which ensures that categories with search results are always expanded during a search, regardless of their previous open/closed state. [[1]](diffhunk://#diff-f55c07c6eae54f5beb77c9520762e3969323190a4ae5b14ee18b4e6906a94da7L16-R24) [[2]](diffhunk://#diff-f55c07c6eae54f5beb77c9520762e3969323190a4ae5b14ee18b4e6906a94da7R110-R116)
* The `toggleCategory` function has been updated to prevent toggling categories while a search query is active, maintaining consistent UI behavior.