### PR TITLE
Optional demo catalog (daily FX sync) + local REST execution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,12 @@ build/
 **/build/
 **/dist/
 
+# Rust / Tauri build artifacts (src-tauri/target can be multiple GB)
+target/
+**/target/
+flowfile_frontend/src-tauri/target/
+flowfile_frontend/src-tauri/gen/
+
 # Node.js
 node_modules/
 **/node_modules/

--- a/flowfile/flowfile/__init__.py
+++ b/flowfile/flowfile/__init__.py
@@ -12,7 +12,7 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("Flowfile")
 except PackageNotFoundError:
-    __version__ = "0.12.0"
+    __version__ = "0.12.1"
 
 import logging
 import os

--- a/flowfile/flowfile/__main__.py
+++ b/flowfile/flowfile/__main__.py
@@ -150,7 +150,9 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="FlowFile: A visual ETL tool with a Polars-like API")
-    parser.add_argument("command", nargs="?", choices=["run"], help="Command to execute")
+    parser.add_argument(
+        "command", nargs="?", choices=["run", "seed-demo", "remove-demo"], help="Command to execute"
+    )
     parser.add_argument("component", nargs="?", choices=["ui", "core", "worker", "flow"], help="Component to run")
     parser.add_argument("file_path", nargs="?", help="Path to flow file (for 'flow' component)")
     parser.add_argument("--host", default="127.0.0.1", help="Host to bind the server to")
@@ -191,6 +193,13 @@ def main():
                 print("Usage: flowfile run flow <path-to-flow-file>", file=sys.stderr)
                 sys.exit(1)
             sys.exit(run_flow(args.file_path, param_overrides=args.params, run_id=args.run_id))
+    elif args.command in ("seed-demo", "remove-demo"):
+        from flowfile_core.catalog.demo_seed import remove_demo_catalog, seed_demo_catalog
+
+        if args.command == "seed-demo":
+            print(f"Demo catalog seeded: {seed_demo_catalog()}")
+        else:
+            print(f"Demo catalog removed: {remove_demo_catalog()}")
     else:
         from importlib.metadata import PackageNotFoundError, version
 
@@ -207,6 +216,10 @@ def main():
         print("")
         print("  # Run a flow from a file")
         print("  flowfile run flow my_pipeline.yaml")
+        print("")
+        print("  # Load or remove the optional demo catalog")
+        print("  flowfile seed-demo")
+        print("  flowfile remove-demo")
         print("")
         print("  # Advanced: Run individual components")
         print("  flowfile run core  # Start only the core service")

--- a/flowfile_core/flowfile_core/catalog/demo_flows/demo_fx_sync.yaml
+++ b/flowfile_core/flowfile_core/catalog/demo_flows/demo_fx_sync.yaml
@@ -1,0 +1,295 @@
+flowfile_version: 0.12.0
+flowfile_id: 920001
+flowfile_name: demo_fx_sync
+flowfile_settings:
+  description: Daily ECB foreign-exchange rates from frankfurter.app
+  execution_mode: Performance
+  execution_location: local
+  auto_save: false
+  show_detailed_progress: true
+  max_parallel_workers: 4
+  source_registration_id: null
+  parameters: []
+nodes:
+- id: 1
+  type: rest_api_reader
+  is_start_node: true
+  description: Fetch latest USD FX rates
+  node_reference: null
+  x_position: 0
+  y_position: 175
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: null
+  outputs: [2]
+  output_handles: [output-0]
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    rest_api_settings:
+      url: https://api.frankfurter.app/latest?base=USD
+      method: GET
+      headers: {}
+      query_params: {}
+      json_body: null
+      auth:
+        auth_type: none
+        api_key_name: X-API-Key
+        api_key_location: header
+        basic_username: ''
+        secret_name: ''
+        secret: null
+      pagination:
+        pagination_type: none
+        offset_param: offset
+        limit_param: limit
+        page_size: 100
+        page_param: page
+        start_page: 1
+        cursor_param: cursor
+        cursor_location: body
+        cursor_response_path: ''
+        initial_cursor: ''
+        max_pages: 1000
+        max_records: null
+        page_delay_seconds: 0.0
+      record_path: ''
+      timeout_seconds: 30.0
+      max_retries: 3
+    fields: null
+- id: 2
+  type: select
+  is_start_node: false
+  description: Rename major currencies
+  node_reference: null
+  x_position: 200
+  y_position: 175
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [1]
+  outputs: [3]
+  output_handles: [output-0]
+  setting_input:
+    cache_results: false
+    keep_missing: false
+    select_input:
+    - old_name: date
+    - old_name: rates.GBP
+      new_name: GBP
+    - old_name: rates.JPY
+      new_name: JPY
+    - old_name: rates.CHF
+      new_name: CHF
+    - old_name: rates.AUD
+      new_name: AUD
+    - old_name: rates.CAD
+      new_name: CAD
+    - old_name: rates.CNY
+      new_name: CNY
+    - old_name: amount
+    - old_name: base
+    - old_name: rates.BRL
+    - old_name: rates.CZK
+    - old_name: rates.DKK
+    - old_name: rates.HKD
+    - old_name: rates.HUF
+    - old_name: rates.IDR
+    - old_name: rates.ILS
+    - old_name: rates.INR
+    - old_name: rates.ISK
+    - old_name: rates.KRW
+    - old_name: rates.MXN
+    - old_name: rates.MYR
+    - old_name: rates.NOK
+    - old_name: rates.NZD
+    - old_name: rates.PHP
+    - old_name: rates.PLN
+    - old_name: rates.RON
+    - old_name: rates.SEK
+    - old_name: rates.SGD
+    - old_name: rates.THB
+    - old_name: rates.TRY
+    - old_name: rates.USD
+    - old_name: rates.ZAR
+    sorted_by: none
+- id: 3
+  type: unpivot
+  is_start_node: false
+  description: Currencies to long format
+  node_reference: null
+  x_position: 400
+  y_position: 175
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [2]
+  outputs: [9]
+  output_handles: [output-0]
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    unpivot_input:
+      index_columns: [date, amount]
+      value_columns: []
+      data_type_selector: numeric
+      data_type_selector_mode: data_type
+- id: 9
+  type: filter
+  is_start_node: false
+  description: variable != amount
+  node_reference: null
+  x_position: 600
+  y_position: 175
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [3]
+  outputs: [4]
+  output_handles: [output-0]
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    filter_input:
+      mode: basic
+      basic_filter:
+        field: variable
+        operator: not_equals
+        value: amount
+        value2: null
+        filter_type: null
+        filter_value: null
+      advanced_filter: ''
+      filter_type: null
+    split_mode: false
+- id: 4
+  type: select
+  is_start_node: false
+  description: Name currency/rate columns
+  node_reference: null
+  x_position: 800
+  y_position: 175
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [9]
+  outputs: [8, 6]
+  output_handles: [output-0, output-0]
+  setting_input:
+    cache_results: false
+    keep_missing: false
+    select_input:
+    - old_name: date
+    - old_name: variable
+      new_name: currency
+    - old_name: amount
+    - old_name: value
+      new_name: rate
+    sorted_by: none
+- id: 8
+  type: formula
+  is_start_node: false
+  description: date = to_date([date])
+  node_reference: null
+  x_position: 1000
+  y_position: 250
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [4]
+  outputs: [5]
+  output_handles: [output-0]
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    function:
+      field:
+        name: date
+        data_type: Datetime
+      function: to_date([date])
+- id: 5
+  type: catalog_writer
+  is_start_node: false
+  description: Upsert into fx_rates
+  node_reference: null
+  x_position: 1200
+  y_position: 100
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [8]
+  outputs: []
+  output_handles: []
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    catalog_write_settings:
+      table_name: fx_rates
+      namespace_id: 7
+      description: Daily USD exchange rates for major currencies (ECB via frankfurter.app)
+      write_mode: upsert
+      merge_keys: [date, currency]
+      partition_by: []
+- id: 6
+  type: group_by
+  is_start_node: false
+  description: Per-date sync stats
+  node_reference: null
+  x_position: 1000
+  y_position: 100
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [4]
+  outputs: [7]
+  output_handles: [output-0]
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    groupby_input:
+      agg_cols:
+      - old_name: date
+        agg: groupby
+        new_name: date
+        output_type: null
+      - old_name: currency
+        agg: count
+        new_name: currencies
+        output_type: Int64
+      - old_name: rate
+        agg: min
+        new_name: min_rate
+        output_type: null
+      - old_name: rate
+        agg: max
+        new_name: max_rate
+        output_type: null
+      - old_name: rate
+        agg: mean
+        new_name: avg_rate
+        output_type: Float64
+- id: 7
+  type: catalog_writer
+  is_start_node: false
+  description: Upsert into fx_sync_log
+  node_reference: null
+  x_position: 1200
+  y_position: 250
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [6]
+  outputs: []
+  output_handles: []
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    catalog_write_settings:
+      table_name: fx_sync_log
+      namespace_id: 7
+      description: 'Daily FX sync log: currency count and rate stats per sync date'
+      write_mode: upsert
+      merge_keys: [date]
+      partition_by: []
+groups: []

--- a/flowfile_core/flowfile_core/catalog/demo_flows/demo_sales_by_region.yaml
+++ b/flowfile_core/flowfile_core/catalog/demo_flows/demo_sales_by_region.yaml
@@ -1,0 +1,94 @@
+flowfile_version: 0.12.0
+flowfile_id: 920002
+flowfile_name: demo_sales_by_region
+flowfile_settings:
+  description: Aggregate the demo sales table into revenue per region
+  execution_mode: Performance
+  execution_location: local
+  auto_save: false
+  show_detailed_progress: true
+  max_parallel_workers: 4
+  source_registration_id: null
+  parameters: []
+nodes:
+- id: 1
+  type: catalog_reader
+  is_start_node: true
+  description: Read demo sales table
+  node_reference: null
+  x_position: 0
+  y_position: 100
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: null
+  outputs: [2]
+  output_handles: [output-0]
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    catalog_table_id: null
+    catalog_full_table_name: sales_analytics.sales
+    catalog_table_name: null
+    catalog_namespace_id: null
+    delta_version: null
+    sql_query: null
+    is_virtual_optimized: null
+- id: 2
+  type: group_by
+  is_start_node: false
+  description: Revenue per region
+  node_reference: null
+  x_position: 200
+  y_position: 100
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [1]
+  outputs: [3]
+  output_handles: [output-0]
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    groupby_input:
+      agg_cols:
+      - old_name: region
+        agg: groupby
+        new_name: region
+        output_type: null
+      - old_name: unit_price
+        agg: count
+        new_name: order_count
+        output_type: Int64
+      - old_name: amount
+        agg: sum
+        new_name: total_revenue
+        output_type: null
+      - old_name: amount
+        agg: mean
+        new_name: avg_order_value
+        output_type: Float64
+- id: 3
+  type: catalog_writer
+  is_start_node: false
+  description: Write sales_by_region
+  node_reference: null
+  x_position: 400
+  y_position: 100
+  group_id: null
+  left_input_id: null
+  right_input_id: null
+  input_ids: [2]
+  outputs: []
+  output_handles: []
+  setting_input:
+    cache_results: false
+    output_field_config: null
+    catalog_write_settings:
+      table_name: sales_by_region
+      namespace_id: 6
+      description: Revenue per region, derived from the demo sales table
+      write_mode: overwrite
+      merge_keys: []
+      partition_by: []
+groups: []

