### PR TITLE
Add delete in tree

### DIFF
--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogTreeNode.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogTreeNode.vue
@@ -66,6 +66,7 @@
           @flow-context-menu="$emit('flowContextMenu', $event)"
           @select-visualization="$emit('selectVisualization', $event)"
           @select-notebook="$emit('selectNotebook', $event)"
+          @delete-notebook="$emit('deleteNotebook', $event)"
           @toggle-favorite="$emit('toggleFavorite', $event)"
           @toggle-table-favorite="$emit('toggleTableFavorite', $event)"
           @register-flow="$emit('registerFlow', $event)"
@@ -280,6 +281,15 @@
         >
           <i class="fa-solid fa-book table-icon notebook-icon" title="Notebook"></i>
           <span class="table-name">{{ nb.name }}</span>
+          <div class="flow-actions" @click.stop>
+            <button
+              class="action-btn delete-btn"
+              title="Delete notebook"
+              @click="$emit('deleteNotebook', nb)"
+            >
+              <i class="fa-solid fa-trash"></i>
+            </button>
+          </div>
         </div>
       </TreeSection>
     </div>
@@ -329,6 +339,7 @@ defineEmits([
   "flowContextMenu",
   "selectVisualization",
   "selectNotebook",
+  "deleteNotebook",
   "toggleFavorite",
   "toggleTableFavorite",
   "registerFlow",

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -102,6 +102,7 @@
               @flow-context-menu="onFlowContextMenu($event)"
               @select-visualization="openVisualization($event)"
               @select-notebook="openNotebook($event)"
+              @delete-notebook="handleDeleteNotebook($event)"
               @toggle-favorite="catalogStore.toggleFavorite($event)"
               @toggle-table-favorite="catalogStore.toggleTableFavorite($event)"
               @register-flow="openRegisterFlow($event)"
@@ -504,6 +505,7 @@ import { useFlowStore } from "../../stores/flow-store";
 import { CatalogApi } from "../../api/catalog.api";
 import { FlowApi } from "../../api/flow.api";
 import { NodeApi } from "../../api/node.api";
+import type { NotebookSummary } from "../../api/notebook.api";
 import { EmptyState } from "../../components/common";
 import ContextMenu from "../../components/common/ContextMenu/ContextMenu.vue";
 import CatalogTreeNode from "./CatalogTreeNode.vue";
@@ -759,6 +761,24 @@ function openNotebook(notebookId: number) {
   void notebookStore.openNotebook(notebookId);
   if (catalogStore.activeTab !== "notebook") {
     router.push({ name: "catalog", query: { tab: "notebook" } });
+  }
+}
+
+async function handleDeleteNotebook(nb: NotebookSummary) {
+  try {
+    await ElMessageBox.confirm(
+      `Delete notebook "${nb.name}"? This cannot be undone.`,
+      "Delete notebook",
+      { confirmButtonText: "Delete", cancelButtonText: "Cancel", type: "warning" },
+    );
+  } catch {
+    return; // User cancelled
+  }
+  try {
+    await notebookStore.deleteNotebook(nb.id);
+    await Promise.all([catalogStore.loadTree(), catalogStore.loadStats()]);
+  } catch (e: any) {
+    ElMessage.error(e?.response?.data?.detail ?? e?.message ?? "Failed to delete notebook");
   }
 }
 


### PR DESCRIPTION
This pull request adds the ability to delete notebooks directly from the catalog tree in the Catalog view. The main changes include UI updates to show a delete button for notebooks, event handling to propagate the delete action, and logic to confirm and process notebook deletions.

**Notebook Deletion Feature:**

* Added a delete button next to each notebook in the catalog tree UI, allowing users to initiate notebook deletion.
* Emitted a new `deleteNotebook` event from `CatalogTreeNode.vue` when the delete button is clicked, and updated the component's `defineEmits` to include this event. [[1]](diffhunk://#diff-2faef1d6b290833769bdd846689611c114c563f7c67f194a1a57440f59b3cf0cR69) [[2]](diffhunk://#diff-2faef1d6b290833769bdd846689611c114c563f7c67f194a1a57440f59b3cf0cR342)
* Handled the `deleteNotebook` event in `CatalogView.vue` by implementing a `handleDeleteNotebook` function that shows a confirmation dialog and performs the deletion using the store, with error handling and UI feedback. [[1]](diffhunk://#diff-28f97ff2d8ee94dc7e78eb64c0ad9c6f3025b0f357f17c9c8a37a09e0defb991R105) [[2]](diffhunk://#diff-28f97ff2d8ee94dc7e78eb64c0ad9c6f3025b0f357f17c9c8a37a09e0defb991R767-R784)
* Imported the `NotebookSummary` type in `CatalogView.vue` to properly type the delete handler function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notebook deletion functionality. Users can now delete notebooks with a confirmation dialog to prevent accidental removal. The catalog automatically refreshes after deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->