### PR TITLE
Fix sort code generation flipping Descending to ascending

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/code_generator/code_generator.py
+++ b/flowfile_core/flowfile_core/flowfile/code_generator/code_generator.py
@@ -930,7 +930,7 @@ class FlowGraphCodeConverter:
 
         for sort_input in settings.sort_input:
             sort_cols.append(f'"{sort_input.column}"')
-            descending.append(sort_input.how == "desc")
+            descending.append(sort_input.descending)
 
         self._add_code(f"{var_name} = {input_df}.sort([{', '.join(sort_cols)}], descending={descending})")
         self._add_code("")
@@ -1007,7 +1007,7 @@ class FlowGraphCodeConverter:
         sorted_df = input_df
         if window_input.order_by:
             sort_cols = [f'"{s.column}"' for s in window_input.order_by]
-            descending = [s.how == "desc" for s in window_input.order_by]
+            descending = [s.descending for s in window_input.order_by]
             self._add_code(f"{var_name} = {input_df}.sort([{', '.join(sort_cols)}], descending={descending})")
             sorted_df = var_name
 

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
@@ -1079,7 +1079,7 @@ class FlowDataEngine:
 
         df = self.data_frame
         if settings.order_by:
-            descending = [s.how == "desc" or (s.how or "").lower() == "descending" for s in settings.order_by]
+            descending = [s.descending for s in settings.order_by]
             df = df.sort([s.column for s in settings.order_by], descending=descending)
 
         exprs = [
@@ -1101,7 +1101,7 @@ class FlowDataEngine:
         if not sorts:
             return self
 
-        descending = [s.how == "desc" or s.how.lower() == "descending" for s in sorts]
+        descending = [s.descending for s in sorts]
         df = self.data_frame.sort([sort_by.column for sort_by in sorts], descending=descending)
         return FlowDataEngine(df, number_of_records=self.number_of_records, schema=self.schema)
 

--- a/flowfile_core/flowfile_core/schemas/transform_schema.py
+++ b/flowfile_core/flowfile_core/schemas/transform_schema.py
@@ -949,11 +949,25 @@ class PivotInput(BaseModel):
         return pl.struct([pl.col(c) for c in self.aggregations]).alias("vals")
 
 
+def is_descending(how: str | None) -> bool:
+    """Whether a sort-direction string means descending.
+
+    Accepts both the programmatic ``"asc"``/``"desc"`` form (flowfile_frame) and the
+    visual editor's ``"Ascending"``/``"Descending"`` form (case-insensitive).
+    """
+    return (how or "").lower() in ("desc", "descending")
+
+
 class SortByInput(BaseModel):
     """Defines a single sort condition on a column, including the direction."""
 
     column: str
     how: str | None = "asc"
+
+    @property
+    def descending(self) -> bool:
+        """Resolve ``how`` to the boolean Polars expects, accepting both conventions."""
+        return is_descending(self.how)
 
 
 class RecordIdInput(BaseModel):

--- a/flowfile_core/tests/flowfile/test_code_generator.py
+++ b/flowfile_core/tests/flowfile/test_code_generator.py
@@ -2171,6 +2171,87 @@ def test_sort_operation(export_func):
 
 
 @pytest.mark.parametrize("export_func", [export_flow_to_polars, export_flow_to_flowframe], ids=["polars", "flowframe"])
+def test_sort_descending_ui_convention(export_func):
+    """Sort nodes built in the visual editor store how='Descending'/'Ascending', not 'desc'/'asc'.
+
+    Regression for the code generator emitting descending=[False] for a 'Descending'
+    sort, silently inverting the order relative to the executed graph.
+    """
+    flow = create_basic_flow()
+    data = input_schema.NodeManualInput(
+        flow_id=1,
+        node_id=1,
+        raw_data_format=input_schema.RawData(
+            columns=[
+                input_schema.MinimalFieldInfo(name="name", data_type="String"),
+                input_schema.MinimalFieldInfo(name="score", data_type="Integer")
+            ],
+            data=[["Alice", "Bob", "Alice", "Charlie", "Bob"], [85, 90, 85, 75, 95]]
+        )
+    )
+    flow.add_manual_input(data)
+
+    sort_node = input_schema.NodeSort(
+        flow_id=1,
+        node_id=2,
+        depending_on_id=1,
+        sort_input=[
+            transform_schema.SortByInput(column="score", how="Descending"),
+            transform_schema.SortByInput(column="name", how="Ascending")
+        ]
+    )
+    flow.add_sort(sort_node)
+    add_connection(flow, input_schema.NodeConnection.create_from_simple_input(1, 2))
+
+    code = export_func(flow)
+
+    if export_func is export_flow_to_polars:
+        verify_code_contains(code,
+                             'sort(["score", "name"], descending=[True, False])',
+                             )
+    verify_if_execute(code)
+    result_df = normalize_result(get_result_from_generated_code(code))
+    expected_df = normalize_result(flow.get_node(2).get_resulting_data().data_frame)
+    assert_frame_equal(result_df, expected_df)
+
+
+@pytest.mark.parametrize("export_func", [export_flow_to_polars, export_flow_to_flowframe], ids=["polars", "flowframe"])
+def test_window_functions_descending_order_by(export_func):
+    """Window-function order_by accepts the 'Descending' direction the engine honors.
+
+    The generated ordering sort must match the executed graph rather than silently
+    falling back to ascending.
+    """
+    flow = create_basic_flow()
+    flow = create_sales_dataframe_node(flow)
+
+    window_node = input_schema.NodeWindowFunctions(
+        flow_id=1,
+        node_id=2,
+        depending_on_id=1,
+        window_input=transform_schema.WindowFunctionsInput(
+            partition_by=["region"],
+            order_by=[transform_schema.SortByInput(column="date", how="Descending")],
+            window_functions=[
+                transform_schema.WindowFunctionInput(
+                    column="quantity",
+                    function="cum_sum",
+                    new_column_name="qty_cum_sum",
+                ),
+            ],
+        ),
+    )
+    flow.add_window_functions(window_node)
+    add_connection(flow, node_connection=input_schema.NodeConnection.create_from_simple_input(1, 2))
+
+    code = export_func(flow)
+
+    # The ordering sort is emitted identically for both frameworks.
+    verify_code_contains(code, 'sort(["date"], descending=[True])')
+    verify_if_execute(code)
+
+
+@pytest.mark.parametrize("export_func", [export_flow_to_polars, export_flow_to_flowframe], ids=["polars", "flowframe"])
 def test_sort_and_unique_operations(export_func):
     """Test sort and unique operations"""
     flow = create_basic_flow()


### PR DESCRIPTION
The code generator translated a sort direction to a boolean with
`how == "desc"`, but sort nodes built in the visual editor store
`how` as "Descending"/"Ascending". That comparison silently produced
`descending=[False]` for a Descending sort, so generated Polars code
sorted ascending while the executed graph sorted descending — inverting
any order-dependent downstream logic with no error raised.

Centralize the direction parsing in `transform_schema.is_descending`
(plus a `SortByInput.descending` property) so it accepts both the
"asc"/"desc" and "Ascending"/"Descending" conventions, and use it in
the code generator (sort + window order_by) and the execution engine
(do_sort + window order_by), which previously each carried their own
copy of this logic and had drifted apart.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BJeo1EyjymuV5MpXtowjqk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sort direction handling to properly support ascending and descending sorts across code generation and data operations.
  * Fixed window function ordering when descending sort is specified.

* **Tests**
  * Added regression tests for sort and window function descending direction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->