### PR TITLE
Fix/save as overwrite issue

### DIFF
--- a/flowfile/flowfile/__main__.py
+++ b/flowfile/flowfile/__main__.py
@@ -84,6 +84,11 @@ def run_flow(flow_path: str, param_overrides: list[str] | None = None, run_id: i
     flow.print_tree()
     print("-" * 40)
 
+    # Stamp registration id before running so writes record producer lineage (mirrors canvas).
+    from flowfile_core.flowfile.catalog_helpers import resolve_source_registration_id
+
+    resolve_source_registration_id(flow)
+
     try:
         result = flow.run_graph()
     except Exception as e:

--- a/flowfile_core/flowfile_core/catalog/demo_flows/demo_fx_sync.yaml
+++ b/flowfile_core/flowfile_core/catalog/demo_flows/demo_fx_sync.yaml
@@ -76,6 +76,8 @@ nodes:
     keep_missing: false
     select_input:
     - old_name: date
+    - old_name: amount
+    - old_name: base
     - old_name: rates.GBP
       new_name: GBP
     - old_name: rates.JPY
@@ -88,31 +90,52 @@ nodes:
       new_name: CAD
     - old_name: rates.CNY
       new_name: CNY
-    - old_name: amount
-    - old_name: base
     - old_name: rates.BRL
+      new_name: BRL
     - old_name: rates.CZK
+      new_name: CZK
     - old_name: rates.DKK
+      new_name: DKK
     - old_name: rates.HKD
+      new_name: HKD
     - old_name: rates.HUF
+      new_name: HUF
     - old_name: rates.IDR
+      new_name: IDR
     - old_name: rates.ILS
+      new_name: ILS
     - old_name: rates.INR
+      new_name: INR
     - old_name: rates.ISK
+      new_name: ISK
     - old_name: rates.KRW
+      new_name: KRW
     - old_name: rates.MXN
+      new_name: MXN
     - old_name: rates.MYR
+      new_name: MYR
     - old_name: rates.NOK
+      new_name: NOK
     - old_name: rates.NZD
+      new_name: NZD
     - old_name: rates.PHP
+      new_name: PHP
     - old_name: rates.PLN
+      new_name: PLN
     - old_name: rates.RON
+      new_name: RON
     - old_name: rates.SEK
+      new_name: SEK
     - old_name: rates.SGD
+      new_name: SGD
     - old_name: rates.THB
+      new_name: THB
     - old_name: rates.TRY
+      new_name: TRY
     - old_name: rates.USD
+      new_name: USD
     - old_name: rates.ZAR
+      new_name: ZAR
     sorted_by: none
 - id: 3
   type: unpivot

--- a/flowfile_core/flowfile_core/flowfile/catalog_helpers.py
+++ b/flowfile_core/flowfile_core/flowfile/catalog_helpers.py
@@ -304,6 +304,9 @@ def register_python_editor_flow(
 
     flow.flow_settings.source_registration_id = reg_id
 
+    # save_flow above synced read-links before the id existed; re-sync now it's set.
+    flow._sync_catalog_read_links()
+
     return reg_id
 
 

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -485,6 +485,10 @@ class CatalogTableInfo(NamedTuple):
     # False when the executing principal may not read the table; the reader
     # node's compute then fails closed instead of scanning the data.
     authorized: bool = True
+    # Resolved identity, surfaced for back-filling name-only readers.
+    table_id: int | None = None
+    namespace_id: int | None = None
+    table_name: str | None = None
 
 
 def _resolve_catalog_table_info(node_catalog_reader: "input_schema.NodeCatalogReader") -> CatalogTableInfo:
@@ -494,6 +498,9 @@ def _resolve_catalog_table_info(node_catalog_reader: "input_schema.NodeCatalogRe
     serialized_lf: bytes | None = None
     is_optimized: bool = False
     source_table_versions: str | None = None
+    resolved_table_id: int | None = None
+    resolved_namespace_id: int | None = None
+    resolved_table_name: str | None = None
     try:
         with get_db_context() as db:
             repo = SQLAlchemyCatalogRepository(db)
@@ -532,6 +539,9 @@ def _resolve_catalog_table_info(node_catalog_reader: "input_schema.NodeCatalogRe
                 return CatalogTableInfo(None, "physical", None, False, None, authorized=False)
 
             if table_record is not None:
+                resolved_table_id = table_record.id
+                resolved_namespace_id = table_record.namespace_id
+                resolved_table_name = table_record.name
                 table_type = table_record.table_type
                 if table_type == "virtual":
                     is_optimized = table_record.is_optimized
@@ -553,6 +563,9 @@ def _resolve_catalog_table_info(node_catalog_reader: "input_schema.NodeCatalogRe
         serialized_lf=serialized_lf,
         is_optimized=is_optimized,
         source_table_versions=source_table_versions,
+        table_id=resolved_table_id,
+        namespace_id=resolved_namespace_id,
+        table_name=resolved_table_name,
     )
 
 
@@ -3527,6 +3540,15 @@ class FlowGraph:
         """
 
         info = _resolve_catalog_table_info(node_catalog_reader)
+
+        # Back-fill id from a name-only reference so the settings form and read
+        # lineage (both keyed on catalog_table_id) work.
+        if node_catalog_reader.catalog_table_id is None and info.table_id is not None:
+            node_catalog_reader.catalog_table_id = info.table_id
+            if node_catalog_reader.catalog_namespace_id is None:
+                node_catalog_reader.catalog_namespace_id = info.namespace_id
+            if node_catalog_reader.catalog_table_name is None:
+                node_catalog_reader.catalog_table_name = info.table_name
 
         is_virtual_optimized: bool | None = info.is_optimized if info.table_type == "virtual" else None
 

--- a/flowfile_core/flowfile_core/main.py
+++ b/flowfile_core/flowfile_core/main.py
@@ -310,6 +310,11 @@ def _run_flow_cli(flow_path: str, run_id: int) -> int:
     flow_name = flow.flow_settings.name or f"Flow {flow.flow_id}"
     _cli_logger.debug("Running flow: %s (id=%s), nodes: %d", flow_name, flow.flow_id, len(flow.nodes))
 
+    # Stamp registration id before running so writes record producer lineage (mirrors canvas).
+    from flowfile_core.flowfile.catalog_helpers import resolve_source_registration_id
+
+    resolve_source_registration_id(flow)
+
     try:
         result = flow.run_graph()
     except Exception as e:

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -101,7 +101,18 @@ from shared.storage_config import storage
 
 router = APIRouter(dependencies=[Depends(get_current_active_user)])
 
-_MANAGED_FLOW_STEM_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+def _slugify_managed_flow_stem(name: str) -> str:
+    """Derive a filesystem-safe filename stem from a free-form flow display name.
+
+    Managed catalog flow files must match ``[A-Za-z0-9_-]+`` (enforced by
+    ``resolve_managed_flow_path``), but the name a user types is a free-form label
+    that may contain spaces, dots, or other punctuation. Collapse every run of
+    disallowed characters into a single underscore and trim leading/trailing
+    separators, so ``"market analytics"`` becomes ``"market_analytics"``. Returns
+    ``""`` when nothing usable remains, leaving the caller to reject the name.
+    """
+    return re.sub(r"[^A-Za-z0-9_\-]+", "_", name).strip("_-")
 
 
 def get_node_model(setting_name_ref: str):
@@ -1577,16 +1588,27 @@ def save_flow_to_catalog(
     two flows with the same user-chosen name in different namespaces cannot overwrite
     each other. Returns the (possibly new) flow id so the frontend can switch to it.
     """
-    stem = flow_name.strip()
-    if not stem:
+    display_name = flow_name.strip()
+    if not display_name:
         raise HTTPException(422, "flow_name must not be empty")
-    # Reject path separators and parent-traversal before any sanitization so
-    # callers can't launder ``../evil`` through ``Path(...).name``.
-    if "/" in stem or "\\" in stem or ".." in stem:
+    # The display name is a free-form label — spaces and ordinary punctuation are
+    # fine — but reject path separators / parent-traversal outright: a name is
+    # never a path, so these signal a malformed or hostile request, not a label.
+    if "/" in display_name or "\\" in display_name or ".." in display_name:
         raise HTTPException(status_code=403, detail="invalid managed flow filename")
-    stem = stem.rsplit(".yaml", 1)[0].rsplit(".yml", 1)[0].rsplit(".json", 1)[0]
-    if not _MANAGED_FLOW_STEM_RE.fullmatch(stem):
-        raise HTTPException(status_code=403, detail="invalid managed flow filename")
+    # Strip a flow extension the user may have typed so it doesn't double up with
+    # the ``.yaml`` we append below; the name is otherwise preserved for registration.
+    display_name = display_name.rsplit(".yaml", 1)[0].rsplit(".yml", 1)[0].rsplit(".json", 1)[0].strip()
+    if not display_name:
+        raise HTTPException(422, "flow_name must not be empty")
+
+    # The on-disk filename is a filesystem-safe slug of the display name. The
+    # ``{flow_id}_`` prefix already guarantees cross-flow uniqueness, so two
+    # distinct names that slugify alike never collide on disk, and
+    # ``resolve_managed_flow_path`` re-validates the slug as a final safety net.
+    stem = _slugify_managed_flow_stem(display_name)
+    if not stem:
+        raise HTTPException(status_code=422, detail="flow_name must contain at least one letter or number")
 
     flow = flow_file_handler.get_flow(flow_id)
     if flow is None:
@@ -1605,15 +1627,28 @@ def save_flow_to_catalog(
 
     # Pre-save name-collision check: reject BEFORE writing any YAML so a failed save doesn't leave orphaned files
     # on disk.
-    existing_by_name = find_registration_by_name(stem, namespace_id)
+    existing_by_name = find_registration_by_name(display_name, namespace_id)
     if existing_by_name is not None and existing_by_name.id != source_registration_id:
-        raise HTTPException(
+        name_conflict = HTTPException(
             status_code=409,
             detail=(
-                f"A flow named '{stem}' already exists in this namespace. "
+                f"A flow named '{display_name}' already exists in this namespace. "
                 "Select it in the catalog picker to overwrite, or choose a different name."
             ),
         )
+        if os.path.exists(existing_by_name.flow_path):
+            raise name_conflict
+        # Ghost registration: its backing file was deleted (e.g. by an older
+        # Save-As). Reclaim the name by removing the dead row instead of blocking
+        # the user with a 409 they can't act on. Best-effort — fall back to the
+        # conflict if it can't be cleanly removed (e.g. it still has artifacts).
+        try:
+            with get_db_context() as db:
+                CatalogService(SQLAlchemyCatalogRepository(db)).delete_flow(
+                    registration_id=existing_by_name.id, delete_file=False
+                )
+        except Exception as err:
+            raise name_conflict from err
 
     existing_reg = find_registration_by_path(flow_path)
     if existing_reg is not None and existing_reg.id != source_registration_id:
@@ -1629,11 +1664,12 @@ def save_flow_to_catalog(
 
     user_id = current_user.id if current_user else None
 
-    # Always register under the user-typed ``stem`` rather than the filename
-    # (``{flow_id}_{stem}``) so the catalog picker shows exactly what the user
-    # typed — and so the name-collision check below compares apples to apples.
+    # Always register under the user-typed ``display_name`` rather than the
+    # filename slug (``{flow_id}_{stem}``) so the catalog picker shows exactly
+    # what the user typed — and so the name-collision check above compares apples
+    # to apples.
     def _register(fp: str, _n: str, uid: int | None) -> None:
-        register_flow_in_namespace(fp, stem, uid, namespace_id)
+        register_flow_in_namespace(fp, display_name, uid, namespace_id)
 
     if is_new_path:
         try:
@@ -1649,15 +1685,21 @@ def save_flow_to_catalog(
         except FlowNameNamespaceCollision as err:
             raise HTTPException(status_code=409, detail=str(err)) from err
 
-        # If we renamed within the managed flows directory, unlink the old file.
+        # Save-As under a new name is a copy: the original flow file and its
+        # catalog registration stay intact. Only clean up throwaway scratch
+        # files (quick-create / python-editor temp flows) that were never meant
+        # to persist — never a real, registered catalog flow.
         if normalized_current and normalized_current != flow_path:
-            managed_root = str(Path(storage.flows_directory).resolve()) + os.sep
-            if normalized_current.startswith(managed_root):
+            scratch_roots = (
+                str(Path(storage.unnamed_flows_directory).resolve()) + os.sep,
+                str(Path(storage.python_editor_flows_directory).resolve()) + os.sep,
+            )
+            if normalized_current.startswith(scratch_roots):
                 try:
                     os.unlink(normalized_current)
                 except OSError:
                     logger.info(
-                        f"Could not unlink old managed flow file {normalized_current}",
+                        f"Could not unlink old scratch flow file {normalized_current}",
                         exc_info=True,
                     )
         sync_api_compatibility(flow_file_handler.get_flow(new_flow_id))
@@ -1666,7 +1708,7 @@ def save_flow_to_catalog(
     resolve_source_registration_id(flow)
     flow.save_flow(flow_path=flow_path)
     try:
-        register_flow_in_namespace(flow_path, stem, user_id, namespace_id)
+        register_flow_in_namespace(flow_path, display_name, user_id, namespace_id)
     except FlowPathNamespaceCollision as err:
         raise HTTPException(status_code=409, detail=str(err)) from err
     except FlowNameNamespaceCollision as err:

--- a/flowfile_core/tests/flowfile/test_catalog_flow_graph.py
+++ b/flowfile_core/tests/flowfile/test_catalog_flow_graph.py
@@ -137,6 +137,72 @@ class TestCatalogWriter:
             assert len(tables) == 1
             assert tables[0].source_registration_id == reg_id
 
+    def test_cli_runner_records_producer_lineage(self):
+        """The subprocess flow runner (manual-trigger / scheduled runs) must stamp
+        source_registration_id before run_graph so produced tables record producer
+        lineage. Regression: canvas runs resolved the registration but the CLI
+        runners did not, so manual/scheduled runs lost lineage.
+
+        Exercises flowfile.__main__.run_flow (the non-frozen subprocess path);
+        flowfile_core.main._run_flow_cli is an identical mirror for frozen builds.
+        """
+        from flowfile_core.configs.settings import OFFLOAD_TO_WORKER
+
+        ns_id = _create_namespace()
+
+        # Build a physical catalog_writer flow with NO in-memory
+        # source_registration_id, then persist it — the state a manual/scheduled
+        # run loads from disk before executing.
+        graph = _create_graph(execution_location="local")
+        _add_manual_input(graph, SAMPLE_DATA, node_id=1)
+        graph.add_node_promise(
+            input_schema.NodePromise(flow_id=graph.flow_id, node_id=2, node_type="catalog_writer")
+        )
+        graph.add_catalog_writer(
+            input_schema.NodeCatalogWriter(
+                flow_id=graph.flow_id,
+                node_id=2,
+                depending_on_id=1,
+                catalog_write_settings=input_schema.CatalogWriteSettings(
+                    table_name="cli_produced_table",
+                    namespace_id=ns_id,
+                ),
+                user_id=1,
+            )
+        )
+        add_connection(graph, input_schema.NodeConnection.create_from_simple_input(from_id=1, to_id=2))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            flow_path = Path(tmp) / "producer_flow.yaml"
+            graph.save_flow(str(flow_path))
+            # open_flow stamps the resolved path; register at that exact string so
+            # resolve_source_registration_id finds the registration by path.
+            resolved_path = str(flow_path.resolve())
+            reg_id = _create_flow_registration(ns_id, name="producer_flow", path=resolved_path)
+
+            prev_offload = OFFLOAD_TO_WORKER.value
+            prev_env = {k: os.environ.get(k) for k in ("FLOWFILE_SINGLE_FILE_MODE", "FLOWFILE_WORKER_PORT")}
+            try:
+                from flowfile.__main__ import run_flow
+
+                exit_code = run_flow(resolved_path, run_id=None)
+            finally:
+                OFFLOAD_TO_WORKER.set(prev_offload)
+                for key, value in prev_env.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value
+
+        assert exit_code == 0
+
+        with get_db_context() as db:
+            repo = SQLAlchemyCatalogRepository(db)
+            tables = repo.list_tables(namespace_id=ns_id)
+            assert len(tables) == 1
+            assert tables[0].name == "cli_produced_table"
+            assert tables[0].source_registration_id == reg_id
+
     def test_writer_overwrite_mode_replaces_table(self, execution_location):
         """With write_mode='overwrite', running twice should replace the table and preserve its ID."""
         ns_id = _create_namespace()
@@ -484,6 +550,84 @@ class TestSyncCatalogReadLinks:
             assert len(links) == 0
 
         os.unlink(save_path)
+
+    def test_reader_backfills_identity_from_full_name(self):
+        """A reader referenced only by catalog_full_table_name gets its
+        catalog_table_id / namespace_id / table_name back-filled on add, so the
+        settings form populates on reopen and read-lineage can be recorded."""
+        ns_id = _create_namespace()
+
+        df = pl.DataFrame(SAMPLE_DATA)
+        tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+        df.write_parquet(tmp.name)
+        tmp.close()
+
+        with get_db_context() as db:
+            svc = CatalogService(SQLAlchemyCatalogRepository(db))
+            table_out = svc.register_table(name="named_table", file_path=tmp.name, owner_id=1, namespace_id=ns_id)
+        table_id = table_out.id
+
+        graph = _create_graph()
+        graph.add_node_promise(
+            input_schema.NodePromise(flow_id=graph.flow_id, node_id=1, node_type="catalog_reader")
+        )
+        reader = input_schema.NodeCatalogReader(
+            flow_id=graph.flow_id,
+            node_id=1,
+            catalog_full_table_name="TestSch.named_table",
+        )
+        graph.add_catalog_reader(reader)
+
+        assert reader.catalog_table_id == table_id
+        assert reader.catalog_namespace_id == ns_id
+        assert reader.catalog_table_name == "named_table"
+
+        os.unlink(tmp.name)
+
+    def test_register_python_editor_flow_records_named_reader_link(self):
+        """register_python_editor_flow records read links for readers referenced
+        only by full table name (regression: the demo flow's reader produced no
+        read lineage)."""
+        from flowfile_core.flowfile.catalog_helpers import register_python_editor_flow
+
+        ns_id = _create_namespace()
+
+        df = pl.DataFrame(SAMPLE_DATA)
+        tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+        df.write_parquet(tmp.name)
+        tmp.close()
+
+        with get_db_context() as db:
+            svc = CatalogService(SQLAlchemyCatalogRepository(db))
+            table_out = svc.register_table(
+                name="demo_named_table", file_path=tmp.name, owner_id=1, namespace_id=ns_id
+            )
+        table_id = table_out.id
+
+        graph = _create_graph()
+        graph.add_node_promise(
+            input_schema.NodePromise(flow_id=graph.flow_id, node_id=1, node_type="catalog_reader")
+        )
+        graph.add_catalog_reader(
+            input_schema.NodeCatalogReader(
+                flow_id=graph.flow_id,
+                node_id=1,
+                catalog_full_table_name="TestSch.demo_named_table",
+                user_id=1,
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as tmpd:
+            flow_path = str(Path(tmpd) / "named_reader_flow.yaml")
+            reg_id = register_python_editor_flow(
+                graph, name="named_reader_flow", namespace_id=ns_id, flow_path=flow_path, user_id=1
+            )
+
+        with get_db_context() as db:
+            link = db.query(CatalogTableReadLink).filter_by(table_id=table_id, registration_id=reg_id).first()
+            assert link is not None
+
+        os.unlink(tmp.name)
 
 
 # Round-trip: write → read

--- a/flowfile_core/tests/test_catalog.py
+++ b/flowfile_core/tests/test_catalog.py
@@ -4,6 +4,8 @@ Covers namespace CRUD, flow registration, favorites, follows,
 run history, stats, and the default namespace seeding.
 """
 
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -25,6 +27,8 @@ from flowfile_core.database.models import (
     User,
 )
 from flowfile_core.flowfile.catalog_helpers import auto_register_flow
+from flowfile_core.routes.routes import flow_file_handler
+from shared.storage_config import storage
 
 # Helpers
 
@@ -1833,3 +1837,128 @@ class TestCatalogTableStorageDeletion:
         import shutil
 
         shutil.rmtree(managed_dir, ignore_errors=True)
+
+
+class TestSaveFlowToCatalog:
+    """``/save_flow_to_catalog`` Save-As semantics: a new name copies (leaves the
+    original intact), and a name freed by a deleted file can be reclaimed."""
+
+    def _make_namespace(self) -> int:
+        cat = client.post("/catalog/namespaces", json={"name": "SaveCat"}).json()
+        schema = client.post("/catalog/namespaces", json={"name": "SaveSchema", "parent_id": cat["id"]}).json()
+        return schema["id"]
+
+    def _user_id(self) -> int:
+        with get_db_context() as db:
+            return db.query(User).first().id
+
+    def _new_inmemory_flow(self, name: str) -> int:
+        """Create a quick-create scratch flow in the in-memory handler."""
+        return flow_file_handler.add_flow(name=name, user_id=self._user_id())
+
+    def _path_of(self, flow_id: int) -> Path:
+        return Path(flow_file_handler.get_flow(flow_id).flow_settings.path)
+
+    @staticmethod
+    def _cleanup(flow_ids: tuple[int, ...], paths: tuple[Path, ...]) -> None:
+        for p in paths:
+            p.unlink(missing_ok=True)
+        for fid in flow_ids:
+            try:
+                flow_file_handler.delete_flow(fid)
+            except Exception:
+                pass
+
+    def test_save_as_new_name_keeps_original(self):
+        ns_id = self._make_namespace()
+        fid = self._new_inmemory_flow("sa_alpha")
+        scratch = self._path_of(fid)
+        assert str(scratch).startswith(str(storage.unnamed_flows_directory))
+
+        # First catalog save (scratch -> managed): throwaway scratch file is cleaned up.
+        r1 = client.post(
+            "/save_flow_to_catalog",
+            params={"flow_id": fid, "flow_name": "sa_alpha", "namespace_id": ns_id},
+        )
+        assert r1.status_code == 200, r1.text
+        fid2 = r1.json()
+        alpha_path = self._path_of(fid2)
+        assert alpha_path.exists()
+        assert not scratch.exists(), "scratch temp flow should be cleaned up on first catalog save"
+
+        # Save-As under a NEW name: the original managed flow must survive (copy, not move).
+        r2 = client.post(
+            "/save_flow_to_catalog",
+            params={"flow_id": fid2, "flow_name": "sa_beta", "namespace_id": ns_id},
+        )
+        assert r2.status_code == 200, r2.text
+        fid3 = r2.json()
+        beta_path = self._path_of(fid3)
+
+        assert alpha_path.exists(), "Save-As under a new name must not delete the original file"
+        assert beta_path.exists()
+
+        flows = client.get("/catalog/flows", params={"namespace_id": ns_id}).json()
+        by_name = {f["name"]: f for f in flows}
+        assert {"sa_alpha", "sa_beta"} <= set(by_name)
+        # Save-As is a copy: the new name is a brand-new registration row pointing
+        # at its own file — never a repoint of the original's row onto the new path.
+        assert by_name["sa_alpha"]["id"] != by_name["sa_beta"]["id"], (
+            "Save-As must create a new catalog registration, not reuse the original's id"
+        )
+        assert by_name["sa_alpha"]["flow_path"] == str(alpha_path)
+        assert by_name["sa_beta"]["flow_path"] == str(beta_path)
+
+        self._cleanup((fid2, fid3), (alpha_path, beta_path))
+
+    def test_save_as_over_ghost_reclaims_name(self):
+        ns_id = self._make_namespace()
+        ghost_path = str(storage.flows_directory / "999999999_ghost.yaml")
+        assert not Path(ghost_path).exists()
+        client.post(
+            "/catalog/flows",
+            json={"name": "ghost", "flow_path": ghost_path, "namespace_id": ns_id},
+        )
+
+        fid = self._new_inmemory_flow("sa_scratch_ghost")
+        resp = client.post(
+            "/save_flow_to_catalog",
+            params={"flow_id": fid, "flow_name": "ghost", "namespace_id": ns_id},
+        )
+        assert resp.status_code == 200, resp.text  # ghost reclaimed instead of a dead-end 409
+        new_fid = resp.json()
+        new_path = self._path_of(new_fid)
+        assert new_path.exists()
+
+        flows = client.get("/catalog/flows", params={"namespace_id": ns_id}).json()
+        ghosts = [f for f in flows if f["name"] == "ghost"]
+        assert len(ghosts) == 1, "the dead ghost row should be replaced, not duplicated"
+        # The id may be reused (SQLite recycles rowids); what matters is the
+        # surviving row points at the new, existing file — not the dead path.
+        assert ghosts[0]["flow_path"] == str(new_path)
+        assert ghosts[0]["flow_path"] != ghost_path
+        assert ghosts[0]["file_exists"] is True
+
+        self._cleanup((new_fid,), (new_path,))
+
+    def test_name_collision_with_live_file_still_409(self):
+        ns_id = self._make_namespace()
+        fid_a = self._new_inmemory_flow("sa_dup_a")
+        ra = client.post(
+            "/save_flow_to_catalog",
+            params={"flow_id": fid_a, "flow_name": "sa_dup", "namespace_id": ns_id},
+        )
+        assert ra.status_code == 200, ra.text
+        fid_a2 = ra.json()
+        dup_path = self._path_of(fid_a2)
+        assert dup_path.exists()
+
+        # A different flow cannot silently take a name whose file is alive.
+        fid_b = self._new_inmemory_flow("sa_dup_b")
+        rb = client.post(
+            "/save_flow_to_catalog",
+            params={"flow_id": fid_b, "flow_name": "sa_dup", "namespace_id": ns_id},
+        )
+        assert rb.status_code == 409
+
+        self._cleanup((fid_a2, fid_b), (dup_path,))

--- a/flowfile_core/tests/test_endpoints.py
+++ b/flowfile_core/tests/test_endpoints.py
@@ -574,8 +574,9 @@ def test_save_flow_to_catalog_refuses_overwrite_of_foreign_file():
             db.commit()
 
 
-def test_save_flow_to_catalog_unlinks_old_file_on_rename():
-    """Renaming a catalog-saved flow removes the previous managed yaml."""
+def test_save_flow_to_catalog_keeps_old_file_on_rename():
+    """Saving a catalog flow under a new name is a copy, not a move: the previous
+    managed yaml survives so Save-As never destroys the original."""
     from flowfile_core.database.models import FlowRegistration
 
     first_name = "rename_before"
@@ -612,8 +613,8 @@ def test_save_flow_to_catalog_unlinks_old_file_on_rename():
         )
         assert resp_second.status_code == 200, f"Second save failed: {resp_second.text}"
         assert second_expected.exists(), "Second-name file should exist after rename save"
-        assert not first_expected.exists(), (
-            f"Old managed file {first_expected} should have been unlinked on rename"
+        assert first_expected.exists(), (
+            f"Save-As under a new name must not delete the original file {first_expected}"
         )
     finally:
         for p in (first_expected, locals().get("second_expected")):
@@ -2160,6 +2161,53 @@ def test_save_flow_path_traversal_with_dots():
 
     response = client.post("/save_flow", params={"flow_id": flow_id, "flow_path": "../../../etc/malicious.yaml"})
     assert response.status_code == 403, "Path traversal with .. should be blocked"
+
+
+def test_save_flow_to_catalog_allows_name_with_spaces():
+    """A flow name with spaces is a free-form display label, not a filename. The
+    save must succeed (200), the catalog must register the exact name typed, and
+    the file on disk must use a slugified, filesystem-safe ``{flow_id}_{slug}.yaml``
+    name (no spaces). Regression guard for the old filename-regex rejection."""
+    from flowfile_core.database.models import User
+
+    cat = client.post("/catalog/namespaces", json={"name": "SpaceCat"}).json()
+    schema = client.post("/catalog/namespaces", json={"name": "SpaceSchema", "parent_id": cat["id"]}).json()
+    ns_id = schema["id"]
+
+    with get_db_context() as db:
+        user_id = db.query(User).first().id
+    flow_id = flow_file_handler.add_flow(name="space_scratch", user_id=user_id)
+
+    new_flow_id = None
+    try:
+        resp = client.post(
+            "/save_flow_to_catalog",
+            params={"flow_id": flow_id, "flow_name": "market analytics", "namespace_id": ns_id},
+        )
+        assert resp.status_code == 200, resp.text
+        new_flow_id = resp.json()
+
+        # The filename is a slug of the display name, prefixed with the originating
+        # flow id; the space must never reach disk.
+        saved_path = Path(flow_file_handler.get_flow(new_flow_id).flow_settings.path)
+        assert saved_path.name == f"{flow_id}_market_analytics.yaml", saved_path.name
+        assert " " not in saved_path.name
+        assert saved_path.exists()
+
+        # The catalog registration keeps exactly what the user typed.
+        names = {f["name"] for f in client.get("/catalog/flows", params={"namespace_id": ns_id}).json()}
+        assert "market analytics" in names, names
+    finally:
+        for fid in (flow_id, new_flow_id):
+            if fid is None:
+                continue
+            saved = flow_file_handler.get_flow(fid)
+            if saved is not None:
+                Path(saved.flow_settings.path).unlink(missing_ok=True)
+            try:
+                flow_file_handler.delete_flow(fid)
+            except Exception:
+                pass
 
 
 def test_get_excel_sheet_names_path_traversal_blocked(monkeypatch):

--- a/flowfile_frontend/src/renderer/app/components/layout/Header/HeaderButtons.vue
+++ b/flowfile_frontend/src/renderer/app/components/layout/Header/HeaderButtons.vue
@@ -290,6 +290,7 @@ import CreateDialog from "../../../features/designer/components/CreateDialog.vue
 import { useNodeStore } from "../../../stores/column-store";
 import { useEditorStore } from "../../../stores/editor-store";
 import { useTutorialStore } from "../../../stores/tutorial-store";
+import { useCatalogStore } from "../../../stores/catalog-store";
 import { useRecentFlows } from "../../../composables/useRecentFlows";
 import {
   createFlow,
@@ -306,7 +307,8 @@ import { MODIFIER_LABEL } from "../../../utils/shortcuts";
 const nodeStore = useNodeStore();
 const editorStore = useEditorStore();
 const tutorialStore = useTutorialStore();
-const { recordFlowFromSettings } = useRecentFlows();
+const catalogStore = useCatalogStore();
+const { recordFlowFromSettings, refreshCatalogRefs } = useRecentFlows();
 
 const modalVisibleForOpen = ref(false);
 const modalVisibleForSave = ref(false);
@@ -452,6 +454,10 @@ const handleSaveDialogComplete = (flowId: number) => {
   } else {
     emit("flowSaved", flowId);
   }
+  // A catalog save adds/updates a registration; refresh the cached listing so
+  // the Catalog view and recents reflect it without a manual reload.
+  catalogStore.loadAllFlows();
+  refreshCatalogRefs();
   if (tutorialStore.isActive && tutorialStore.currentStep?.id === "save-flow") {
     setTimeout(() => {
       tutorialStore.nextStep();

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/exploreData/vueGraphicWalker/VueGraphicWalker.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/exploreData/vueGraphicWalker/VueGraphicWalker.vue
@@ -67,6 +67,7 @@ const getReactProps = () => {
     appearance: props.appearance || "light",
     themeKey: props.themeKey,
     storeRef: internalStoreRef.value,
+    hideProfiling: true,
     ...(chartSpecArray.length > 0 && { chart: chartSpecArray }),
   };
 

--- a/flowfile_frontend/src/renderer/app/features/designer/components/CatalogFlowPicker.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/components/CatalogFlowPicker.vue
@@ -127,7 +127,10 @@ const loadFlows = async (namespaceId: number) => {
   flowsLoading.value = true;
   flowsError.value = null;
   try {
-    flows.value = await CatalogApi.getFlows(namespaceId);
+    const fetched = await CatalogApi.getFlows(namespaceId);
+    // Hide ghost rows whose backing file was deleted — they can't be a valid
+    // overwrite target and otherwise linger in the list after a rename.
+    flows.value = fetched.filter((f) => f.file_exists);
     emit("flows-loaded", flows.value);
   } catch (err: unknown) {
     console.error("Failed to load catalog flows", err);
@@ -171,7 +174,17 @@ watch(
 
 onMounted(loadTree);
 
-defineExpose({ reload: loadTree });
+// Reload the namespace tree AND re-fetch the currently-selected namespace's
+// flows. ``loadTree`` alone only refreshes flows when no namespace is selected
+// yet, so callers re-opening the picker need this to escape a stale list.
+const refresh = async () => {
+  await loadTree();
+  if (selectedNamespaceId.value !== null) {
+    await loadFlows(selectedNamespaceId.value);
+  }
+};
+
+defineExpose({ reload: loadTree, refresh });
 </script>
 
 <style scoped>

--- a/flowfile_frontend/src/renderer/app/features/designer/components/SaveDialog.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/components/SaveDialog.vue
@@ -65,6 +65,7 @@
             <div class="form-group">
               <label>Browse the catalog</label>
               <catalog-flow-picker
+                ref="catalogPickerRef"
                 v-model="selectedRegistrationId"
                 :hide-system-namespaces="true"
                 @select-flow="handleOverwriteTargetSelected"
@@ -158,7 +159,18 @@ const emit = defineEmits(["save-complete", "save-cancelled", "update:visible"]);
 const isVisible = ref(props.visible);
 const initialPath = ref("");
 
-const saveMode = ref<"file" | "catalog">("file");
+// Persist the last-used source (file vs catalog) so the dialog reopens on
+// whichever source was used last. Intentionally shares the Open dialog's key
+// so the file/catalog preference is consistent across open and save.
+const DIALOG_MODE_STORAGE_KEY = "openDialog_mode";
+
+function loadSaveMode(): "file" | "catalog" {
+  return localStorage.getItem(DIALOG_MODE_STORAGE_KEY) === "catalog" ? "catalog" : "file";
+}
+
+const saveMode = ref<"file" | "catalog">(loadSaveMode());
+
+watch(saveMode, (m) => localStorage.setItem(DIALOG_MODE_STORAGE_KEY, m));
 
 // Catalog options
 const registerInCatalog = ref(true);
@@ -186,6 +198,8 @@ const fileBrowserRef = ref<{
   navigateUpDirectory: () => Promise<void>;
   selectedFile: FileInfo | null;
 } | null>(null);
+
+const catalogPickerRef = ref<{ refresh: () => Promise<void> } | null>(null);
 
 watch(
   () => props.visible,
@@ -219,6 +233,11 @@ const updateInitialPath = async () => {
   selectedRegistrationId.value = null;
   overwriteTargetHint.value = "";
 
+  // Re-fetch the catalog listing every open — the dialog content persists
+  // across open/close, so without this the picker shows the flow list as it
+  // was on first mount (stale after saves/renames).
+  await catalogPickerRef.value?.refresh();
+
   // Always refresh the managed catalog flows directory — this is the target
   // for the Catalog tab and must never be influenced by the user's last
   // browsed directory.
@@ -232,7 +251,15 @@ const updateInitialPath = async () => {
     const settings = await getFlowSettings(props.flowId);
     if (settings?.path) {
       const fileName = settings.path.split(/[/\\]/).pop() ?? "";
-      catalogFlowName.value = fileName.replace(/\.(yaml|yml|json)$/i, "");
+      let stem = fileName.replace(/\.(yaml|yml|json)$/i, "");
+      // Managed catalog flows are stored as ``{flow_id}_{name}.yaml`` — the id
+      // prefix is a filename collision-avoidance trick that must never surface
+      // to users. Strip it only for internal/managed paths so a user's own
+      // ``2024_report.yaml`` is left intact.
+      if (isInternalFlowfilePath(settings.path)) {
+        stem = stem.replace(/^\d+_/, "");
+      }
+      catalogFlowName.value = settings.display_name?.trim() || stem;
 
       // Only seed the file-browser initial path from the current flow path
       // when that path lives in a real user directory.  Quick-created flows
@@ -290,13 +317,16 @@ const handleSaveFlow = async (flowPath: string) => {
 
 const catalogFilePath = computed(() => {
   // Display-only preview of the final catalog path. Must mirror the backend
-  // convention in /save_flow_to_catalog (``{flow_id}_{stem}.yaml`` under the
-  // managed flows dir) so the user sees what will actually be written.
+  // convention in /save_flow_to_catalog (``{flow_id}_{slug}.yaml`` under the
+  // managed flows dir) so the user sees what will actually be written. The flow
+  // name is a free-form label, but the filename is a filesystem-safe slug of it.
   const dir = catalogFlowsDir.value || "~/.flowfile/flows";
-  const raw = catalogFlowName.value.trim() || "flow";
-  const stem = raw.replace(/\.(yaml|yml|json)$/i, "");
+  const raw = catalogFlowName.value.trim().replace(/\.(yaml|yml|json)$/i, "");
+  // Mirror backend _slugify_managed_flow_stem: collapse runs of characters
+  // outside [A-Za-z0-9_-] into a single underscore and trim separators.
+  const slug = raw.replace(/[^A-Za-z0-9_-]+/g, "_").replace(/^[_-]+|[_-]+$/g, "") || "flow";
   const sep = dir.includes("\\") ? "\\" : "/";
-  return `${dir}${sep}${props.flowId}_${stem}.yaml`;
+  return `${dir}${sep}${props.flowId}_${slug}.yaml`;
 });
 
 const normalizedCatalogName = computed(() =>


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to flow registration, catalog lineage tracking, and flow naming/registration logic. The main focus is on ensuring correct producer and reader lineage is recorded for catalog tables, improving the robustness of flow naming and registration, and enhancing test coverage for these behaviors.

**Lineage and Catalog Identity Handling:**

* Ensures that the `source_registration_id` is stamped on flows before execution in both CLI and main entrypoints, guaranteeing correct producer lineage for catalog tables regardless of how the flow is run. [[1]](diffhunk://#diff-5fe12c1b0bf3e23653aae1f425dfa1b2f0c5d64a11cb60ad52f5742799333515R87-R91) [[2]](diffhunk://#diff-309affc0fd27159e801a224ccd970b6ada99aba85443d8067f22e21c14846a1bR313-R317)
* When adding a catalog reader node referenced only by full table name, back-fills its `catalog_table_id`, `catalog_namespace_id`, and `catalog_table_name` so the settings form and lineage tracking work as expected. [[1]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R488-R491) [[2]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R501-R503) [[3]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R542-R544) [[4]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R566-R568) [[5]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R3544-R3552)
* Updates `register_python_editor_flow` to re-sync catalog read links after assigning the registration id, ensuring read lineage is correctly recorded for readers referenced by name.

**Flow Naming and Registration:**

* Refines the flow naming and registration logic: introduces a slugification function for display names, handles extension stripping, and robustly rejects invalid or empty names. Also, improves collision handling by reclaiming "ghost" registrations whose files have been deleted. [[1]](diffhunk://#diff-32e613ce2488a56db7b959c15d488a566e528efc483b772c3582b5e7992358aaL104-R115) [[2]](diffhunk://#diff-32e613ce2488a56db7b959c15d488a566e528efc483b772c3582b5e7992358aaL1580-R1611) [[3]](diffhunk://#diff-32e613ce2488a56db7b959c15d488a566e528efc483b772c3582b5e7992358aaL1608-R1651) [[4]](diffhunk://#diff-32e613ce2488a56db7b959c15d488a566e528efc483b772c3582b5e7992358aaL1632-R1672)
* Adjusts file cleanup behavior to only remove scratch files (not registered catalog flows) during Save-As operations, preventing accidental deletion of important files.
* Ensures all catalog registrations use the user-typed display name, not the slugified filename, for catalog display and collision checks.

**Test Coverage:**

* Adds tests to verify that CLI/manual flow runs correctly record producer lineage, that reader identity is back-filled from full table names, and that registering python editor flows records correct read links for name-only readers. [[1]](diffhunk://#diff-7b7d79c3572f711bf5122cec81014edf9286625b971c5a6eed91466e8c9560a0R140-R205) [[2]](diffhunk://#diff-7b7d79c3572f711bf5122cec81014edf9286625b971c5a6eed91466e8c9560a0R554-R631)

**Demo Flow and Miscellaneous:**

* Updates the demo FX sync flow YAML to standardize output column naming and selection. [[1]](diffhunk://#diff-f8d80f4e469ac01574b1ee401b4a8bcf8465fb16a197ec7c01fe74745207f69aR79-R80) [[2]](diffhunk://#diff-f8d80f4e469ac01574b1ee401b4a8bcf8465fb16a197ec7c01fe74745207f69aL91-R138)

These changes collectively improve flow lineage tracking, user experience with flow naming, and the reliability of catalog operations.