--- a/flowfile_core/flowfile_core/catalog/demo_seed.py
+++ b/flowfile_core/flowfile_core/catalog/demo_seed.py
@@ -1,0 +1,313 @@
+"""Optional demo catalog: one-call seed and one-call teardown.
+
+Seeds a self-contained ``Demo`` catalog (sample tables under ``sales_analytics`` plus
+a daily FX-sync flow under ``market``) and removes it as a single subtree. Idempotent.
+"""
+
+import datetime
+import logging
+import random
+from pathlib import Path
+
+import polars as pl
+
+from flowfile_core.catalog import CatalogService
+from flowfile_core.catalog.repository import SQLAlchemyCatalogRepository
+from flowfile_core.database.connection import get_db_context
+from flowfile_core.flowfile.catalog_helpers import register_python_editor_flow
+from flowfile_core.flowfile.flow_data_engine.sample_data import create_fake_data
+from flowfile_core.flowfile.flow_graph import FlowGraph, add_connection
+from flowfile_core.schemas import input_schema, schemas, transform_schema
+from shared.storage_config import storage
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["seed_demo_catalog", "remove_demo_catalog"]
+
+DEMO_CATALOG = "Demo"
+SCHEMA_ANALYTICS = "sales_analytics"
+SCHEMA_MARKET = "market"
+
+FX_FLOW_NAME = "Daily FX Sync"
+FX_TABLE = "fx_rates"
+FX_FLOW_ID = 920001
+FX_URL = "https://api.frankfurter.app/latest?base=USD"
+FX_CRON = "0 6 * * *"
+
+# Flattened Frankfurter response (rates.<CUR> columns) -> long (date, base, currency, rate).
+FX_RESHAPE_CODE = """
+output_df = (
+    input_df
+    .unpivot(index="date", on=cs.starts_with("rates."), variable_name="currency", value_name="rate")
+    .with_columns(
+        col("currency").str.strip_prefix("rates."),
+        col("date").str.to_date(),
+        lit("USD").alias("base"),
+        col("rate").cast(Float64),
+    )
+    .select(["date", "base", "currency", "rate"])
+)
+"""
+
+
+def _ensure_namespace(service, repo, db, name, parent_id, owner_id, description):
+    """Get-or-create a public namespace, mirroring init_db's seeded containers."""
+    existing = repo.get_namespace_by_name(name, parent_id)
+    if existing is not None:
+        return existing
+    ns = service.create_namespace(name=name, owner_id=owner_id, parent_id=parent_id, description=description)
+    ns.is_public = True
+    db.commit()
+    db.refresh(ns)
+    return ns
+
+
+def _register_delta_table(service, df, *, name, namespace_id, owner_id, description):
+    """Write ``df`` as a managed Delta table and register it. Idempotent by name."""
+    if any(t.name == name for t in service.list_tables(namespace_id=namespace_id)):
+        return False
+    table_dir = storage.catalog_tables_directory / f"demo_{name}"
+    df.write_delta(str(table_dir), mode="overwrite")
+    schema = [{"name": c, "dtype": str(dt)} for c, dt in df.schema.items()]
+    size_bytes = sum(p.stat().st_size for p in table_dir.rglob("*") if p.is_file())
+    service.register_table_from_data(
+        name=name,
+        table_path=str(table_dir),
+        owner_id=owner_id,
+        namespace_id=namespace_id,
+        description=description,
+        storage_format="delta",
+        schema=schema,
+        row_count=df.height,
+        column_count=df.width,
+        size_bytes=size_bytes,
+    )
+    return True
+
+
+def _gen_regions() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "region": ["North", "South", "East", "West", "Central"],
+            "region_name": [
+                "Northern Territory",
+                "Southern District",
+                "Eastern Division",
+                "Western Region",
+                "Central Hub",
+            ],
+            "manager": ["Sarah Chen", "Michael Torres", "Jennifer Park", "Robert Kim", "Aisha Mensah"],
+            "target_sales": [150000, 120000, 180000, 100000, 140000],
+            "bonus_rate": [0.12, 0.10, 0.15, 0.08, 0.11],
+        }
+    )
+
+
+def _gen_products() -> pl.DataFrame:
+    rows = [
+        (1, "Laptop Pro 15", "Electronics", 1299.99),
+        (2, "Wireless Headphones", "Electronics", 149.99),
+        (3, "Ergonomic Chair", "Furniture", 449.99),
+        (4, "Standing Desk", "Furniture", 599.99),
+        (5, "4K Monitor", "Electronics", 399.99),
+        (6, "Mechanical Keyboard", "Electronics", 119.99),
+        (7, "Desk Lamp", "Home", 39.99),
+        (8, "Notebook Set", "Office", 14.99),
+        (9, "Coffee Maker", "Home", 89.99),
+        (10, "Webcam HD", "Electronics", 79.99),
+        (11, "Office Plant", "Home", 24.99),
+        (12, "Whiteboard", "Office", 64.99),
+    ]
+    return pl.DataFrame(rows, schema=["product_id", "product", "category", "unit_price"], orient="row")
+
+
+def _gen_customers(n: int = 500) -> pl.DataFrame:
+    fake = create_fake_data(n_records=n)
+    return fake.with_row_index("customer_id", offset=1).select(
+        "customer_id",
+        pl.col("Name").alias("name"),
+        pl.col("City").alias("city"),
+        pl.col("Country").alias("country"),
+        pl.col("Email").alias("email"),
+    )
+
+
+def _gen_sales(customers: pl.DataFrame, products: pl.DataFrame, regions: pl.DataFrame, n: int = 300) -> pl.DataFrame:
+    rng = random.Random(42)
+    cust_ids = customers["customer_id"].to_list()
+    prods = products.to_dicts()
+    regs = regions["region"].to_list()
+    statuses = ["Completed", "Completed", "Completed", "Pending", "Cancelled"]
+    today = datetime.date.today()
+    rows = []
+    for i in range(n):
+        p = rng.choice(prods)
+        qty = rng.randint(1, 8)
+        rows.append(
+            {
+                "order_id": 1000 + i,
+                "order_date": today - datetime.timedelta(days=rng.randint(0, 90)),
+                "customer_id": rng.choice(cust_ids),
+                "product": p["product"],
+                "category": p["category"],
+                "quantity": qty,
+                "unit_price": p["unit_price"],
+                "amount": round(qty * p["unit_price"], 2),
+                "region": rng.choice(regs),
+                "status": rng.choice(statuses),
+            }
+        )
+    return pl.DataFrame(rows)
+
+
+def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> FlowGraph:
+    """Build the FX-sync flow graph: REST read -> reshape -> catalog upsert."""
+    flow_settings = schemas.FlowSettings(
+        flow_id=FX_FLOW_ID,
+        name=FX_FLOW_NAME,
+        path=str(flow_path),
+        description="Daily ECB foreign-exchange rates from frankfurter.app",
+        track_history=False,
+    )
+    graph = FlowGraph(flow_settings=flow_settings)
+    graph.flow_settings.execution_location = "local"
+
+    graph.add_rest_api_reader(
+        input_schema.NodeRestApiReader(
+            flow_id=FX_FLOW_ID,
+            node_id=1,
+            user_id=user_id,
+            description="Fetch latest USD FX rates",
+            rest_api_settings=input_schema.RestApiSettings(url=FX_URL, method="GET", record_path=""),
+        )
+    )
+    graph.add_polars_code(
+        input_schema.NodePolarsCode(
+            flow_id=FX_FLOW_ID,
+            node_id=2,
+            user_id=user_id,
+            depending_on_ids=[1],
+            description="Reshape rates to long format",
+            polars_code_input=transform_schema.PolarsCodeInput(polars_code=FX_RESHAPE_CODE),
+        )
+    )
+    graph.add_catalog_writer(
+        input_schema.NodeCatalogWriter(
+            flow_id=FX_FLOW_ID,
+            node_id=3,
+            user_id=user_id,
+            depending_on_id=2,
+            description=f"Upsert into {FX_TABLE}",
+            catalog_write_settings=input_schema.CatalogWriteSettings(
+                table_name=FX_TABLE,
+                namespace_id=market_namespace_id,
+                write_mode="upsert",
+                merge_keys=["date", "currency"],
+                description="Daily USD foreign-exchange rates (ECB via frankfurter.app)",
+            ),
+        )
+    )
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2, "main"))
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(2, 3, "main"))
+    return graph
+
+
+def seed_demo_catalog(user_id: int = 1) -> dict:
+    """Create the demo catalog (static tables + daily FX-sync flow). Idempotent."""
+    summary: dict = {"tables_created": [], "flow_registration_id": None, "schedule_id": None, "fx_populate": "skipped"}
+
+    with get_db_context() as db:
+        repo = SQLAlchemyCatalogRepository(db)
+        service = CatalogService(repo)
+
+        demo = _ensure_namespace(service, repo, db, DEMO_CATALOG, None, user_id, "Sample datasets for exploration")
+        analytics = _ensure_namespace(
+            service, repo, db, SCHEMA_ANALYTICS, demo.id, user_id, "Sample sales and customer data"
+        )
+        market = _ensure_namespace(service, repo, db, SCHEMA_MARKET, demo.id, user_id, "Daily-synced market data")
+        market_id = market.id
+
+        regions = _gen_regions()
+        products = _gen_products()
+        customers = _gen_customers()
+        sales = _gen_sales(customers, products, regions)
+        static_tables = [
+            ("regions", regions, "Sales regions with targets and managers"),
+            ("products", products, "Product catalog with prices"),
+            ("customers", customers, "Sample customer records"),
+            ("sales", sales, "Sample order transactions over the last 90 days"),
+        ]
+        for name, df, desc in static_tables:
+            if _register_delta_table(
+                service, df, name=name, namespace_id=analytics.id, owner_id=user_id, description=desc
+            ):
+                summary["tables_created"].append(name)
+
+    fx_flow_path = storage.python_editor_flows_directory / "demo_fx_sync.yaml"
+    graph = _build_fx_flow(user_id, market_id, fx_flow_path)
+    reg_id = register_python_editor_flow(
+        graph, name=FX_FLOW_NAME, namespace_id=market_id, flow_path=str(fx_flow_path), user_id=user_id
+    )
+    summary["flow_registration_id"] = reg_id
+
+    with get_db_context() as db:
+        service = CatalogService(SQLAlchemyCatalogRepository(db))
+        existing = service.list_schedules(registration_id=reg_id)
+        if existing:
+            schedule_id = existing[0].id
+        else:
+            sched = service.create_schedule(
+                registration_id=reg_id,
+                owner_id=user_id,
+                schedule_type="cron",
+                cron_expression=FX_CRON,
+                cron_timezone="UTC",
+                name=FX_FLOW_NAME,
+                description="Daily FX rate sync",
+            )
+            schedule_id = sched.id
+        summary["schedule_id"] = schedule_id
+
+        # Best-effort immediate populate; never fail the seed.
+        try:
+            service.trigger_schedule_now(schedule_id, user_id)
+            summary["fx_populate"] = "triggered"
+        except Exception:
+            logger.info("Immediate FX populate skipped", exc_info=True)
+
+    logger.info("Demo catalog seeded: %s", summary)
+    return summary
+
+
+def remove_demo_catalog(user_id: int = 1) -> dict:
+    """Remove everything under the ``Demo`` catalog (tables, flows, schedules, namespaces)."""
+    summary: dict = {"removed": False, "tables": 0, "flows": 0, "schedules": 0, "namespaces": 0}
+
+    with get_db_context() as db:
+        repo = SQLAlchemyCatalogRepository(db)
+        service = CatalogService(repo)
+
+        demo = repo.get_namespace_by_name(DEMO_CATALOG, None)
+        if demo is None:
+            return summary
+
+        schemas_under = repo.list_child_namespaces(demo.id)
+        for schema in schemas_under:
+            for flow in service.list_flows(user_id, namespace_id=schema.id):
+                for sched in service.list_schedules(registration_id=flow.id):
+                    service.delete_schedule(sched.id)
+                    summary["schedules"] += 1
+                service.delete_flow(flow.id, delete_file=True)
+                summary["flows"] += 1
+            for table in service.list_tables(namespace_id=schema.id):
+                service.delete_table(table.id, delete_file=True)
+                summary["tables"] += 1
+            service.delete_namespace(schema.id)
+            summary["namespaces"] += 1
+
+        service.delete_namespace(demo.id)
+        summary["namespaces"] += 1
+        summary["removed"] = True
+
+    logger.info("Demo catalog removed: %s", summary)
+    return summary

