### PR TITLE
Improve load settings

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
@@ -1628,12 +1628,17 @@ class FlowNode:
                 data=[],
             )
 
-    def get_node_data(self, flow_id: int, include_example: bool = False) -> NodeData:
+    def get_node_data(self, flow_id: int, include_example: bool = False, include_output: bool = True) -> NodeData:
         """Gathers all necessary data for representing the node in the UI.
 
         Args:
             flow_id: The ID of the parent flow.
             include_example: If True, includes data samples.
+            include_output: If True, computes this node's own output preview
+                (``main_output``). The settings panel only needs the input
+                schemas, so callers that just open settings pass False to skip
+                the potentially expensive output-schema prediction (e.g. a pivot
+                must materialize data to determine its output columns).
 
         Returns:
             A `NodeData` object.
@@ -1651,7 +1656,7 @@ class FlowNode:
             node.left_input = self.left_input.get_table_example()
         if self.right_input:
             node.right_input = self.right_input.get_table_example()
-        if self.is_setup:
+        if self.is_setup and include_output:
             node.main_output = self.get_table_example(include_example)
         node = setting_generator.get_setting_generator(self.node_type)(node)
 

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -1268,14 +1268,21 @@ def preview_dynamic_rename(request: DynamicRenamePreviewRequest) -> DynamicRenam
 
 
 @router.get("/node", response_model=output_model.NodeData, tags=["editor"])
-def get_node(flow_id: int, node_id: int, get_data: bool = False):
-    """Retrieves the complete state and data preview for a single node."""
+def get_node(flow_id: int, node_id: int, get_data: bool = False, include_output: bool = True):
+    """Retrieves the complete state and data preview for a single node.
+
+    When ``include_output`` is False the node's own output preview
+    (``main_output``) is skipped. The settings panel only needs the input
+    schemas, and computing the output can be expensive for data-dependent nodes
+    (e.g. a pivot must materialize data to determine its output columns), so the
+    editor opens settings with ``include_output=false`` for an instant response.
+    """
     logging.info(f"Getting node {node_id} from flow {flow_id}")
     flow = flow_file_handler.get_flow(flow_id)
     node = flow.get_node(node_id)
     if node is None:
         raise HTTPException(422, "Not found")
-    v = node.get_node_data(flow_id=flow.flow_id, include_example=get_data)
+    v = node.get_node_data(flow_id=flow.flow_id, include_example=get_data, include_output=include_output)
     return v
 
 

--- a/flowfile_core/tests/test_endpoints.py
+++ b/flowfile_core/tests/test_endpoints.py
@@ -25,6 +25,7 @@ from flowfile_core.routes.routes import (
     output_model,
 )
 from flowfile_core.schemas import cloud_storage_schemas as cloud_ss
+from flowfile_core.schemas import transform_schema
 from flowfile_core.schemas.transform_schema import SelectInput
 from flowfile_core.secret_manager.secret_manager import get_encrypted_secret
 from shared.storage_config import storage
@@ -1199,6 +1200,60 @@ def test_python_script_node_data_before_run():
     assert node_data.main_output is not None
     assert node_data.main_output.columns == ["name", "city"], "Predicted schema should pass through input columns"
     assert node_data.main_output.data == [], "Node data should be empty before run"
+
+
+def test_get_node_skips_output_schema_when_not_requested():
+    """Opening node settings can skip the node's own output preview (`main_output`).
+
+    For data-dependent nodes like pivot, predicting the output columns requires
+    materializing data — work the settings panel never needs, since it only uses
+    the input schemas. `include_output=false` must skip it; the default and an
+    explicit `include_output=true` must still compute it.
+    """
+    flow_id = create_flow_with_manual_input()  # node 1: manual_input with columns ['name', 'city']
+
+    add_node(flow_id, 2, node_type="pivot", pos_x=200, pos_y=0)
+    connection = input_schema.NodeConnection.create_from_simple_input(1, 2)
+    connect_node(flow_id, connection)
+
+    pivot_settings = input_schema.NodePivot(
+        flow_id=flow_id,
+        node_id=2,
+        pos_x=200,
+        pos_y=0,
+        depending_on_ids=[1],
+        pivot_input=transform_schema.PivotInput(
+            index_columns=["city"],
+            pivot_column="name",
+            value_col="name",
+            aggregations=["count"],
+        ),
+    )
+    r = client.post("/update_settings/", json=pivot_settings.model_dump(), params={"node_type": "pivot"})
+    assert r.status_code == 200
+
+    # Without include_output the expensive pivot output prediction is skipped,
+    # but the input schema the settings panel needs is still returned.
+    response = client.get("/node", params={"flow_id": flow_id, "node_id": 2, "include_output": False})
+    assert response.status_code == 200
+    node_data = output_model.NodeData(**response.json())
+    assert node_data.main_output is None, "main_output should be skipped when include_output=false"
+    assert node_data.main_input is not None, "input schema is still needed by the settings panel"
+    assert node_data.main_input.columns == ["name", "city"]
+    assert node_data.setting_input is not None
+
+    # The default and an explicit include_output=true still compute the pivoted output.
+    for params in (
+        {"flow_id": flow_id, "node_id": 2},
+        {"flow_id": flow_id, "node_id": 2, "include_output": True},
+    ):
+        response = client.get("/node", params=params)
+        assert response.status_code == 200
+        node_data = output_model.NodeData(**response.json())
+        assert node_data.main_output is not None, f"main_output should be computed for params={params}"
+        # The single 'count' pivot widens unique 'name' values into columns.
+        assert "city" in node_data.main_output.columns
+        assert "John" in node_data.main_output.columns
 
 
 def test_get_node_data_after_run():

--- a/flowfile_frontend/src/renderer/app/api/node.api.ts
+++ b/flowfile_frontend/src/renderer/app/api/node.api.ts
@@ -3,11 +3,20 @@ import type { NodeData, TableExample, NodeDescriptionResponse } from "../types";
 
 export class NodeApi {
   /**
-   * Get node data for a specific node
+   * Get node data for a specific node.
+   *
+   * `includeOutput` controls whether the backend computes the node's own output
+   * preview (`main_output`). The settings panel only needs the input schemas, so
+   * it defaults to false to avoid the potentially expensive output-schema
+   * prediction (e.g. a pivot must materialize data to list its output columns).
    */
-  static async getNodeData(flowId: number, nodeId: number): Promise<NodeData> {
+  static async getNodeData(
+    flowId: number,
+    nodeId: number,
+    includeOutput = false,
+  ): Promise<NodeData> {
     const response = await axios.get<NodeData>("/node", {
-      params: { flow_id: flowId, node_id: nodeId },
+      params: { flow_id: flowId, node_id: nodeId, include_output: includeOutput },
       headers: { accept: "application/json" },
     });
     return response.data;

--- a/flowfile_frontend/src/renderer/app/components/nodes/baseNode/genericNodeSettings.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/baseNode/genericNodeSettings.vue
@@ -517,7 +517,9 @@ const loadFieldsFromSchema = async () => {
     // Give the backend a moment to process and update the schema
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    const nodeData = await nodeStore.getNodeData(props.modelValue.node_id, false);
+    // Auto-detect needs the node's computed output schema, so opt back into
+    // include_output (settings opens skip it for speed).
+    const nodeData = await nodeStore.getNodeData(props.modelValue.node_id, false, true);
 
     if (nodeData?.main_output?.table_schema) {
       outputFieldConfig.fields = nodeData.main_output.table_schema.map((col: any) => ({

--- a/flowfile_frontend/src/renderer/app/stores/node-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/node-store.ts
@@ -102,7 +102,11 @@ export const useNodeStore = defineStore("node", {
 
   actions: {
     // ========== Node Data Management ==========
-    async getNodeData(nodeId: number, useCache = true): Promise<NodeData | null> {
+    async getNodeData(
+      nodeId: number,
+      useCache = true,
+      includeOutput = false,
+    ): Promise<NodeData | null> {
       const flowStore = useFlowStore();
 
       if (this.nodeId === nodeId && useCache) {
@@ -114,7 +118,7 @@ export const useNodeStore = defineStore("node", {
 
       try {
         console.log("Getting node data");
-        const data = await NodeApi.getNodeData(flowStore.flowId, nodeId);
+        const data = await NodeApi.getNodeData(flowStore.flowId, nodeId, includeOutput);
         this.nodeData = data;
         this.isLoaded = true;
         this.nodeExists = true;


### PR DESCRIPTION
This pull request introduces an optimization to how node data is retrieved in both the backend and frontend. Specifically, it allows callers to skip computing a node's own output preview (`main_output`) when it isn't needed—such as when opening the settings panel—thereby improving performance for expensive, data-dependent nodes like pivots. The change is implemented across backend API endpoints, core logic, frontend API calls, and store usage, and is covered by new tests.

**Backend enhancements:**

- Added an `include_output` parameter to `get_node_data` in `flow_node.py` and to the `/node` API endpoint, allowing callers to control whether the node's output preview (`main_output`) is computed. When `include_output` is `False`, the output preview is skipped, significantly speeding up settings panel loads for complex nodes. [[1]](diffhunk://#diff-993e18bf8895e3f28e1f3af04ced412bcc607f860061c12acd43dc2d71183106L1631-R1641) [[2]](diffhunk://#diff-993e18bf8895e3f28e1f3af04ced412bcc607f860061c12acd43dc2d71183106L1654-R1659) [[3]](diffhunk://#diff-32e613ce2488a56db7b959c15d488a566e528efc483b772c3582b5e7992358aaL1271-R1285)

**Testing improvements:**

- Added a test (`test_get_node_skips_output_schema_when_not_requested`) to ensure that the backend correctly skips or computes the output preview based on the `include_output` parameter, validating both the fast-path and default/explicit computation cases.

**Frontend integration:**

- Updated the `NodeApi.getNodeData` method and all related calls to accept an `includeOutput` parameter, defaulting to `false` for settings panels to avoid unnecessary computation, but allowing opt-in when the output schema is required (e.g., for auto-detect features). [[1]](diffhunk://#diff-d8e8adc963575a5b0da916376a7a2a88f7e4c2f513f5ebe0e887db250e9639bdL6-R19) [[2]](diffhunk://#diff-954143b391ececc777d6adf4d9579c5141c0d0e68ab00ae9d7238056aa6a8764L105-R109) [[3]](diffhunk://#diff-954143b391ececc777d6adf4d9579c5141c0d0e68ab00ae9d7238056aa6a8764L117-R121) [[4]](diffhunk://#diff-cb18d8796513a2f1c58433fdbcc69ed6f91326d658916f781f831818fe9bcc05L520-R522)

These changes together make the node settings panel more responsive, especially for nodes where output schema prediction is expensive, while still supporting cases where the output preview is needed.