### PR TITLE
Bundle demo-catalog flow YAMLs for PyInstaller

### DIFF
--- a/build_backends/build_backends/main.py
+++ b/build_backends/build_backends/main.py
@@ -156,12 +156,24 @@ def get_code_generator_datas():
         return [(shim, _os.path.join("flowfile_core", "flowfile", "code_generator"))]
     return []
 
+# Ship the bundled demo-catalog flow YAMLs. demo_seed.py reads them at runtime via
+# Path(__file__).parent / "demo_flows"; PyInstaller stores .py as bytecode only, so
+# without this the YAMLs are absent and seeding the demo catalog fails.
+def get_demo_flows_datas():
+    \"\"\"Collect demo-catalog flow YAMLs for PyInstaller bundling.\"\"\"
+    import os as _os
+    demo_dir = _os.path.join("flowfile_core", "flowfile_core", "catalog", "demo_flows")
+    if _os.path.isdir(demo_dir):
+        return [(demo_dir, _os.path.join("flowfile_core", "catalog", "demo_flows"))]
+    return []
+
 # Collect numpy and pyarrow data files
 numpy_datas = collect_data_files('numpy')
 pyarrow_datas = collect_data_files('pyarrow')
 connectorx_datas = get_connectorx_metadata()
 alembic_datas = get_alembic_datas()
 code_generator_datas = get_code_generator_datas()
+demo_flows_datas = get_demo_flows_datas()
 
 # Polars plugins that have subpackages or compiled extensions. The plain
 # `hiddenimports=['polars_ds']` directive only adds the top-level — it does
@@ -228,7 +240,7 @@ with open('connectorx_hook.py', 'w') as f:
 a = Analysis(
     [r'{os.path.join(directory, script_name)}'],
     binaries=plugin_binaries + ai_binaries,
-    datas=numpy_datas + pyarrow_datas + connectorx_datas + alembic_datas + code_generator_datas + plugin_datas + litellm_datas + ai_datas,
+    datas=numpy_datas + pyarrow_datas + connectorx_datas + alembic_datas + code_generator_datas + demo_flows_datas + plugin_datas + litellm_datas + ai_datas,
     hiddenimports={hidden_imports} + plugin_hiddenimports + litellm_hiddenimports + ai_hiddenimports + [
         'numpy',
         'numpy.core._dtype_ctypes',


### PR DESCRIPTION
## Summary
Adds PyInstaller data collection for demo-catalog flow YAML files to ensure they are bundled correctly in the compiled application. Without this, the demo catalog seeding fails at runtime because PyInstaller stores `.py` files as bytecode only, making relative YAML file lookups inaccessible.

## Changes
- **New function `get_demo_flows_datas()`**: Collects the `demo_flows/` directory from `flowfile_core/flowfile_core/catalog/` and maps it for PyInstaller bundling to `flowfile_core/catalog/demo_flows` in the built application.
- **Updated Analysis datas**: Adds `demo_flows_datas` to the PyInstaller `Analysis` datas list alongside existing data collections (numpy, pyarrow, connectorx, alembic, code_generator, etc.).

## Implementation Details
- The function mirrors the pattern of existing data collectors (`get_code_generator_datas()`, `get_alembic_datas()`) with a directory existence check.
- Preserves the relative path structure expected by `demo_seed.py` at runtime, which reads flows via `Path(__file__).parent / "demo_flows"`.
- Ensures demo catalog initialization works correctly in PyInstaller-bundled distributions.

https://claude.ai/code/session_01PWr1cBV6omT7tYQcybqXNH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Packaged builds now include demo flow examples, so the app can ship with the full set of demo catalog content available out of the box.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->