--- a/flowfile_core/flowfile_core/catalog/demo_seed.py
+++ b/flowfile_core/flowfile_core/catalog/demo_seed.py
@@ -30,6 +30,7 @@ SCHEMA_MARKET = "market"
 
 FX_FLOW_NAME = "Daily FX Sync"
 FX_TABLE = "fx_rates"
+FX_LOG_TABLE = "fx_sync_log"
 FX_FLOW_ID = 920001
 FX_URL = "https://api.frankfurter.app/latest?base=USD"
 FX_CRON = "0 6 * * *"
@@ -153,7 +154,7 @@ def _gen_sales(customers: pl.DataFrame, products: pl.DataFrame, regions: pl.Data
 
 
 def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> FlowGraph:
-    """Build the FX-sync flow graph: REST read -> select (rename/drop) -> catalog upsert."""
+    """Build the FX-sync flow: REST read -> select majors -> unpivot to long -> catalog upsert."""
     flow_settings = schemas.FlowSettings(
         flow_id=FX_FLOW_ID,
         name=FX_FLOW_NAME,
@@ -187,24 +188,85 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
             select_input=select_input,
         )
     )
-    graph.add_catalog_writer(
-        input_schema.NodeCatalogWriter(
+    graph.add_unpivot(
+        input_schema.NodeUnpivot(
             flow_id=FX_FLOW_ID,
             node_id=3,
             user_id=user_id,
             depending_on_id=2,
+            description="Currencies to long format",
+            unpivot_input=transform_schema.UnpivotInput(index_columns=["date"], value_columns=list(FX_CURRENCIES)),
+        )
+    )
+    graph.add_select(
+        input_schema.NodeSelect(
+            flow_id=FX_FLOW_ID,
+            node_id=4,
+            user_id=user_id,
+            depending_on_id=3,
+            keep_missing=False,
+            description="Name currency/rate columns",
+            select_input=[
+                transform_schema.SelectInput(old_name="date", new_name="date", keep=True, position=0),
+                transform_schema.SelectInput(old_name="variable", new_name="currency", keep=True, position=1),
+                transform_schema.SelectInput(old_name="value", new_name="rate", keep=True, position=2),
+            ],
+        )
+    )
+    graph.add_catalog_writer(
+        input_schema.NodeCatalogWriter(
+            flow_id=FX_FLOW_ID,
+            node_id=5,
+            user_id=user_id,
+            depending_on_id=4,
             description=f"Upsert into {FX_TABLE}",
             catalog_write_settings=input_schema.CatalogWriteSettings(
                 table_name=FX_TABLE,
                 namespace_id=market_namespace_id,
                 write_mode="upsert",
-                merge_keys=["date"],
+                merge_keys=["date", "currency"],
                 description="Daily USD exchange rates for major currencies (ECB via frankfurter.app)",
             ),
         )
     )
-    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2, "main"))
-    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(2, 3, "main"))
+    # Second output: a per-sync stats row that accumulates into a log over days.
+    graph.add_group_by(
+        input_schema.NodeGroupBy(
+            flow_id=FX_FLOW_ID,
+            node_id=6,
+            user_id=user_id,
+            depending_on_id=4,
+            description="Per-date sync stats",
+            groupby_input=transform_schema.GroupByInput(
+                agg_cols=[
+                    transform_schema.AggColl("date", "groupby", "date"),
+                    transform_schema.AggColl("currency", "count", "currencies"),
+                    transform_schema.AggColl("rate", "min", "min_rate"),
+                    transform_schema.AggColl("rate", "max", "max_rate"),
+                    transform_schema.AggColl("rate", "mean", "avg_rate"),
+                ]
+            ),
+        )
+    )
+    graph.add_catalog_writer(
+        input_schema.NodeCatalogWriter(
+            flow_id=FX_FLOW_ID,
+            node_id=7,
+            user_id=user_id,
+            depending_on_id=6,
+            description=f"Upsert into {FX_LOG_TABLE}",
+            catalog_write_settings=input_schema.CatalogWriteSettings(
+                table_name=FX_LOG_TABLE,
+                namespace_id=market_namespace_id,
+                write_mode="upsert",
+                merge_keys=["date"],
+                description="Daily FX sync log: currency count and rate stats per sync date",
+            ),
+        )
+    )
+    for a, b in ((1, 2), (2, 3), (3, 4), (4, 5), (4, 6), (6, 7)):
+        add_connection(graph, input_schema.NodeConnection.create_from_simple_input(a, b, "main"))
+    graph.apply_layout()
     return graph
 
 
@@ -264,6 +326,7 @@ def _build_sales_flow(user_id: int, analytics_namespace_id: int, flow_path: Path
     )
     add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2, "main"))
     add_connection(graph, input_schema.NodeConnection.create_from_simple_input(2, 3, "main"))
+    graph.apply_layout()
     return graph
 
 

--- a/flowfile_core/flowfile_core/catalog/demo_seed.py
+++ b/flowfile_core/flowfile_core/catalog/demo_seed.py
@@ -154,7 +154,12 @@ def _gen_sales(customers: pl.DataFrame, products: pl.DataFrame, regions: pl.Data
 
 
 def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> FlowGraph:
-    """Build the FX-sync flow: REST read -> select majors -> unpivot to long -> catalog upsert."""
+    """Build the FX-sync flow.
+
+    REST read -> select majors -> unpivot (numeric) -> filter -> name columns,
+    then two outputs: a date-cast long ``fx_rates`` table and a ``fx_sync_log``
+    stats row per sync date.
+    """
     flow_settings = schemas.FlowSettings(
         flow_id=FX_FLOW_ID,
         name=FX_FLOW_NAME,
@@ -174,9 +179,11 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
             rest_api_settings=input_schema.RestApiSettings(url=FX_URL, method="GET", record_path=""),
         )
     )
-    select_input = [transform_schema.SelectInput(old_name="date", new_name="date", keep=True, position=0)]
-    for i, cur in enumerate(FX_CURRENCIES, start=1):
-        select_input.append(transform_schema.SelectInput(old_name=f"rates.{cur}", new_name=cur, keep=True, position=i))
+    majors = [
+        transform_schema.SelectInput(old_name="date", new_name="date", keep=True),
+        transform_schema.SelectInput(old_name="amount", new_name="amount", keep=True),
+    ]
+    majors += [transform_schema.SelectInput(old_name=f"rates.{c}", new_name=c, keep=True) for c in FX_CURRENCIES]
     graph.add_select(
         input_schema.NodeSelect(
             flow_id=FX_FLOW_ID,
@@ -185,7 +192,7 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
             depending_on_id=1,
             keep_missing=False,
             description="Keep date + major currencies",
-            select_input=select_input,
+            select_input=majors,
         )
     )
     graph.add_unpivot(
@@ -195,7 +202,24 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
             user_id=user_id,
             depending_on_id=2,
             description="Currencies to long format",
-            unpivot_input=transform_schema.UnpivotInput(index_columns=["date"], value_columns=list(FX_CURRENCIES)),
+            unpivot_input=transform_schema.UnpivotInput(
+                index_columns=["date", "amount"],
+                data_type_selector="numeric",
+                data_type_selector_mode="data_type",
+            ),
+        )
+    )
+    graph.add_filter(
+        input_schema.NodeFilter(
+            flow_id=FX_FLOW_ID,
+            node_id=9,
+            user_id=user_id,
+            depending_on_id=3,
+            description="variable != amount",
+            filter_input=transform_schema.FilterInput(
+                mode="basic",
+                basic_filter=transform_schema.BasicFilter(field="variable", operator="not_equals", value="amount"),
+            ),
         )
     )
     graph.add_select(
@@ -203,22 +227,36 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
             flow_id=FX_FLOW_ID,
             node_id=4,
             user_id=user_id,
-            depending_on_id=3,
+            depending_on_id=9,
             keep_missing=False,
             description="Name currency/rate columns",
             select_input=[
-                transform_schema.SelectInput(old_name="date", new_name="date", keep=True, position=0),
-                transform_schema.SelectInput(old_name="variable", new_name="currency", keep=True, position=1),
-                transform_schema.SelectInput(old_name="value", new_name="rate", keep=True, position=2),
+                transform_schema.SelectInput(old_name="date", new_name="date", keep=True),
+                transform_schema.SelectInput(old_name="variable", new_name="currency", keep=True),
+                transform_schema.SelectInput(old_name="value", new_name="rate", keep=True),
             ],
         )
     )
+    graph.add_formula(
+        input_schema.NodeFormula(
+            flow_id=FX_FLOW_ID,
+            node_id=8,
+            user_id=user_id,
+            depending_on_id=4,
+            description="date = to_date([date])",
+            function=transform_schema.FunctionInput(
+                field=transform_schema.FieldInput(name="date", data_type="Datetime"),
+                function="to_date([date])",
+            ),
+        )
+    )
+    # Output 1: the long fx_rates table (date cast to a real date).
     graph.add_catalog_writer(
         input_schema.NodeCatalogWriter(
             flow_id=FX_FLOW_ID,
             node_id=5,
             user_id=user_id,
-            depending_on_id=4,
+            depending_on_id=8,
             description=f"Upsert into {FX_TABLE}",
             catalog_write_settings=input_schema.CatalogWriteSettings(
                 table_name=FX_TABLE,
@@ -229,7 +267,7 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
             ),
         )
     )
-    # Second output: a per-sync stats row that accumulates into a log over days.
+    # Output 2: a per-sync stats row that accumulates into a log over days.
     graph.add_group_by(
         input_schema.NodeGroupBy(
             flow_id=FX_FLOW_ID,
@@ -264,7 +302,7 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
             ),
         )
     )
-    for a, b in ((1, 2), (2, 3), (3, 4), (4, 5), (4, 6), (6, 7)):
+    for a, b in ((1, 2), (2, 3), (3, 9), (9, 4), (4, 8), (8, 5), (4, 6), (6, 7)):
         add_connection(graph, input_schema.NodeConnection.create_from_simple_input(a, b, "main"))
     graph.apply_layout()
     return graph

--- a/flowfile_core/flowfile_core/catalog/demo_seed.py
+++ b/flowfile_core/flowfile_core/catalog/demo_seed.py
@@ -38,34 +38,8 @@ SALES_FLOW_NAME = "Sales by Region"
 SALES_FLOW_ID = 920002
 SALES_SUMMARY_TABLE = "sales_by_region"
 
-# Flattened Frankfurter response (rates.<CUR> columns) -> long (date, base, currency, rate).
-FX_RESHAPE_CODE = """
-output_df = (
-    input_df
-    .unpivot(index="date", on=cs.starts_with("rates."), variable_name="currency", value_name="rate")
-    .with_columns(
-        col("currency").str.strip_prefix("rates."),
-        col("date").str.to_date(),
-        lit("USD").alias("base"),
-        col("rate").cast(Float64),
-    )
-    .select(["date", "base", "currency", "rate"])
-)
-"""
-
-# Aggregate the demo sales table into revenue per region.
-SALES_AGG_CODE = """
-output_df = (
-    input_df
-    .group_by("region")
-    .agg(
-        pl.len().alias("order_count"),
-        col("amount").sum().round(2).alias("total_revenue"),
-        col("amount").mean().round(2).alias("avg_order_value"),
-    )
-    .sort("total_revenue", descending=True)
-)
-"""
+# Major currencies present in the frankfurter.app USD-base response.
+FX_CURRENCIES = ["GBP", "JPY", "CHF", "AUD", "CAD", "CNY"]
 
 
 def _ensure_namespace(service, repo, db, name, parent_id, owner_id, description):
