### PR TITLE
Fix bug with alias group key

### DIFF
--- a/flowfile_frame/flowfile_frame/group_frame.py
+++ b/flowfile_frame/flowfile_frame/group_frame.py
@@ -105,7 +105,10 @@ class GroupByFrame:
             elif isinstance(col_expr, Expr):
                 if col_expr.is_complex:
                     return False
-                agg_cols.append(transform_schema.AggColl(old_name=col_expr.column_name, agg="groupby"))
+                old_name = getattr(col_expr, "_initial_column_name", col_expr.column_name) or col_expr.column_name
+                agg_cols.append(
+                    transform_schema.AggColl(old_name=old_name, agg="groupby", new_name=col_expr.column_name)
+                )
             elif isinstance(col_expr, Selector):
                 return False
             else:

--- a/flowfile_frame/tests/test_group_frame.py
+++ b/flowfile_frame/tests/test_group_frame.py
@@ -288,6 +288,18 @@ class TestGroupByFrame:
         if len(north_a) > 0:
             assert north_a["sales"][0] == 250  # 100 + 150
 
+    def test_group_by_rename_group_keys_count(self, sales_data):
+        """Test the alias use in the group by expression"""
+        df = sales_data.group_by(col("product").alias("product_name")).len()
+        pl_df = sales_data.data.group_by(pl.col("product").alias("product_name")).len()
+        assert_frame_equal(df.data, pl_df, check_row_order=False)
+
+    def test_group_by_rename_group_keys_agg(self, sales_data):
+        """Test the alias use in the group by expression"""
+        df = sales_data.group_by(col("product").alias("product_name")).agg(col("sales").sum())
+        pl_df = sales_data.data.group_by(pl.col("product").alias("product_name")).agg(pl.col("sales").sum())
+        assert_frame_equal(df.data, pl_df, check_row_order=False)
+
     def test_group_by_mixed_column_types(self, sales_data):
         """Test grouping with a mix of string columns and expressions."""
         sales_with_date = sales_data.with_columns(


### PR DESCRIPTION
This pull request improves support for column aliasing in group-by operations and adds new tests to ensure correct behavior when using renamed group keys. The main updates involve capturing column aliases in the aggregation schema and verifying that group-by operations with renamed columns produce the expected results.

Enhancements to group-by alias handling:

* Modified the `_process_group_columns` method in `group_frame.py` to capture and store the alias (`new_name`) when a group-by key is renamed using `.alias()`, ensuring that both the original and new column names are tracked in the aggregation schema.

Expanded group-by alias test coverage:

* Added `test_group_by_rename_group_keys_count` and `test_group_by_rename_group_keys_agg` in `test_group_frame.py` to verify that group-by operations using column aliases behave identically to the underlying Polars implementation, both for counting and aggregation.