### PR TITLE
Fix handling of . in tauri app.

### DIFF
--- a/flowfile_frontend/src-tauri/src/sidecar/mod.rs
+++ b/flowfile_frontend/src-tauri/src/sidecar/mod.rs
@@ -168,9 +168,7 @@ fn binary_path(app: &AppHandle, kind: SidecarKind) -> Result<PathBuf, SidecarErr
     Ok(path)
 }
 
-/// Ensure the executable bit is set on Unix. Tauri's `bundle.resources` copy
-/// may strip it; without this the .app bundle would refuse to spawn the
-/// sidecar with EACCES.
+/// Ensure the executable bit is set on Unix — Tauri's `bundle.resources` copy may strip it, causing EACCES on spawn.
 #[cfg(unix)]
 fn ensure_executable(path: &std::path::Path) {
     use std::os::unix::fs::PermissionsExt;
@@ -205,13 +203,7 @@ pub(crate) fn spawn_service(
     let name = kind.name();
     log::info!("spawning sidecar {} from {}", name, path.display());
 
-    // Run the sidecar from the user's home directory rather than inheriting the
-    // shell's cwd (which is the app bundle / a read-only location like `/` when
-    // packaged). The Python backend resolves a relative output `directory`
-    // (e.g. the legacy `"."` default) against the process cwd, so without this a
-    // write to `output.csv` lands at `/output.csv` and fails with
-    // "Read-only file system". Home matches the HOME/FLOWFILE_STORAGE_DIR base
-    // exported in env.rs and the file browser's default location.
+    // Run from the user's home dir so the backend's relative output paths don't resolve against a read-only packaged cwd (e.g. `/`).
     let work_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
 
     let mut cmd = TokioCommand::new(&path);
@@ -222,21 +214,12 @@ pub(crate) fn spawn_service(
         .stderr(Stdio::piped())
         .kill_on_drop(false);
 
-    // Put each sidecar in its own process group (pgid == this child's pid) so
-    // shutdown can signal the whole subtree in one call. The worker forks
-    // multiprocessing viz-session children that inherit this group, so the
-    // group SIGTERM/SIGKILL in shutdown.rs reaps them too — a plain kill(pid)
-    // on Unix would orphan those grandchildren. (Core's scheduled-flow runs use
-    // start_new_session=True to escape into their own session, so they are
-    // deliberately NOT in this group and survive app exit.)
+    // Own process group (pgid == child pid) so shutdown can SIGTERM/SIGKILL the whole subtree at once, reaping the worker's multiprocessing children a plain kill(pid) would orphan.
+    // (Core's scheduled-flow runs use start_new_session=True to deliberately escape this group and survive app exit.)
     #[cfg(unix)]
     cmd.process_group(0);
 
-    // The PyInstaller sidecars are console-subsystem binaries. Without this flag
-    // Windows allocates a visible console window for each one when spawned from
-    // the GUI shell. CREATE_NO_WINDOW suppresses those terminals; stdout/stderr
-    // are still piped to pump_stream for logging. (creation_flags is an inherent
-    // method on tokio's Command on Windows.)
+    // CREATE_NO_WINDOW suppresses the console window Windows would otherwise allocate for each console-subsystem PyInstaller sidecar; stdout/stderr are still piped to pump_stream.
     #[cfg(windows)]
     {
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
@@ -330,11 +313,8 @@ async fn handle_termination(
 
     if *state.is_shutting_down.lock() {
         log::debug!("{} terminated during shutdown, not restarting", kind.name());
-        // TODO(C): this early return leaves the stale pid in state, so
-        // shutdown.rs's `.take()` + killpg may target a process/group whose PID
-        // has been recycled. Clear the pid here too (as the restart path does
-        // just below) so shutdown skips the kill entirely once the process is
-        // known dead.
+        // TODO(C): clear the pid here too — leaving it stale lets shutdown.rs's
+        // `.take()` + killpg target a process/group whose PID has been recycled.
         return;
     }
 
@@ -393,16 +373,12 @@ async fn handle_termination(
         SidecarKind::Worker => worker_port,
     };
 
-    // Re-check is_shutting_down and respawn while *holding* the lock, closing the
-    // restart↔shutdown race. shutdown_all/kill_spawned flip the flag to true under
-    // this same lock and only `.take()` the pid afterwards, so holding the lock
-    // across the spawn serializes the two: either we see the flag already set and
-    // bail, or we win the lock and store the new pid (inside spawn_service) before
-    // releasing — so shutdown, which can't set the flag until we release, then
-    // observes that pid when it takes it, and kills the respawn. No orphan in the
-    // gap. spawn_service is synchronous, so holding the parking_lot guard across it
-    // is safe; we must NOT hold it across the async readiness wait, hence the guard
-    // is scoped to this block.
+    // Hold the lock across the re-check + respawn to close the restart↔shutdown
+    // race: shutdown flips the flag and `.take()`s the pid under this same lock,
+    // so we either see it set and bail, or store the new pid (in spawn_service)
+    // before releasing and shutdown then kills the respawn — no orphan in the gap.
+    // spawn_service is sync so holding the parking_lot guard is safe; the guard
+    // MUST NOT span the async readiness wait, hence the scoped block.
     let respawn = {
         let shutting_down = state.is_shutting_down.lock();
         if *shutting_down {

--- a/flowfile_frontend/src-tauri/src/sidecar/mod.rs
+++ b/flowfile_frontend/src-tauri/src/sidecar/mod.rs
@@ -205,9 +205,19 @@ pub(crate) fn spawn_service(
     let name = kind.name();
     log::info!("spawning sidecar {} from {}", name, path.display());
 
+    // Run the sidecar from the user's home directory rather than inheriting the
+    // shell's cwd (which is the app bundle / a read-only location like `/` when
+    // packaged). The Python backend resolves a relative output `directory`
+    // (e.g. the legacy `"."` default) against the process cwd, so without this a
+    // write to `output.csv` lands at `/output.csv` and fails with
+    // "Read-only file system". Home matches the HOME/FLOWFILE_STORAGE_DIR base
+    // exported in env.rs and the file browser's default location.
+    let work_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+
     let mut cmd = TokioCommand::new(&path);
     cmd.args(kind.args(core_port, worker_port))
         .envs(env)
+        .current_dir(work_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(false);

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/output/Output.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/output/Output.vue
@@ -89,7 +89,7 @@
         :allowed-file-types="['csv', 'xlsx', 'parquet']"
         :allow-directory-selection="true"
         mode="create"
-        context="dataFiles"
+        context="output"
         :is-visible="showFileSelectionModal"
         @directory-selected="handleDirectorySelected"
         @overwrite-file="handleFileSelected"
@@ -113,7 +113,9 @@ import {
   createExcelTableSettings,
 } from "./defaultValues";
 import { useNodeStore } from "../../../../../stores/node-store";
+import { useFileBrowserStore } from "../../../../../stores/fileBrowserStore";
 import { useNodeSettings } from "../../../../../composables/useNodeSettings";
+import { getDefaultPath } from "@/api/file.api";
 import axios, { AxiosError } from "axios";
 import CsvTableConfig from "./outputCsv.vue";
 import ExcelTableConfig from "./outputExcel.vue";
@@ -129,11 +131,23 @@ interface LocalFileInfo {
 }
 
 const nodeStore = useNodeStore();
+const fileBrowserStore = useFileBrowserStore();
 const nodeOutput = ref<NodeOutput | null>(null);
 const dataLoaded = ref(false);
 
+/**
+ * Remember the chosen output directory so the next new output node defaults to
+ * it (persisted to localStorage via the "output" file-browser context).
+ */
+function rememberOutputDirectory(directory: string | undefined) {
+  if (directory) fileBrowserStore.setCurrentPath("output", directory);
+}
+
 const { saveSettings, pushNodeData } = useNodeSettings({
   nodeRef: nodeOutput,
+  onBeforeSave: () => {
+    rememberOutputDirectory(nodeOutput.value?.output_settings.directory);
+  },
 });
 const showFileSelectionModal = ref(false);
 const selectedDirectoryExists = ref<boolean | null>(null);
@@ -231,6 +245,7 @@ function handleDirectorySelected(directoryPath: string) {
   if (!nodeOutput.value) return;
 
   nodeOutput.value.output_settings.directory = directoryPath;
+  rememberOutputDirectory(directoryPath);
   showFileSelectionModal.value = false;
   fetchFiles();
 }
@@ -240,6 +255,7 @@ function handleFileSelected(filePath: string, currentPath: string, fileName: str
 
   nodeOutput.value.output_settings.name = fileName;
   nodeOutput.value.output_settings.directory = currentPath;
+  rememberOutputDirectory(currentPath);
   showFileSelectionModal.value = false;
   detectFileType(fileName);
 }
@@ -257,6 +273,54 @@ const querySearch = (queryString: string, cb: (suggestions: LocalFileInfo[]) => 
   cb(results);
 };
 
+/**
+ * A directory is "resolved" only if it's an absolute path the user can actually
+ * see the target of. A relative value like "." is not — the backend resolves it
+ * against its own working directory, so the UI can't tell where the file lands.
+ */
+function isResolvedDirectory(directory: string | undefined): boolean {
+  if (!directory || directory === ".") return false;
+  // Absolute: POSIX (/...), Windows drive (C:\ or C:/), or UNC (\\...).
+  return /^([a-zA-Z]:[\\/]|\\\\|\/)/.test(directory);
+}
+
+/**
+ * Pick a concrete output directory: the last directory the user wrote to
+ * (remembered in the "output" file-browser context), else the user's home
+ * location from the backend. Falls back to "." only if the backend is
+ * unreachable.
+ */
+async function resolveDefaultOutputDirectory(): Promise<string> {
+  const remembered = fileBrowserStore.getLastUsedPath("output");
+  if (isResolvedDirectory(remembered)) return remembered;
+  try {
+    return (await getDefaultPath()) || ".";
+  } catch {
+    return ".";
+  }
+}
+
+/**
+ * On open, make sure the directory field shows a real, writable location rather
+ * than an unresolved "." — otherwise the user can't tell where the file will be
+ * written. Resolves to the last-used output dir (else home) and remembers it.
+ * For an already-configured node we persist the conversion immediately so the
+ * saved flow stops carrying "." for good.
+ */
+async function ensureResolvedDirectory() {
+  const settings = nodeOutput.value?.output_settings;
+  if (!settings || isResolvedDirectory(settings.directory)) return;
+
+  const resolved = await resolveDefaultOutputDirectory();
+  if (!isResolvedDirectory(resolved)) return; // backend unreachable — leave as-is
+
+  const wasConfigured = nodeOutput.value?.is_setup === true;
+  settings.directory = resolved;
+  rememberOutputDirectory(resolved);
+
+  if (wasConfigured) await saveSettings();
+}
+
 async function loadNodeData(nodeId: number) {
   const nodeResult = await nodeStore.getNodeData(nodeId, false);
   if (nodeResult?.setting_input && nodeResult.setting_input.is_setup) {
@@ -273,6 +337,7 @@ async function loadNodeData(nodeId: number) {
       description: "",
     };
   }
+  await ensureResolvedDirectory();
   dataLoaded.value = true;
 }
 

--- a/flowfile_frontend/src/renderer/app/stores/fileBrowserStore.ts
+++ b/flowfile_frontend/src/renderer/app/stores/fileBrowserStore.ts
@@ -8,7 +8,7 @@ export type SortDirectionType = "asc" | "desc";
  * Context types for different file browser use cases.
  * Each context maintains its own independent path state.
  */
-export type FileBrowserContext = "flows" | "dataFiles";
+export type FileBrowserContext = "flows" | "dataFiles" | "output";
 
 /**
  * State for a single file browser context
@@ -61,6 +61,9 @@ export const useFileBrowserStore = defineStore("fileBrowser", {
     contexts: {
       flows: loadContextState("flows"),
       dataFiles: loadContextState("dataFiles"),
+      // Output nodes keep their own remembered directory, independent from the
+      // read-file browser, so "where I last wrote" doesn't follow "where I last read".
+      output: loadContextState("output"),
     } as Record<FileBrowserContext, ContextState>,
   }),
 


### PR DESCRIPTION
This pull request improves the handling of output directories for output nodes, ensuring files are written to user-writable locations and enhancing the user experience by remembering the last used output directory. The changes also introduce a dedicated file browser context for output operations, separate from data file browsing, and update both frontend and backend logic to support these improvements.

**Frontend enhancements for output directory handling:**

- Output nodes now remember the last directory used for writing files, defaulting to the user's home directory if none is set. This is persisted in a new `"output"` file browser context, ensuring that each new output node suggests a sensible, writable location and that the user is never confused about where files will be saved. [[1]](diffhunk://#diff-c281fcd34ffac43aac5d5cf6b6975f7803ba327e8d9af05b3dfdce4b131fdbc5R116-R118) [[2]](diffhunk://#diff-c281fcd34ffac43aac5d5cf6b6975f7803ba327e8d9af05b3dfdce4b131fdbc5R134-R150) [[3]](diffhunk://#diff-c281fcd34ffac43aac5d5cf6b6975f7803ba327e8d9af05b3dfdce4b131fdbc5R276-R323) [[4]](diffhunk://#diff-c281fcd34ffac43aac5d5cf6b6975f7803ba327e8d9af05b3dfdce4b131fdbc5R340) [[5]](diffhunk://#diff-05fe8928b3f8cd6cf783b4a7bb2208b08708865056b0354e4429efa7087cf4e0L11-R11) [[6]](diffhunk://#diff-05fe8928b3f8cd6cf783b4a7bb2208b08708865056b0354e4429efa7087cf4e0R64-R66)
- The file selection modal for output nodes now uses the `"output"` context, keeping output directory history separate from data file browsing.
- When a user selects or overwrites a file/directory, the chosen path is remembered for future use. [[1]](diffhunk://#diff-c281fcd34ffac43aac5d5cf6b6975f7803ba327e8d9af05b3dfdce4b131fdbc5R248) [[2]](diffhunk://#diff-c281fcd34ffac43aac5d5cf6b6975f7803ba327e8d9af05b3dfdce4b131fdbc5R258)

**Backend process improvements:**

- The backend now launches sidecar processes (such as the Python backend) with the user's home directory as the working directory. This ensures that relative output paths (like `"."`) resolve to a writable location, avoiding permission errors and confusion about file locations.