@@ -179,7 +153,7 @@ def _gen_sales(customers: pl.DataFrame, products: pl.DataFrame, regions: pl.Data
 
 
 def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> FlowGraph:
-    """Build the FX-sync flow graph: REST read -> reshape -> catalog upsert."""
+    """Build the FX-sync flow graph: REST read -> select (rename/drop) -> catalog upsert."""
     flow_settings = schemas.FlowSettings(
         flow_id=FX_FLOW_ID,
         name=FX_FLOW_NAME,
@@ -199,14 +173,18 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
             rest_api_settings=input_schema.RestApiSettings(url=FX_URL, method="GET", record_path=""),
         )
     )
-    graph.add_polars_code(
-        input_schema.NodePolarsCode(
+    select_input = [transform_schema.SelectInput(old_name="date", new_name="date", keep=True, position=0)]
+    for i, cur in enumerate(FX_CURRENCIES, start=1):
+        select_input.append(transform_schema.SelectInput(old_name=f"rates.{cur}", new_name=cur, keep=True, position=i))
+    graph.add_select(
+        input_schema.NodeSelect(
             flow_id=FX_FLOW_ID,
             node_id=2,
             user_id=user_id,
-            depending_on_ids=[1],
-            description="Reshape rates to long format",
-            polars_code_input=transform_schema.PolarsCodeInput(polars_code=FX_RESHAPE_CODE),
+            depending_on_id=1,
+            keep_missing=False,
+            description="Keep date + major currencies",
+            select_input=select_input,
         )
     )
     graph.add_catalog_writer(
@@ -220,8 +198,8 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
                 table_name=FX_TABLE,
                 namespace_id=market_namespace_id,
                 write_mode="upsert",
-                merge_keys=["date", "currency"],
-                description="Daily USD foreign-exchange rates (ECB via frankfurter.app)",
+                merge_keys=["date"],
+                description="Daily USD exchange rates for major currencies (ECB via frankfurter.app)",
             ),
         )
     )
@@ -252,14 +230,21 @@ def _build_sales_flow(user_id: int, analytics_namespace_id: int, flow_path: Path
             description="Read demo sales table",
         )
     )
-    graph.add_polars_code(
-        input_schema.NodePolarsCode(
+    graph.add_group_by(
+        input_schema.NodeGroupBy(
             flow_id=SALES_FLOW_ID,
             node_id=2,
             user_id=user_id,
-            depending_on_ids=[1],
-            description="Aggregate revenue per region",
-            polars_code_input=transform_schema.PolarsCodeInput(polars_code=SALES_AGG_CODE),
+            depending_on_id=1,
+            description="Revenue per region",
+            groupby_input=transform_schema.GroupByInput(
+                agg_cols=[
+                    transform_schema.AggColl("region", "groupby", "region"),
+                    transform_schema.AggColl("unit_price", "count", "order_count"),
+                    transform_schema.AggColl("amount", "sum", "total_revenue"),
+                    transform_schema.AggColl("amount", "mean", "avg_order_value"),
+                ]
+            ),
         )
     )
     graph.add_catalog_writer(

--- a/flowfile_core/flowfile_core/catalog/demo_seed.py
+++ b/flowfile_core/flowfile_core/catalog/demo_seed.py
@@ -34,6 +34,10 @@ FX_FLOW_ID = 920001
 FX_URL = "https://api.frankfurter.app/latest?base=USD"
 FX_CRON = "0 6 * * *"
 
+SALES_FLOW_NAME = "Sales by Region"
+SALES_FLOW_ID = 920002
+SALES_SUMMARY_TABLE = "sales_by_region"
+
 # Flattened Frankfurter response (rates.<CUR> columns) -> long (date, base, currency, rate).
 FX_RESHAPE_CODE = """
 output_df = (
@@ -46,6 +50,20 @@ output_df = (
         col("rate").cast(Float64),
     )
     .select(["date", "base", "currency", "rate"])
+)
+"""
+
+# Aggregate the demo sales table into revenue per region.
+SALES_AGG_CODE = """
+output_df = (
+    input_df
+    .group_by("region")
+    .agg(
+        pl.len().alias("order_count"),
+        col("amount").sum().round(2).alias("total_revenue"),
+        col("amount").mean().round(2).alias("avg_order_value"),
+    )
+    .sort("total_revenue", descending=True)
 )
 """
 
@@ -212,9 +230,67 @@ def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> F
     return graph
 
 
+def _build_sales_flow(user_id: int, analytics_namespace_id: int, flow_path: Path) -> FlowGraph:
+    """Build the sales-summary flow: read demo sales -> aggregate -> catalog write."""
+    flow_settings = schemas.FlowSettings(
+        flow_id=SALES_FLOW_ID,
+        name=SALES_FLOW_NAME,
+        path=str(flow_path),
+        description="Aggregate the demo sales table into revenue per region",
+        track_history=False,
+    )
+    graph = FlowGraph(flow_settings=flow_settings)
+    graph.flow_settings.execution_location = "local"
+
+    graph.add_catalog_reader(
+        input_schema.NodeCatalogReader(
+            flow_id=SALES_FLOW_ID,
+            node_id=1,
+            user_id=user_id,
+            catalog_table_name="sales",
+            catalog_namespace_id=analytics_namespace_id,
+            description="Read demo sales table",
+        )
+    )
+    graph.add_polars_code(
+        input_schema.NodePolarsCode(
+            flow_id=SALES_FLOW_ID,
+            node_id=2,
+            user_id=user_id,
+            depending_on_ids=[1],
+            description="Aggregate revenue per region",
+            polars_code_input=transform_schema.PolarsCodeInput(polars_code=SALES_AGG_CODE),
+        )
+    )
+    graph.add_catalog_writer(
+        input_schema.NodeCatalogWriter(
+            flow_id=SALES_FLOW_ID,
+            node_id=3,
+            user_id=user_id,
+            depending_on_id=2,
+            description=f"Write {SALES_SUMMARY_TABLE}",
+            catalog_write_settings=input_schema.CatalogWriteSettings(
+                table_name=SALES_SUMMARY_TABLE,
+                namespace_id=analytics_namespace_id,
+                write_mode="overwrite",
+                description="Revenue per region, derived from the demo sales table",
+            ),
+        )
+    )
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2, "main"))
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(2, 3, "main"))
+    return graph
+
+
 def seed_demo_catalog(user_id: int = 1) -> dict:
     """Create the demo catalog (static tables + daily FX-sync flow). Idempotent."""
-    summary: dict = {"tables_created": [], "flow_registration_id": None, "schedule_id": None, "fx_populate": "skipped"}
+    summary: dict = {
+        "tables_created": [],
+        "flow_registration_id": None,
+        "sales_flow_registration_id": None,
+        "schedule_id": None,
+        "fx_populate": "skipped",
+    }
 
     with get_db_context() as db:
         repo = SQLAlchemyCatalogRepository(db)
@@ -226,6 +302,7 @@ def seed_demo_catalog(user_id: int = 1) -> dict:
         )
         market = _ensure_namespace(service, repo, db, SCHEMA_MARKET, demo.id, user_id, "Daily-synced market data")
         market_id = market.id
+        analytics_id = analytics.id
 
         regions = _gen_regions()
         products = _gen_products()
@@ -242,6 +319,19 @@ def seed_demo_catalog(user_id: int = 1) -> dict:
                 service, df, name=name, namespace_id=analytics.id, owner_id=user_id, description=desc
             ):
                 summary["tables_created"].append(name)
+
+    # Sales-by-region flow: reads the demo sales table and writes an aggregated
+    # summary table. Source data is static, so it just runs once at seed time.
+    sales_flow_path = storage.python_editor_flows_directory / "demo_sales_by_region.yaml"
+    sales_graph = _build_sales_flow(user_id, analytics_id, sales_flow_path)
+    summary["sales_flow_registration_id"] = register_python_editor_flow(
+        sales_graph, name=SALES_FLOW_NAME, namespace_id=analytics_id, flow_path=str(sales_flow_path), user_id=user_id
+    )
+    try:
+        sales_graph.execution_location = "local"
+        sales_graph.run_graph()
+    except Exception:
+        logger.info("Sales-by-region populate skipped", exc_info=True)
 
     fx_flow_path = storage.python_editor_flows_directory / "demo_fx_sync.yaml"
     graph = _build_fx_flow(user_id, market_id, fx_flow_path)

--- a/flowfile_core/flowfile_core/catalog/demo_seed.py
+++ b/flowfile_core/flowfile_core/catalog/demo_seed.py
@@ -1,7 +1,10 @@
 """Optional demo catalog: one-call seed and one-call teardown.
 
-Seeds a self-contained ``Demo`` catalog (sample tables under ``sales_analytics`` plus
-a daily FX-sync flow under ``market``) and removes it as a single subtree. Idempotent.
+Seeds a self-contained ``Demo`` catalog: sample tables under ``sales_analytics``
+plus two flows imported from the bundled YAML in ``demo_flows/`` (a daily FX sync
+under ``market`` and a sales-by-region summary under ``sales_analytics``). The
+flows are the source of truth — edit the YAML, not Python. Removes the whole
+``Demo`` subtree in one call. Idempotent.
 """
 
 import datetime
@@ -16,8 +19,7 @@ from flowfile_core.catalog.repository import SQLAlchemyCatalogRepository
 from flowfile_core.database.connection import get_db_context
 from flowfile_core.flowfile.catalog_helpers import register_python_editor_flow
 from flowfile_core.flowfile.flow_data_engine.sample_data import create_fake_data
-from flowfile_core.flowfile.flow_graph import FlowGraph, add_connection
-from flowfile_core.schemas import input_schema, schemas, transform_schema
+from flowfile_core.flowfile.manage.io_flowfile import open_flow
 from shared.storage_config import storage
 
 logger = logging.getLogger(__name__)
@@ -29,18 +31,10 @@ SCHEMA_ANALYTICS = "sales_analytics"
 SCHEMA_MARKET = "market"
 
 FX_FLOW_NAME = "Daily FX Sync"
-FX_TABLE = "fx_rates"
-FX_LOG_TABLE = "fx_sync_log"
-FX_FLOW_ID = 920001
-FX_URL = "https://api.frankfurter.app/latest?base=USD"
 FX_CRON = "0 6 * * *"
-
 SALES_FLOW_NAME = "Sales by Region"
-SALES_FLOW_ID = 920002
-SALES_SUMMARY_TABLE = "sales_by_region"
 
-# Major currencies present in the frankfurter.app USD-base response.
-FX_CURRENCIES = ["GBP", "JPY", "CHF", "AUD", "CAD", "CNY"]
+DEMO_FLOWS_DIR = Path(__file__).parent / "demo_flows"
 
 
 def _ensure_namespace(service, repo, db, name, parent_id, owner_id, description):
@@ -153,227 +147,31 @@ def _gen_sales(customers: pl.DataFrame, products: pl.DataFrame, regions: pl.Data
     return pl.DataFrame(rows)
 
 
-def _build_fx_flow(user_id: int, market_namespace_id: int, flow_path: Path) -> FlowGraph:
-    """Build the FX-sync flow.
+def _import_demo_flow(yaml_name: str, name: str, namespace_id: int, user_id: int):
+    """Load a bundled demo flow, repoint its catalog writers, register it.
 
-    REST read -> select majors -> unpivot (numeric) -> filter -> name columns,
-    then two outputs: a date-cast long ``fx_rates`` table and a ``fx_sync_log``
-    stats row per sync date.
+    Catalog *readers* resolve by full table name at load time (namespace-id
+    independent); catalog *writers* resolve their target at run time, so
+    repointing ``namespace_id`` after load is enough. Returns ``(registration_id, flow)``.
     """
-    flow_settings = schemas.FlowSettings(
-        flow_id=FX_FLOW_ID,
-        name=FX_FLOW_NAME,
-        path=str(flow_path),
-        description="Daily ECB foreign-exchange rates from frankfurter.app",
-        track_history=False,
+    flow = open_flow(DEMO_FLOWS_DIR / yaml_name, user_id=user_id)
+    flow.flow_settings.execution_location = "local"
+    for node in flow.nodes:
+        if node.node_type == "catalog_writer":
+            node.setting_input.catalog_write_settings.namespace_id = namespace_id
+    flow_path = storage.python_editor_flows_directory / yaml_name
+    reg_id = register_python_editor_flow(
+        flow, name=name, namespace_id=namespace_id, flow_path=str(flow_path), user_id=user_id
     )
-    graph = FlowGraph(flow_settings=flow_settings)
-    graph.flow_settings.execution_location = "local"
-
-    graph.add_rest_api_reader(
-        input_schema.NodeRestApiReader(
-            flow_id=FX_FLOW_ID,
-            node_id=1,
-            user_id=user_id,
-            description="Fetch latest USD FX rates",
-            rest_api_settings=input_schema.RestApiSettings(url=FX_URL, method="GET", record_path=""),
-        )
-    )
-    majors = [
-        transform_schema.SelectInput(old_name="date", new_name="date", keep=True),
-        transform_schema.SelectInput(old_name="amount", new_name="amount", keep=True),
-    ]
-    majors += [transform_schema.SelectInput(old_name=f"rates.{c}", new_name=c, keep=True) for c in FX_CURRENCIES]
-    graph.add_select(
-        input_schema.NodeSelect(
-            flow_id=FX_FLOW_ID,
-            node_id=2,
-            user_id=user_id,
-            depending_on_id=1,
-            keep_missing=False,
-            description="Keep date + major currencies",
-            select_input=majors,
-        )
-    )
-    graph.add_unpivot(
-        input_schema.NodeUnpivot(
-            flow_id=FX_FLOW_ID,
-            node_id=3,
-            user_id=user_id,
-            depending_on_id=2,
-            description="Currencies to long format",
-            unpivot_input=transform_schema.UnpivotInput(
-                index_columns=["date", "amount"],
-                data_type_selector="numeric",
-                data_type_selector_mode="data_type",
-            ),
-        )
-    )
-    graph.add_filter(
-        input_schema.NodeFilter(
-            flow_id=FX_FLOW_ID,
-            node_id=9,
-            user_id=user_id,
-            depending_on_id=3,
-            description="variable != amount",
-            filter_input=transform_schema.FilterInput(
-                mode="basic",
-                basic_filter=transform_schema.BasicFilter(field="variable", operator="not_equals", value="amount"),
-            ),
-        )
-    )
-    graph.add_select(
-        input_schema.NodeSelect(
-            flow_id=FX_FLOW_ID,
-            node_id=4,
-            user_id=user_id,
-            depending_on_id=9,
-            keep_missing=False,
-            description="Name currency/rate columns",
-            select_input=[
-                transform_schema.SelectInput(old_name="date", new_name="date", keep=True),
-                transform_schema.SelectInput(old_name="variable", new_name="currency", keep=True),
-                transform_schema.SelectInput(old_name="value", new_name="rate", keep=True),
-            ],
-        )
-    )
-    graph.add_formula(
-        input_schema.NodeFormula(
-            flow_id=FX_FLOW_ID,
-            node_id=8,
-            user_id=user_id,
-            depending_on_id=4,
-            description="date = to_date([date])",
-            function=transform_schema.FunctionInput(
-                field=transform_schema.FieldInput(name="date", data_type="Datetime"),
-                function="to_date([date])",
-            ),
-        )
-    )
-    # Output 1: the long fx_rates table (date cast to a real date).
-    graph.add_catalog_writer(
-        input_schema.NodeCatalogWriter(
-            flow_id=FX_FLOW_ID,
-            node_id=5,
-            user_id=user_id,
-            depending_on_id=8,
-            description=f"Upsert into {FX_TABLE}",
-            catalog_write_settings=input_schema.CatalogWriteSettings(
-                table_name=FX_TABLE,
-                namespace_id=market_namespace_id,
-                write_mode="upsert",
-                merge_keys=["date", "currency"],
-                description="Daily USD exchange rates for major currencies (ECB via frankfurter.app)",
-            ),
-        )
-    )
-    # Output 2: a per-sync stats row that accumulates into a log over days.
-    graph.add_group_by(
-        input_schema.NodeGroupBy(
-            flow_id=FX_FLOW_ID,
-            node_id=6,
-            user_id=user_id,
-            depending_on_id=4,
-            description="Per-date sync stats",
-            groupby_input=transform_schema.GroupByInput(
-                agg_cols=[
-                    transform_schema.AggColl("date", "groupby", "date"),
-                    transform_schema.AggColl("currency", "count", "currencies"),
-                    transform_schema.AggColl("rate", "min", "min_rate"),
-                    transform_schema.AggColl("rate", "max", "max_rate"),
-                    transform_schema.AggColl("rate", "mean", "avg_rate"),
-                ]
-            ),
-        )
-    )
-    graph.add_catalog_writer(
-        input_schema.NodeCatalogWriter(
-            flow_id=FX_FLOW_ID,
-            node_id=7,
-            user_id=user_id,
-            depending_on_id=6,
-            description=f"Upsert into {FX_LOG_TABLE}",
-            catalog_write_settings=input_schema.CatalogWriteSettings(
-                table_name=FX_LOG_TABLE,
-                namespace_id=market_namespace_id,
-                write_mode="upsert",
-                merge_keys=["date"],
-                description="Daily FX sync log: currency count and rate stats per sync date",
-            ),
-        )
-    )
-    for a, b in ((1, 2), (2, 3), (3, 9), (9, 4), (4, 8), (8, 5), (4, 6), (6, 7)):
-        add_connection(graph, input_schema.NodeConnection.create_from_simple_input(a, b, "main"))
-    graph.apply_layout()
-    return graph
-
-
-def _build_sales_flow(user_id: int, analytics_namespace_id: int, flow_path: Path) -> FlowGraph:
-    """Build the sales-summary flow: read demo sales -> aggregate -> catalog write."""
-    flow_settings = schemas.FlowSettings(
-        flow_id=SALES_FLOW_ID,
-        name=SALES_FLOW_NAME,
-        path=str(flow_path),
-        description="Aggregate the demo sales table into revenue per region",
-        track_history=False,
-    )
-    graph = FlowGraph(flow_settings=flow_settings)
-    graph.flow_settings.execution_location = "local"
-
-    graph.add_catalog_reader(
-        input_schema.NodeCatalogReader(
-            flow_id=SALES_FLOW_ID,
-            node_id=1,
-            user_id=user_id,
-            catalog_table_name="sales",
-            catalog_namespace_id=analytics_namespace_id,
-            description="Read demo sales table",
-        )
-    )
-    graph.add_group_by(
-        input_schema.NodeGroupBy(
-            flow_id=SALES_FLOW_ID,
-            node_id=2,
-            user_id=user_id,
-            depending_on_id=1,
-            description="Revenue per region",
-            groupby_input=transform_schema.GroupByInput(
-                agg_cols=[
-                    transform_schema.AggColl("region", "groupby", "region"),
-                    transform_schema.AggColl("unit_price", "count", "order_count"),
-                    transform_schema.AggColl("amount", "sum", "total_revenue"),
-                    transform_schema.AggColl("amount", "mean", "avg_order_value"),
-                ]
-            ),
-        )
-    )
-    graph.add_catalog_writer(
-        input_schema.NodeCatalogWriter(
-            flow_id=SALES_FLOW_ID,
-            node_id=3,
-            user_id=user_id,
-            depending_on_id=2,
-            description=f"Write {SALES_SUMMARY_TABLE}",
-            catalog_write_settings=input_schema.CatalogWriteSettings(
-                table_name=SALES_SUMMARY_TABLE,
-                namespace_id=analytics_namespace_id,
-                write_mode="overwrite",
-                description="Revenue per region, derived from the demo sales table",
-            ),
-        )
-    )
-    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2, "main"))
-    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(2, 3, "main"))
-    graph.apply_layout()
-    return graph
+    return reg_id, flow
 
 
 def seed_demo_catalog(user_id: int = 1) -> dict:
-    """Create the demo catalog (static tables + daily FX-sync flow). Idempotent."""
+    """Create the demo catalog (static tables + imported flows). Idempotent."""
     summary: dict = {
         "tables_created": [],
-        "flow_registration_id": None,
         "sales_flow_registration_id": None,
+        "fx_flow_registration_id": None,
         "schedule_id": None,
         "fx_populate": "skipped",
     }
@@ -406,34 +204,26 @@ def seed_demo_catalog(user_id: int = 1) -> dict:
             ):
                 summary["tables_created"].append(name)
 
-    # Sales-by-region flow: reads the demo sales table and writes an aggregated
-    # summary table. Source data is static, so it just runs once at seed time.
-    sales_flow_path = storage.python_editor_flows_directory / "demo_sales_by_region.yaml"
-    sales_graph = _build_sales_flow(user_id, analytics_id, sales_flow_path)
-    summary["sales_flow_registration_id"] = register_python_editor_flow(
-        sales_graph, name=SALES_FLOW_NAME, namespace_id=analytics_id, flow_path=str(sales_flow_path), user_id=user_id
-    )
+    # Sales-by-region flow: reads the (now-registered) demo sales table; static
+    # source, so just run it once at seed time.
+    sales_reg, sales_flow = _import_demo_flow("demo_sales_by_region.yaml", SALES_FLOW_NAME, analytics_id, user_id)
+    summary["sales_flow_registration_id"] = sales_reg
     try:
-        sales_graph.execution_location = "local"
-        sales_graph.run_graph()
+        sales_flow.run_graph()
     except Exception:
         logger.info("Sales-by-region populate skipped", exc_info=True)
 
-    fx_flow_path = storage.python_editor_flows_directory / "demo_fx_sync.yaml"
-    graph = _build_fx_flow(user_id, market_id, fx_flow_path)
-    reg_id = register_python_editor_flow(
-        graph, name=FX_FLOW_NAME, namespace_id=market_id, flow_path=str(fx_flow_path), user_id=user_id
-    )
-    summary["flow_registration_id"] = reg_id
-
+    # Daily FX sync flow: schedule it and trigger an immediate first run.
+    fx_reg, _ = _import_demo_flow("demo_fx_sync.yaml", FX_FLOW_NAME, market_id, user_id)
+    summary["fx_flow_registration_id"] = fx_reg
     with get_db_context() as db:
         service = CatalogService(SQLAlchemyCatalogRepository(db))
-        existing = service.list_schedules(registration_id=reg_id)
+        existing = service.list_schedules(registration_id=fx_reg)
         if existing:
             schedule_id = existing[0].id
         else:
             sched = service.create_schedule(
-                registration_id=reg_id,
+                registration_id=fx_reg,
                 owner_id=user_id,
                 schedule_type="cron",
                 cron_expression=FX_CRON,
@@ -467,8 +257,7 @@ def remove_demo_catalog(user_id: int = 1) -> dict:
         if demo is None:
             return summary
 
-        schemas_under = repo.list_child_namespaces(demo.id)
-        for schema in schemas_under:
+        for schema in repo.list_child_namespaces(demo.id):
             for flow in service.list_flows(user_id, namespace_id=schema.id):
                 for sched in service.list_schedules(registration_id=flow.id):
                     service.delete_schedule(sched.id)

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -4140,15 +4140,18 @@ class FlowGraph:
             return resolve_auth_secret_encrypted(auth, node_rest_api_reader.user_id)
 
         def _func() -> FlowDataEngine:
-            # All fetching happens in the worker; the core only orchestrates.
-            fetcher = ExternalRestApiFetcher(
-                build_rest_api_worker_settings(node_rest_api_reader, _resolve_secret_encrypted()),
-                wait_on_completion=False,
-            )
-            node._fetch_cached_df = fetcher
-            # ``get_result()`` returns a ``pl.LazyFrame`` deserialised from the
-            # worker's Arrow IPC file — never collect on the core service.
-            fl = FlowDataEngine(fetcher.get_result())
+            encrypted = _resolve_secret_encrypted()
+            worker_settings = build_rest_api_worker_settings(node_rest_api_reader, encrypted)
+            if self.execution_location == "local":
+                # No worker service in local runs — fetch in-process (cf. add_database_reader).
+                from shared.rest_api.fetch import fetch_rest_api
+
+                secret = decrypt_secret(encrypted).get_secret_value() if encrypted else None
+                fl = FlowDataEngine(fetch_rest_api(worker_settings, secret=secret).lazy())
+            else:
+                fetcher = ExternalRestApiFetcher(worker_settings, wait_on_completion=False)
+                node._fetch_cached_df = fetcher
+                fl = FlowDataEngine(fetcher.get_result())
             cols = schema_callback()
             # Align to the sampled schema (if any) so downstream nodes see stable
             # columns; with no sample yet, the fetched frame defines the schema.

--- a/flowfile_core/flowfile_core/routes/catalog.py
+++ b/flowfile_core/flowfile_core/routes/catalog.py
@@ -207,6 +207,27 @@ def handle_catalog_exceptions(**overrides: str):
     return decorator
 
 
+# Demo catalog (optional, one-click seed/teardown)
+
+
+@router.post("/seed-demo", tags=["demo"])
+@handle_catalog_exceptions()
+def seed_demo(current_user=Depends(get_current_active_user)):
+    """Populate the optional ``Demo`` catalog (sample tables + daily FX-sync flow)."""
+    from flowfile_core.catalog.demo_seed import seed_demo_catalog
+
+    return seed_demo_catalog(user_id=current_user.id)
+
+
+@router.post("/remove-demo", tags=["demo"])
+@handle_catalog_exceptions()
+def remove_demo(current_user=Depends(get_current_active_user)):
+    """Remove the ``Demo`` catalog and everything under it."""
+    from flowfile_core.catalog.demo_seed import remove_demo_catalog
+
+    return remove_demo_catalog(user_id=current_user.id)
+
+
 @router.get("/namespaces", response_model=list[NamespaceOut])
 def list_namespaces(
     parent_id: int | None = None,

--- a/flowfile_core/tests/flowfile/test_rest_api_reader.py
+++ b/flowfile_core/tests/flowfile/test_rest_api_reader.py
@@ -2,8 +2,8 @@
 
 Covers schema inference from a sample, credential resolution (stored secret by
 name, or inline plaintext), worker-settings construction, and node execution.
-All fetching is offloaded to the worker, so execution is tested with a mocked
-``ExternalRestApiFetcher`` — the core never makes an HTTP call.
+Local flows fetch in-process (mocked ``fetch_rest_api``); remote flows offload to
+the worker (mocked ``ExternalRestApiFetcher``) — the core never makes a real HTTP call.
 """
 
 from __future__ import annotations
@@ -51,7 +51,7 @@ def _add_reader(graph: FlowGraph, node: input_schema.NodeRestApiReader) -> None:
 
 
 class _FakeFetcher:
-    """Stands in for ExternalRestApiFetcher so the core never hits the worker/network."""
+    """Stands in for ExternalRestApiFetcher (remote/worker path) so the core never hits the worker/network."""
 
     last: dict = {}
     result = pl.LazyFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
@@ -61,6 +61,19 @@ class _FakeFetcher:
 
     def get_result(self):
         return _FakeFetcher.result
+
+
+def _patch_local_fetch(monkeypatch, result: pl.DataFrame) -> dict:
+    """Patch the in-process fetch engine (local execution path); returns a dict capturing the call."""
+    captured: dict = {}
+
+    def _fake(settings, *, secret=None):
+        captured["settings"] = settings
+        captured["secret"] = secret
+        return result
+
+    monkeypatch.setattr("shared.rest_api.fetch.fetch_rest_api", _fake)
+    return captured
 
 
 # --- schema inference ---------------------------------------------------------
@@ -145,14 +158,43 @@ def test_add_reader_clears_inline_plaintext_and_registers_node():
     assert registered.name == "rest_api_reader"
 
 
-# --- execution (worker-only, mocked fetcher) ---------------------------------
+# --- execution (local in-process / remote worker, both mocked) ---------------
 
 
-def test_execution_uses_worker_fetcher_and_stamps_schema(monkeypatch):
+def test_execution_local_fetches_in_process_and_stamps_schema(monkeypatch):
+    """Local execution fetches in-process via ``fetch_rest_api`` (no worker) and stamps the schema."""
+
+    def _no_worker(*args, **kwargs):
+        raise AssertionError("local execution must not use the worker fetcher")
+
+    monkeypatch.setattr(flow_graph_module, "ExternalRestApiFetcher", _no_worker)
+    captured = _patch_local_fetch(monkeypatch, pl.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]}))
+
+    graph = _graph(execution_location="local")
+    node = _make_node(
+        url="https://x/api",
+        auth=input_schema.RestApiAuthSettings(auth_type="bearer", secret="tok"),
+        pagination=input_schema.RestApiPaginationSettings(pagination_type="offset", page_size=2),
+    )
+    _add_reader(graph, node)
+
+    df = graph.get_node(1).get_resulting_data().data_frame.collect()
+
+    assert captured["settings"].url == "https://x/api"
+    assert captured["settings"].auth.bearer_token_encrypted is not None
+    assert captured["secret"] == "tok"  # the encrypted token is decrypted before the in-process fetch
+    assert df.height == 3
+    assert sorted(df["id"].to_list()) == [1, 2, 3]
+    assert node.fields is not None
+    assert {f.name for f in node.fields} == {"id", "name"}
+
+
+def test_execution_remote_offloads_to_worker_and_stamps_schema(monkeypatch):
+    """Remote execution offloads to the worker fetcher and stamps the schema."""
     monkeypatch.setattr(flow_graph_module, "ExternalRestApiFetcher", _FakeFetcher)
     _FakeFetcher.result = pl.LazyFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
 
-    graph = _graph(execution_location="local")  # even local must offload to the worker
+    graph = _graph(execution_location="remote")
     node = _make_node(
         url="https://x/api",
         auth=input_schema.RestApiAuthSettings(auth_type="bearer", secret="tok"),
@@ -171,8 +213,7 @@ def test_execution_uses_worker_fetcher_and_stamps_schema(monkeypatch):
 
 
 def test_execution_empty_result_returns_empty_frame(monkeypatch):
-    monkeypatch.setattr(flow_graph_module, "ExternalRestApiFetcher", _FakeFetcher)
-    _FakeFetcher.result = pl.LazyFrame({})
+    _patch_local_fetch(monkeypatch, pl.DataFrame({}))
 
     graph = _graph(execution_location="local")
     node = _make_node(url="https://x/api", record_path="items")
@@ -231,8 +272,7 @@ def test_build_worker_settings_routes_bearer_and_basic():
 def test_execution_aligns_fetched_frame_to_cached_schema(monkeypatch):
     """When the node has sampled fields, the fetched frame is aligned to them:
     a missing column is added as a typed null and column order follows the schema."""
-    monkeypatch.setattr(flow_graph_module, "ExternalRestApiFetcher", _FakeFetcher)
-    _FakeFetcher.result = pl.LazyFrame({"id": [1, 2], "name": ["a", "b"]})
+    _patch_local_fetch(monkeypatch, pl.DataFrame({"id": [1, 2], "name": ["a", "b"]}))
 
     graph = _graph(execution_location="local")
     node = _make_node(url="https://x/api")
@@ -248,13 +288,12 @@ def test_execution_aligns_fetched_frame_to_cached_schema(monkeypatch):
     assert df["extra"].null_count() == 2
 
 
-def test_read_api_builds_graph_and_executes_via_worker(monkeypatch):
+def test_read_api_builds_graph_and_executes_locally(monkeypatch):
     """``flowfile_frame.read_api`` coerces auth/pagination, builds the node, and
-    materialises through the (faked) worker fetcher — no real HTTP, no live worker."""
+    materialises in-process — read_api graphs are local, so no real HTTP, no live worker."""
     import flowfile_frame as ff
 
-    monkeypatch.setattr(flow_graph_module, "ExternalRestApiFetcher", _FakeFetcher)
-    _FakeFetcher.result = pl.LazyFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]})
+    captured = _patch_local_fetch(monkeypatch, pl.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"]}))
 
     frame = ff.read_api(
         "https://x/api",
@@ -265,7 +304,7 @@ def test_read_api_builds_graph_and_executes_via_worker(monkeypatch):
 
     assert df.height == 3
     assert sorted(df["id"].to_list()) == [1, 2, 3]
-    settings = _FakeFetcher.last["settings"]
+    settings = captured["settings"]
     assert settings.url == "https://x/api"
     assert settings.auth.bearer_token_encrypted is not None
     assert settings.pagination.pagination_type.value == "offset"

--- a/flowfile_frame/flowfile_frame/__init__.py
+++ b/flowfile_frame/flowfile_frame/__init__.py
@@ -156,4 +156,4 @@ DataFrame = FlowFrame  # Alias for compatibility with generated code
 try:
     __version__ = version("Flowfile")
 except PackageNotFoundError:
-    __version__ = "0.12.0"
+    __version__ = "0.12.1"

--- a/flowfile_frontend/package.json
+++ b/flowfile_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Flowfile",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A tool for designing and executing data flows",
   "scripts": {
     "dev": "tauri dev",

--- a/flowfile_frontend/src-tauri/Cargo.lock
+++ b/flowfile_frontend/src-tauri/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "flowfile"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/flowfile_frontend/src-tauri/Cargo.toml
+++ b/flowfile_frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowfile"
-version = "0.12.0"
+version = "0.12.1"
 description = "Flowfile — visual ETL platform"
 authors = ["Edwardvaneechoud"]
 license = "MIT"

--- a/flowfile_frontend/src-tauri/src/env.rs
+++ b/flowfile_frontend/src-tauri/src/env.rs
@@ -60,6 +60,9 @@ pub fn build_child_env(core_port: u16, worker_port: u16) -> HashMap<String, Stri
         std::process::id().to_string(),
     );
 
+    // Run the embedded scheduler in the core sidecar so recurring flows fire.
+    env_vars.insert("FLOWFILE_SCHEDULER_ENABLED".into(), "true".into());
+
     // Mirror the discovered ports into env vars so the Python configs that
     // read them at import time also see the right values (CLI args also pass
     // them, but `flowfile_worker.configs` consults env vars in spawned-child

--- a/flowfile_frontend/src-tauri/src/env.rs
+++ b/flowfile_frontend/src-tauri/src/env.rs
@@ -60,9 +60,6 @@ pub fn build_child_env(core_port: u16, worker_port: u16) -> HashMap<String, Stri
         std::process::id().to_string(),
     );
 
-    // Run the embedded scheduler in the core sidecar so recurring flows fire.
-    env_vars.insert("FLOWFILE_SCHEDULER_ENABLED".into(), "true".into());
-
     // Mirror the discovered ports into env vars so the Python configs that
     // read them at import time also see the right values (CLI args also pass
     // them, but `flowfile_worker.configs` consults env vars in spawned-child

--- a/flowfile_frontend/src-tauri/tauri.conf.json
+++ b/flowfile_frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Flowfile",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "identifier": "com.flowfile.app",
   "build": {
     "frontendDist": "../build/renderer",

--- a/flowfile_frontend/src/renderer/app/api/catalog.api.ts
+++ b/flowfile_frontend/src/renderer/app/api/catalog.api.ts
@@ -570,4 +570,16 @@ export class CatalogApi {
   static async deleteDashboard(id: number): Promise<void> {
     await axios.delete(`/catalog/dashboards/${id}`);
   }
+
+  // ====== Demo catalog ======
+
+  static async seedDemoCatalog(): Promise<Record<string, unknown>> {
+    const response = await axios.post<Record<string, unknown>>("/catalog/seed-demo");
+    return response.data;
+  }
+
+  static async removeDemoCatalog(): Promise<Record<string, unknown>> {
+    const response = await axios.post<Record<string, unknown>>("/catalog/remove-demo");
+    return response.data;
+  }
 }

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/groupBy/GroupBy.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/groupBy/GroupBy.vue
@@ -129,6 +129,7 @@ const aggOptions: (AggOption | GroupByOption)[] = [
   "groupby",
   "sum",
   "max",
+  "mean",
   "median",
   "min",
   "count",
@@ -248,6 +249,7 @@ interface SingleColumnAggOption {
 const singleColumnAggOptions: SingleColumnAggOption[] = [
   { value: "count", label: "Count" },
   { value: "max", label: "Max" },
+  { value: "mean", label: "Mean" },
   { value: "median", label: "Median" },
   { value: "min", label: "Min" },
   { value: "sum", label: "Sum" },

--- a/flowfile_frontend/src/renderer/app/composables/useRecentFlows.test.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useRecentFlows.test.ts
@@ -175,4 +175,19 @@ describe("useRecentFlows", () => {
 
     expect(recentFlows.value[0].catalogRef).toBe("General.marketing.a");
   });
+
+  it("records a catalogId when provided", () => {
+    const { recentFlows, recordFlow } = useRecentFlows();
+    recordFlow({ path: "/flows/a.yaml", name: "a", catalogRef: "General.default.a", catalogId: 7 });
+
+    expect(recentFlows.value[0].catalogId).toBe(7);
+  });
+
+  it("keeps catalogId on re-records without one", () => {
+    const { recentFlows, recordFlow } = useRecentFlows();
+    recordFlow({ path: "/flows/a.yaml", catalogId: 7 });
+    recordFlow({ path: "/flows/a.yaml" });
+
+    expect(recentFlows.value[0].catalogId).toBe(7);
+  });
 });

--- a/flowfile_frontend/src/renderer/app/composables/useRecentFlows.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useRecentFlows.ts
@@ -75,7 +75,12 @@ function persist(list: RecentFlow[]): void {
 const recentFlows = ref<RecentFlow[]>(readStored());
 
 export function useRecentFlows() {
-  function recordFlow(entry: { path: string; name?: string; catalogRef?: string }): void {
+  function recordFlow(entry: {
+    path: string;
+    name?: string;
+    catalogRef?: string;
+    catalogId?: number;
+  }): void {
     if (!entry.path) return;
     // Re-records without explicit metadata (e.g. reopening from the recents
     // list) keep the name/catalogRef/catalogId captured on the original open.
@@ -85,7 +90,7 @@ export function useRecentFlows() {
       name: entry.name || existing?.name || basenameNoExt(entry.path),
       lastOpened: Date.now(),
       catalogRef: entry.catalogRef ?? existing?.catalogRef,
-      catalogId: existing?.catalogId,
+      catalogId: entry.catalogId ?? existing?.catalogId,
     });
     persist(recentFlows.value);
   }

--- a/flowfile_frontend/src/renderer/app/features/designer/dataPreview.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/dataPreview.vue
@@ -50,6 +50,7 @@
         ref="gridComponentRef"
         :default-col-def="defaultColDef"
         :column-defs="columnDefs"
+        :suppress-field-dot-notation="true"
         class="ag-theme-balham"
         :row-data="rowData"
         :style="{ width: '100%', height: gridHeightComputed }"

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -177,7 +177,7 @@
           @view-schedule-runs="navigateToScheduleRuns"
           @toggle-favorite="catalogStore.toggleFavorite($event)"
           @toggle-follow="catalogStore.toggleFollow($event)"
-          @open-flow="openFlowInDesigner($event)"
+          @open-flow="catalogStore.selectedFlow && openFlowInDesigner(catalogStore.selectedFlow)"
           @select-table="selectTable($event)"
           @delete-flow="handleDeleteFlow($event)"
           @rename-flow="handleRenameFlow"
@@ -525,6 +525,8 @@ import VisualizationViewer from "./VisualizationViewer.vue";
 import VisualizationEditor from "./VisualizationEditor.vue";
 import ShareDialog from "../../components/sharing/ShareDialog.vue";
 import { useResourceSharing } from "../../composables/useResourceSharing";
+import { useRecentFlows } from "../../composables/useRecentFlows";
+import { findNamespacePath } from "../../types";
 import { catalogTabs } from "./catalogTabs";
 import { useGraphicWalkerAppearance } from "../../composables/useGraphicWalkerAppearance";
 import type {
@@ -544,6 +546,7 @@ const route = useRoute();
 
 const catalogStore = useCatalogStore();
 const flowStore = useFlowStore();
+const { recordFlow } = useRecentFlows();
 
 // Namespace sharing (one dialog for the whole tree).
 const { canManageGrants } = useResourceSharing();
@@ -783,7 +786,7 @@ function onFlowMenuSelect(action: string) {
   const flow = flowMenu.value?.flow;
   if (!flow) return;
   if (action === "view") selectFlow(flow.id);
-  else if (action === "open") openFlowInDesigner(flow.flow_path);
+  else if (action === "open") openFlowInDesigner(flow);
   else if (action === "runs") {
     flowDetailFocusRuns.value = true;
     selectFlow(flow.id);
@@ -1091,10 +1094,23 @@ async function openRunSnapshot(runId: number) {
   }
 }
 
-async function openFlowInDesigner(flowPath: string) {
+async function openFlowInDesigner(
+  flow: Pick<FlowRegistration, "flow_path" | "name" | "namespace_id" | "id">,
+) {
   try {
-    const flowId = await FlowApi.importFlow(flowPath);
+    const flowId = await FlowApi.importFlow(flow.flow_path);
     flowStore.setFlowId(flowId);
+    // Catalog opens were never landing in recents (the home screen looked empty
+    // in docker, where flows are opened from the catalog rather than a file
+    // dialog). Record here, building catalogRef exactly like refreshCatalogRefs.
+    const nsPath =
+      flow.namespace_id != null ? findNamespacePath(catalogStore.tree, flow.namespace_id) : [];
+    recordFlow({
+      path: flow.flow_path,
+      name: flow.name,
+      catalogRef: nsPath.length ? `${nsPath.join(".")}.${flow.name}` : undefined,
+      catalogId: flow.id,
+    });
     router.push({ name: "designer" });
   } catch (e: any) {
     ElMessage.error(e?.response?.data?.detail ?? "Failed to open flow");

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -73,11 +73,15 @@
           <div v-if="catalogStore.loading" class="loading-state">Loading...</div>
           <div v-else-if="catalogStore.tree.length === 0" class="empty-state">
             <p>No catalogs yet.</p>
-            <button class="btn-primary btn-sm" @click="showCreateNamespace = true">
-              Create your first catalog
+            <button class="btn btn-primary btn-sm" @click="showCreateNamespace = true">
+              <i class="fa-solid fa-plus"></i> Create your first catalog
             </button>
-            <button class="btn btn-ghost btn-sm" :disabled="demoBusy" @click="handleLoadDemoData">
-              Load demo data
+            <button
+              class="btn btn-secondary btn-sm"
+              :disabled="demoBusy"
+              @click="handleLoadDemoData"
+            >
+              <i class="fa-solid fa-flask"></i> Load demo data
             </button>
           </div>
           <div v-else>
@@ -463,19 +467,19 @@
           </p>
           <button
             v-if="!hasDemoCatalog"
-            class="btn-primary btn-sm"
+            class="btn btn-primary btn-sm demo-card-btn"
             :disabled="demoBusy"
             @click="handleLoadDemoData"
           >
-            Load demo data
+            <i class="fa-solid fa-flask"></i> Load demo data
           </button>
           <button
             v-else
-            class="btn btn-ghost btn-sm"
+            class="btn btn-ghost btn-sm demo-card-btn"
             :disabled="demoBusy"
             @click="handleRemoveDemoData"
           >
-            Remove demo data
+            <i class="fa-solid fa-broom"></i> Remove demo data
           </button>
         </div>
       </div>
@@ -1883,6 +1887,10 @@ onUnmounted(() => {
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
   line-height: 1.5;
+}
+
+.catalog-view .info-card .demo-card-btn {
+  margin-top: var(--spacing-3);
 }
 </style>
 

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -76,6 +76,9 @@
             <button class="btn-primary btn-sm" @click="showCreateNamespace = true">
               Create your first catalog
             </button>
+            <button class="btn btn-ghost btn-sm" :disabled="demoBusy" @click="handleLoadDemoData">
+              Load demo data
+            </button>
           </div>
           <div v-else>
             <CatalogTreeNode
@@ -449,6 +452,32 @@
             and manage schedules from the Schedules tab.
           </p>
         </div>
+        <div class="info-card">
+          <div class="info-card-header">
+            <i class="fa-solid fa-flask"></i>
+            <h4>Demo data</h4>
+          </div>
+          <p>
+            Load a self-contained <strong>Demo</strong> catalog with sample tables and a daily
+            foreign-exchange sync flow to explore Flowfile. Remove it again at any time.
+          </p>
+          <button
+            v-if="!hasDemoCatalog"
+            class="btn-primary btn-sm"
+            :disabled="demoBusy"
+            @click="handleLoadDemoData"
+          >
+            Load demo data
+          </button>
+          <button
+            v-else
+            class="btn btn-ghost btn-sm"
+            :disabled="demoBusy"
+            @click="handleRemoveDemoData"
+          >
+            Remove demo data
+          </button>
+        </div>
       </div>
     </el-dialog>
   </div>
@@ -643,6 +672,46 @@ async function refreshAll() {
     ]);
   } finally {
     refreshing.value = false;
+  }
+}
+
+// --- Demo catalog (optional sample data) ---
+
+const demoBusy = ref(false);
+const hasDemoCatalog = computed(() => catalogStore.tree.some((n) => n.name === "Demo"));
+
+async function handleLoadDemoData() {
+  demoBusy.value = true;
+  try {
+    await CatalogApi.seedDemoCatalog();
+    await refreshAll();
+    ElMessage.success("Demo catalog loaded");
+  } catch (e: any) {
+    ElMessage.error(e?.response?.data?.detail ?? "Failed to load demo data");
+  } finally {
+    demoBusy.value = false;
+  }
+}
+
+async function handleRemoveDemoData() {
+  try {
+    await ElMessageBox.confirm(
+      "This removes the Demo catalog and all of its sample tables, flows and schedules. This cannot be undone.",
+      "Remove demo data",
+      { confirmButtonText: "Remove", cancelButtonText: "Cancel", type: "warning" },
+    );
+  } catch {
+    return;
+  }
+  demoBusy.value = true;
+  try {
+    await CatalogApi.removeDemoCatalog();
+    await refreshAll();
+    ElMessage.success("Demo catalog removed");
+  } catch (e: any) {
+    ElMessage.error(e?.response?.data?.detail ?? "Failed to remove demo data");
+  } finally {
+    demoBusy.value = false;
   }
 }
 

--- a/flowfile_frontend/src/renderer/app/views/HomeView/HomeView.vue
+++ b/flowfile_frontend/src/renderer/app/views/HomeView/HomeView.vue
@@ -6,6 +6,7 @@
     @open="openDialogVisible = true"
     @browse-templates="browseTemplates"
     @open-recent="handleOpenRecent"
+    @remove-recent="handleRemoveRecent"
     @start-tutorial="handleStartTutorial"
   />
 
@@ -31,7 +32,7 @@ import { gettingStartedTutorial } from "../../components/tutorial/tutorials";
 const router = useRouter();
 const nodeStore = useNodeStore();
 const tutorialStore = useTutorialStore();
-const { recentFlows, recordFlowFromSettings, refreshCatalogRefs } = useRecentFlows();
+const { recentFlows, recordFlowFromSettings, refreshCatalogRefs, removeFlow } = useRecentFlows();
 const { openFlow } = useFlowOpener();
 
 const openDialogVisible = ref(false);
@@ -120,6 +121,9 @@ const handleOpenRecent = async (flowPath: string) => {
   const flowId = await openFlow(flowPath);
   if (flowId !== null) goToDesigner();
 };
+
+// Non-destructive: only clears the localStorage entry, never the file.
+const handleRemoveRecent = (flowPath: string) => removeFlow(flowPath);
 
 // The tutorial's data-tutorial anchors live in the designer header, so route
 // there first (mirrors Sidebar's guard).

--- a/flowfile_frontend/src/renderer/app/views/HomeView/WelcomeScreen.vue
+++ b/flowfile_frontend/src/renderer/app/views/HomeView/WelcomeScreen.vue
@@ -59,38 +59,66 @@
         <h2 class="welcome-section-title">Recent flows</h2>
         <ul v-if="recentFlows.length" class="recent-list">
           <li v-for="flow in recentFlows" :key="flow.path">
-            <el-dropdown class="recent-dropdown" trigger="contextmenu" placement="bottom-start">
-              <button class="recent-row" :title="flow.path" @click="emit('open-recent', flow.path)">
-                <i
-                  v-if="flow.catalogRef"
-                  class="fa-solid fa-folder-tree recent-icon recent-icon--catalog"
-                ></i>
-                <span v-else class="material-icons recent-icon">description</span>
-                <span class="recent-name">{{ flow.name }}</span>
-                <span class="recent-loc">
+            <el-tooltip placement="top" :show-after="400" :hide-after="0">
+              <template #content>
+                <div v-if="flow.catalogRef">{{ flow.catalogRef }}</div>
+                <div>{{ flow.path }}</div>
+              </template>
+              <el-dropdown class="recent-dropdown" trigger="contextmenu" placement="bottom-start">
+                <div
+                  class="recent-row"
+                  role="button"
+                  tabindex="0"
+                  @click="emit('open-recent', flow.path)"
+                  @keydown.enter="emit('open-recent', flow.path)"
+                  @keydown.space.prevent="emit('open-recent', flow.path)"
+                >
+                  <i
+                    v-if="flow.catalogRef"
+                    class="fa-solid fa-folder-tree recent-icon recent-icon--catalog"
+                  ></i>
+                  <span v-else class="material-icons recent-icon">description</span>
+                  <span class="recent-name">{{ displayName(flow) }}</span>
                   <span v-if="flow.catalogRef" class="recent-catalog-ref">
                     {{ flow.catalogRef }}
                   </span>
-                  <span v-else class="recent-path">{{ flow.path }}</span>
-                </span>
-                <span class="recent-time">{{ relativeTime(flow.lastOpened) }}</span>
-              </button>
-              <template #dropdown>
-                <el-dropdown-menu>
-                  <el-dropdown-item @click="emit('open-recent', flow.path)">
-                    <span class="material-icons recent-menu-icon">open_in_new</span>
-                    Open flow
-                  </el-dropdown-item>
-                  <el-dropdown-item
-                    :disabled="flow.catalogId === undefined"
-                    @click="viewInCatalog(flow)"
+                  <span v-else-if="parentFolder(flow.path)" class="recent-folder">
+                    {{ parentFolder(flow.path) }}
+                  </span>
+                  <span class="recent-time">{{ relativeTime(flow.lastOpened) }}</span>
+                  <button
+                    class="recent-remove"
+                    type="button"
+                    :aria-label="`Remove ${displayName(flow)} from recents`"
+                    title="Remove from recents"
+                    @click.stop="emit('remove-recent', flow.path)"
+                    @keydown.enter.stop="emit('remove-recent', flow.path)"
+                    @keydown.space.stop.prevent="emit('remove-recent', flow.path)"
                   >
-                    <span class="material-icons recent-menu-icon">folder_open</span>
-                    View in catalog
-                  </el-dropdown-item>
-                </el-dropdown-menu>
-              </template>
-            </el-dropdown>
+                    <span class="material-icons">close</span>
+                  </button>
+                </div>
+                <template #dropdown>
+                  <el-dropdown-menu>
+                    <el-dropdown-item @click="emit('open-recent', flow.path)">
+                      <span class="material-icons recent-menu-icon">open_in_new</span>
+                      Open flow
+                    </el-dropdown-item>
+                    <el-dropdown-item
+                      :disabled="flow.catalogId === undefined"
+                      @click="viewInCatalog(flow)"
+                    >
+                      <span class="material-icons recent-menu-icon">folder_open</span>
+                      View in catalog
+                    </el-dropdown-item>
+                    <el-dropdown-item divided @click="emit('remove-recent', flow.path)">
+                      <span class="material-icons recent-menu-icon">close</span>
+                      Remove from recents
+                    </el-dropdown-item>
+                  </el-dropdown-menu>
+                </template>
+              </el-dropdown>
+            </el-tooltip>
           </li>
         </ul>
         <p v-else class="recent-empty">Flows you create or open will show up here.</p>
@@ -191,6 +219,7 @@ const emit = defineEmits<{
   (e: "open"): void;
   (e: "browse-templates"): void;
   (e: "open-recent", path: string): void;
+  (e: "remove-recent", path: string): void;
   (e: "start-tutorial"): void;
 }>();
 
@@ -216,6 +245,21 @@ const viewInCatalog = (flow: RecentFlow) => {
   if (flow.catalogId === undefined) return;
   router.push({ name: "catalog", query: { tab: "catalog", flowId: String(flow.catalogId) } });
 };
+
+const KNOWN_FLOW_EXTS = /\.(ya?ml|flowfile)$/i;
+
+// Display-only; never mutates the stored entry. Catalog names have no extension
+// and pass through unchanged.
+function displayName(flow: RecentFlow): string {
+  return flow.name.replace(KNOWN_FLOW_EXTS, "");
+}
+
+// Parent directory only (e.g. "unnamed_flows") — the orientation the chip shows
+// in place of the full path, which now lives in the row tooltip.
+function parentFolder(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts.length >= 2 ? parts[parts.length - 2] : "";
+}
 
 const relativeFormat = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
 const RELATIVE_STEPS: [Intl.RelativeTimeFormatUnit, number][] = [
@@ -495,31 +539,30 @@ function relativeTime(timestamp: number): string {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   color: var(--color-text-primary);
-  flex-shrink: 0;
-  max-width: 45%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.recent-loc {
   flex: 1;
   min-width: 0;
-  display: flex;
-  align-items: center;
-}
-
-.recent-path {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
+}
+
+/* Muted parent-folder chip — quieter than the accent catalog ref badge. */
+.recent-folder {
+  flex-shrink: 0;
+  max-width: 30%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 1px var(--spacing-2);
+  background-color: var(--color-background-tertiary);
+  border-radius: var(--border-radius-full);
+  font-size: var(--font-size-2xs);
+  color: var(--color-text-tertiary);
 }
 
 .recent-catalog-ref {
-  max-width: 100%;
+  flex-shrink: 0;
+  max-width: 45%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -535,6 +578,46 @@ function relativeTime(timestamp: number): string {
   flex-shrink: 0;
   font-size: var(--font-size-xs);
   color: var(--color-text-tertiary);
+}
+
+/* Remove-from-recents X — hidden until the row is hovered/focused. */
+.recent-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  border-radius: var(--border-radius-full);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--transition-fast),
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.recent-row:hover .recent-remove,
+.recent-remove:focus-visible {
+  opacity: 1;
+}
+
+.recent-remove:hover {
+  color: var(--color-danger);
+  background-color: var(--color-danger-bg, rgba(239, 68, 68, 0.1));
+}
+
+.recent-remove:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 1px;
+}
+
+.recent-remove .material-icons {
+  font-size: 15px;
 }
 
 .recent-empty {

--- a/flowfile_wasm/src/components/Canvas.vue
+++ b/flowfile_wasm/src/components/Canvas.vue
@@ -212,6 +212,7 @@
               :rowData="rowData"
               :columnDefs="columnDefs"
               :defaultColDef="defaultColDef"
+              :suppressFieldDotNotation="true"
               :pagination="true"
               :paginationPageSize="100"
               :enableCellTextSelection="true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Flowfile"
-version = "0.12.0"
+version = "0.12.1"
 description = "Project combining flowfile core (backend) and flowfile_worker (compute offloader) and flowfile_frame (api)"
 readme = "readme-pypi.md"
 authors = ["Edward van Eechoud <evaneechoud@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,9 @@ include = [
     { path = "flowfile/flowfile/web/static/**/*", format = "sdist" },
     { path = "flowfile/flowfile/web/static/**/*", format = "wheel" },
     { path = "flowfile/flowfile/py.typed", format = "sdist" },
-    { path = "flowfile/flowfile/py.typed", format = "wheel" }
+    { path = "flowfile/flowfile/py.typed", format = "wheel" },
+    { path = "flowfile_core/flowfile_core/catalog/demo_flows/*.yaml", format = "sdist" },
+    { path = "flowfile_core/flowfile_core/catalog/demo_flows/*.yaml", format = "wheel" }
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## What

A self-contained, **optional** `Demo` catalog you can load or wipe with one click — invisible to anyone who doesn't ask for it.

- **`Demo > sales_analytics`** — static Delta tables `regions`, `products`, `customers` (Faker), `sales`. Written with Polars + registered with precomputed metadata (no worker needed → always seeds, even offline).
- **`Demo > market`** — a registered flow **"Daily FX Sync"** (`rest_api_reader → polars_code reshape → catalog_writer upsert`) on a `0 6 * * *` UTC cron that pulls ECB rates from [frankfurter.app](https://frankfurter.app) into a growing `fx_rates` time series, idempotent on `(date, currency)`.

### Three entry points, one implementation
- **UI**: "Load demo data" in the catalog empty state, and a **Demo data** card in the "About the Catalog" info modal (Load / Remove).
- **API**: `POST /catalog/seed-demo`, `POST /catalog/remove-demo`.
- **CLI**: `flowfile seed-demo`, `flowfile remove-demo`.

Everything is rooted under one `Demo` namespace, so cleanup is a clean subtree delete (reusing `CatalogService` deletes so Delta files and sharing-grants are removed). All operations are idempotent.

### Desktop
The Tauri sidecar now sets `FLOWFILE_SCHEDULER_ENABLED=true` so the daily flow fires. Combined with the cron engine's catch-up-fire-once, the FX table refreshes once per day the next time the app is opened.

## Notable fix (general, not demo-specific)

`rest_api_reader` had **no local execution branch** — it always offloaded to the worker, so under headless `flowfile run flow` (forced `FULL_LOCAL`, as the scheduler uses) it failed with `{"detail":"Not Found"}` (the worker URL resolves to core's `:63578/worker`, which has no such route). Added an in-process fetch via `shared.rest_api.fetch` when `execution_location == "local"`, mirroring `add_database_reader`. REST-API flows now run end-to-end headlessly with no worker.

## Verification
- ruff + eslint clean on all touched files.
- FX reshape proven against a live Frankfurter response → `(date: Date, base: String, currency: String, rate: Float64)`.
- End-to-end (isolated temp storage): seed → Demo subtree + 4 tables + flow + cron schedule; re-seed = clean no-op; remove deletes everything.
- FX flow runs fully in-process (no worker) → `fx_rates` populated (29 rows); same-day re-run stays 29 (upsert dedup).

## Files
- New: `flowfile_core/flowfile_core/catalog/demo_seed.py`
- `routes/catalog.py`, `flowfile/__main__.py`, `flow_graph.py` (REST local branch), `src-tauri/src/env.rs`, `catalog.api.ts`, `CatalogView.vue`