### PR TITLE
catalog(shared): thread storage_options through Delta helpers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,19 @@ FLOWFILE_INTERNAL_TOKEN=your-secure-internal-token-change-in-production
 FLOWFILE_ENABLE_PROJECTS=true
 
 # ============================================
+# Catalog Object Storage (optional)
+# ============================================
+# By default catalog tables are materialized as local Delta directories. Set
+# these two together to store NEW catalog table data in object storage (S3)
+# instead. Unset ⇒ today's local behavior, unchanged. Existing local tables are
+# never moved. The SQLite catalog metadata DB always stays local.
+#   - FLOWFILE_CATALOG_STORAGE_URI: the catalog root, e.g. s3://bucket/catalog
+#   - FLOWFILE_CATALOG_STORAGE_CONNECTION: name of an existing CloudStorageConnection
+#     supplying the credentials (required whenever the URI is set).
+# FLOWFILE_CATALOG_STORAGE_URI=
+# FLOWFILE_CATALOG_STORAGE_CONNECTION=
+
+# ============================================
 # AI Rate Limits (per-provider, optional)
 # ============================================
 # Soft per-provider request budgets enforced by flowfile_core/ai/scheduler.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,7 @@ environment in local/desktop runs.
 | `FLOWFILE_USER_DATA_DIR` | User data path. Default home dir (local) / `/app/user_data` (compose). |
 | `FLOWFILE_SCHEDULER_ENABLED` | Start the embedded scheduler when truthy (`true`/`1`/`yes`); otherwise recurring flows never fire. |
 | `FLOWFILE_ENABLE_PROJECTS` | Enable the git project-tracking router in docker mode (truthy `true`/`1`/`yes`/`on`); otherwise `/project/*` 404s. Always on in electron/package mode. |
+| `FLOWFILE_CATALOG_STORAGE_URI` / `_CONNECTION` | Optional object-storage backend for **new** catalog table data (S3). Set the URI (e.g. `s3://bucket/catalog`) **and** the name of an existing `CloudStorageConnection` for credentials. Unset ⇒ local Delta dirs (today's behavior); existing local tables are never moved; the metadata DB stays local. Resolved via `flowfile_core/catalog/storage_backend.py::resolve_catalog_storage`. |
 | `FLOWFILE_KERNEL_IMAGE` / `_BASE` / `_ML` / `_LITE` | Override kernel container images; unset uses the registry default. |
 
 **AI subsystem (see `.env.example`):**

--- a/flowfile_core/flowfile_core/catalog/service.py
+++ b/flowfile_core/flowfile_core/catalog/service.py
@@ -29,6 +29,7 @@ from flowfile_core.catalog.repository import CatalogRepository
 
 if TYPE_CHECKING:
     from flowfile_core.catalog.access import AccessResolver
+    from flowfile_core.catalog.storage_backend import CatalogStorageTarget
 from flowfile_core.catalog.serializers import (
     VizEnrichment,
     format_pyarrow_preview,
@@ -519,12 +520,7 @@ class CatalogService:
             node.children = [c for c in (_prune(child) for child in node.children) if c is not None]
             self._stamp_access([node], "catalog_namespace", details["catalog_namespace"])
             has_items = bool(
-                node.flows
-                or node.tables
-                or node.visualizations
-                or node.notebooks
-                or node.artifacts
-                or node.children
+                node.flows or node.tables or node.visualizations or node.notebooks or node.artifacts or node.children
             )
             if node.id in visible_ns:
                 return node
@@ -905,10 +901,10 @@ class CatalogService:
         table_name: str,
         namespace_id: int | None,
         write_mode: str,
-        catalog_dir: Path,
-    ) -> tuple[CatalogTable | None, Path, str]:
-        """Resolve the destination path and Delta write mode for a catalog write."""
-        return self._tables.resolve_write_destination(table_name, namespace_id, write_mode, catalog_dir)
+        target: CatalogStorageTarget,
+    ) -> tuple[CatalogTable | None, str, str]:
+        """Resolve the destination (local path or object-storage URI) and Delta write mode."""
+        return self._tables.resolve_write_destination(table_name, namespace_id, write_mode, target)
 
     def resolve_table_file_path(
         self,

--- a/flowfile_core/flowfile_core/catalog/services/tables.py
+++ b/flowfile_core/flowfile_core/catalog/services/tables.py
@@ -825,6 +825,10 @@ class TableService:
 
         Returns the destination as a ``str``: a filesystem path for local targets, an
         ``s3://``-style URI for cloud targets.
+
+        Forward-only: an **existing** table always writes back to its own stored
+        location (keyed off its ``file_path``), regardless of the current global
+        config — the config (*target*) only chooses where a **new** table is created.
         """
         existing = self.repo.get_table_by_name(table_name, namespace_id)
 
@@ -833,8 +837,8 @@ class TableService:
                 raise TableExistsError(name=table_name, namespace_id=namespace_id)
 
             old_path = existing.file_path
-            if target.is_cloud:
-                # Cloud delta tables reuse their stored URI (assume delta; no local probe).
+            if _is_cloud_uri(old_path):
+                # Existing object-storage table: reuse its URI (assume delta; no local probe).
                 return existing, old_path, write_mode
 
             old_path_p = Path(old_path)

--- a/flowfile_core/flowfile_core/catalog/services/tables.py
+++ b/flowfile_core/flowfile_core/catalog/services/tables.py
@@ -929,8 +929,12 @@ class TableService:
         """Delete a catalog table; optionally delete its materialized storage.
 
         Storage is only removed when ``delete_file`` is set AND the path is
-        Flowfile-managed (under the catalog tables dir) — external/user-owned
+        Flowfile-managed (under the local catalog tables dir) — external/user-owned
         files are never touched. Virtual tables have no file to delete.
+
+        v1 limitation: object-storage (``s3://`` …) tables are NOT auto-deleted even
+        with ``delete_file=True`` — the catalog row is removed but the Delta objects are
+        left in the bucket (callers wanting cleanup must remove them out-of-band).
         """
         table = self.repo.get_table(table_id)
         if table is None:

--- a/flowfile_core/flowfile_core/catalog/services/tables.py
+++ b/flowfile_core/flowfile_core/catalog/services/tables.py
@@ -31,6 +31,12 @@ from flowfile_core.catalog.services._resolve import resolve_or_log
 from flowfile_core.catalog.services.flows import FlowRegistrationService
 from flowfile_core.catalog.services.namespaces import NamespaceService
 from flowfile_core.catalog.services.schedules import ScheduleService
+from flowfile_core.catalog.storage_backend import (
+    CatalogStorageTarget,
+    _is_cloud_uri,
+    join_catalog_uri,
+    resolve_catalog_storage,
+)
 from flowfile_core.catalog.validators import format_full_name, validate_table_registration
 from flowfile_core.database.models import CatalogNamespace, CatalogTable, TableFavorite
 from flowfile_core.flowfile.flow_data_engine.subprocess_operations.subprocess_operations import (
@@ -54,13 +60,26 @@ def _is_managed_table_path(file_path: str) -> bool:
     """True when the storage path lives under Flowfile's managed catalog dir.
 
     External/user-registered paths (registered by pointing at an existing file
-    outside the managed dir) return False and must never be deleted.
+    outside the managed dir) return False and must never be deleted. Object-storage
+    URIs are never "managed" locally ⇒ cloud tables are not auto-deleted (v1 default).
     """
+    if _is_cloud_uri(file_path):
+        return False
     try:
         Path(file_path).resolve().relative_to(storage.catalog_tables_directory.resolve())
         return True
     except (ValueError, OSError):
         return False
+
+
+def _catalog_table_dir_name(path_or_uri: str) -> str:
+    """Last path segment (the table directory name) of a local path or object-storage URI.
+
+    Avoids ``Path(...).name`` on URIs, where ``Path`` would corrupt the ``scheme://`` prefix.
+    """
+    if _is_cloud_uri(path_or_uri):
+        return path_or_uri.rstrip("/").rsplit("/", 1)[-1]
+    return Path(path_or_uri).name
 
 
 def _should_offload() -> bool:
@@ -196,14 +215,24 @@ class TableService:
     # ---- Metadata helpers ------------------------------------------------ #
 
     @staticmethod
-    def _read_table_metadata(table_path: str, storage_format: str) -> tuple[list[dict[str, str]], int, int, int]:
-        """Read schema, row_count, column_count, size_bytes from a table."""
-        if _should_offload():
+    def _read_table_metadata(
+        table_path: str, storage_format: str, storage: dict | None = None
+    ) -> tuple[list[dict[str, str]], int, int, int]:
+        """Read schema, row_count, column_count, size_bytes from a table.
+
+        When *storage* (a worker ``CatalogStorageInterface`` payload) is set, the table
+        lives in object storage and the read is always offloaded to the worker with no
+        local fallback.
+        """
+        is_cloud = storage is not None
+        if is_cloud or _should_offload():
             try:
-                data = trigger_read_table_metadata(Path(table_path).name)
+                data = trigger_read_table_metadata(_catalog_table_dir_name(table_path), storage=storage)
                 schema_list = [{"name": c["name"], "dtype": c["dtype"]} for c in data["column_schema"]]
                 return schema_list, data["row_count"], data["column_count"], data["size_bytes"]
             except (RuntimeError, OSError, ValueError, KeyError):
+                if is_cloud:
+                    raise
                 logger.warning("Worker metadata read failed, falling back to local read", exc_info=True)
 
         path = Path(table_path)
@@ -426,6 +455,7 @@ class TableService:
         self,
         source_file_path: str,
         table_name: str | None = None,
+        storage: dict | None = None,
     ) -> CatalogMaterializationResult:
         # Lazy module lookup so monkeypatches on ``catalog.service.trigger_catalog_materialize``
         # — used by tests — flow through.
@@ -434,6 +464,7 @@ class TableService:
         response = _service_module.trigger_catalog_materialize(
             source_file_path=source_file_path,
             table_name=table_name,
+            storage=storage,
         )
         if response.ok:
             data = response.json()
@@ -481,9 +512,11 @@ class TableService:
         """Register a new table by materializing it as a Delta table."""
         self.validate_table_registration(name, namespace_id)
 
+        target = resolve_catalog_storage(owner_id, namespace_id=namespace_id)
         materialized = self._materialize_table_with_worker(
             source_file_path=file_path,
             table_name=name,
+            storage=target.to_worker_payload(),
         )
 
         return self._create_table_record_from_metadata(
@@ -586,26 +619,29 @@ class TableService:
             raise TableNotFoundError(table_id=table_id)
 
         resolved_path_str = table_path or parquet_path
-        dest_path = Path(resolved_path_str)
+        is_cloud = _is_cloud_uri(resolved_path_str)
 
         if storage_format is None:
-            storage_format = "delta" if is_delta_table(dest_path) else "parquet"
+            storage_format = "delta" if (is_cloud or is_delta_table(Path(resolved_path_str))) else "parquet"
 
         if schema is not None and row_count is not None and size_bytes is not None:
             schema_list = schema
             if column_count is None:
                 column_count = len(schema_list)
         else:
-            schema_list, row_count, column_count, size_bytes = self._read_table_metadata(str(dest_path), storage_format)
+            schema_list, row_count, column_count, size_bytes = self._read_table_metadata(
+                resolved_path_str, storage_format
+            )
 
-        old_path = Path(table.file_path)
-        if old_path != dest_path and old_path.exists():
-            try:
-                delete_table_storage(old_path)
-            except OSError:
-                logger.warning("Failed to delete old table storage %s", old_path, exc_info=True)
+        if not is_cloud:
+            old_path = Path(table.file_path)
+            if old_path != Path(resolved_path_str) and old_path.exists():
+                try:
+                    delete_table_storage(old_path)
+                except OSError:
+                    logger.warning("Failed to delete old table storage %s", old_path, exc_info=True)
 
-        table.file_path = str(dest_path)
+        table.file_path = resolved_path_str
         table.storage_format = storage_format
         table.schema_json = json.dumps(schema_list)
         table.row_count = row_count
@@ -664,14 +700,23 @@ class TableService:
 
     # ---- Delta maintenance (optimize / vacuum) --------------------------- #
 
-    def _require_delta_table_path(self, table: CatalogTable) -> Path:
-        """Guard: ensure *table* is a physical on-disk Delta table, else raise ``ValueError``."""
+    def _require_delta_table_path(self, table: CatalogTable) -> str:
+        """Guard: ensure *table* is a physical Delta table, else raise ``ValueError``.
+
+        Returns the local path or object-storage URI. Cloud tables can't be cheaply
+        probed for the ``_delta_log`` locally, so a cloud ``storage_format == "delta"``
+        table is accepted on trust.
+        """
         if getattr(table, "table_type", "physical") == "virtual" or not table.file_path:
             raise ValueError(f"Table '{table.name}' is virtual and has no Delta storage to maintain")
+        if _is_cloud_uri(table.file_path):
+            if table.storage_format != "delta":
+                raise ValueError(f"Table '{table.name}' is not a Delta table and cannot be optimized or vacuumed")
+            return table.file_path
         path = Path(table.file_path)
         if table.storage_format != "delta" or is_legacy_parquet(path) or not is_delta_table(path):
             raise ValueError(f"Table '{table.name}' is not a Delta table and cannot be optimized or vacuumed")
-        return path
+        return str(path)
 
     def _update_table_size(self, table: CatalogTable, size_bytes: int | None) -> None:
         """Persist a recomputed size after a maintenance op."""
@@ -689,6 +734,7 @@ class TableService:
         if table is None:
             raise TableNotFoundError(table_id=table_id)
         data_path = self._require_delta_table_path(table)
+        is_cloud = _is_cloud_uri(data_path)
 
         if z_order_columns:
             valid = {c.name for c in self._parse_schema_columns(table)}
@@ -696,14 +742,27 @@ class TableService:
             if missing:
                 raise ValueError(f"z_order_columns not in table schema: {missing}")
 
+        target = resolve_catalog_storage(table.owner_id) if is_cloud else None
+        storage_options = target.storage_options if target else None
+
         if _should_offload():
-            result = trigger_optimize_catalog_table(data_path.name, z_order_columns)
+            result = trigger_optimize_catalog_table(
+                _catalog_table_dir_name(data_path),
+                z_order_columns,
+                storage=target.to_worker_payload() if target else None,
+            )
             metrics, size_bytes = result.get("metrics", {}), result.get("size_bytes")
         else:
-            from shared.delta_utils import optimize_delta
+            from shared.delta_utils import get_delta_size_bytes, optimize_delta
 
-            metrics = optimize_delta(str(data_path), z_order_columns=z_order_columns or None)
-            size_bytes = get_delta_table_size_bytes(data_path)
+            metrics = optimize_delta(
+                data_path, z_order_columns=z_order_columns or None, storage_options=storage_options
+            )
+            size_bytes = (
+                get_delta_size_bytes(data_path, storage_options=storage_options)
+                if is_cloud
+                else get_delta_table_size_bytes(Path(data_path))
+            )
 
         self._update_table_size(table, size_bytes)
         return OptimizeTableResponse(metrics=metrics, size_bytes=size_bytes)
@@ -719,15 +778,30 @@ class TableService:
         if table is None:
             raise TableNotFoundError(table_id=table_id)
         data_path = self._require_delta_table_path(table)
+        is_cloud = _is_cloud_uri(data_path)
+
+        target = resolve_catalog_storage(table.owner_id) if is_cloud else None
+        storage_options = target.storage_options if target else None
 
         if _should_offload():
-            result = trigger_vacuum_catalog_table(data_path.name, retention_hours, dry_run)
+            result = trigger_vacuum_catalog_table(
+                _catalog_table_dir_name(data_path),
+                retention_hours,
+                dry_run,
+                storage=target.to_worker_payload() if target else None,
+            )
             files, size_bytes = result.get("files_removed", []), result.get("size_bytes")
         else:
-            from shared.delta_utils import vacuum_delta
+            from shared.delta_utils import get_delta_size_bytes, vacuum_delta
 
-            files = vacuum_delta(str(data_path), retention_hours=retention_hours, dry_run=dry_run)
-            size_bytes = get_delta_table_size_bytes(data_path)
+            files = vacuum_delta(
+                data_path, retention_hours=retention_hours, dry_run=dry_run, storage_options=storage_options
+            )
+            size_bytes = (
+                get_delta_size_bytes(data_path, storage_options=storage_options)
+                if is_cloud
+                else get_delta_table_size_bytes(Path(data_path))
+            )
 
         if not dry_run:
             self._update_table_size(table, size_bytes)
@@ -745,24 +819,33 @@ class TableService:
         table_name: str,
         namespace_id: int | None,
         write_mode: str,
-        catalog_dir: Path,
-    ) -> tuple[CatalogTable | None, Path, str]:
-        """Resolve the destination path and Delta write mode for a catalog write."""
+        target: CatalogStorageTarget,
+    ) -> tuple[CatalogTable | None, str, str]:
+        """Resolve the destination (local path or object-storage URI) and Delta write mode.
+
+        Returns the destination as a ``str``: a filesystem path for local targets, an
+        ``s3://``-style URI for cloud targets.
+        """
         existing = self.repo.get_table_by_name(table_name, namespace_id)
 
         if existing is not None:
             if write_mode == "error":
                 raise TableExistsError(name=table_name, namespace_id=namespace_id)
 
-            old_path = Path(existing.file_path)
-            if is_delta_table(old_path):
+            old_path = existing.file_path
+            if target.is_cloud:
+                # Cloud delta tables reuse their stored URI (assume delta; no local probe).
                 return existing, old_path, write_mode
 
-            new_dir = old_path.parent / old_path.stem
-            return existing, new_dir, write_mode
+            old_path_p = Path(old_path)
+            if is_delta_table(old_path_p):
+                return existing, str(old_path_p), write_mode
+
+            new_dir = old_path_p.parent / old_path_p.stem
+            return existing, str(new_dir), write_mode
 
         dir_name = f"{table_name}_{uuid4().hex[:8]}"
-        return None, catalog_dir / dir_name, write_mode
+        return None, join_catalog_uri(target.base, dir_name), write_mode
 
     def resolve_table_file_path(
         self,

--- a/flowfile_core/flowfile_core/catalog/storage_backend.py
+++ b/flowfile_core/flowfile_core/catalog/storage_backend.py
@@ -1,0 +1,102 @@
+"""Resolve where catalog table data lives — local filesystem or object storage.
+
+This is the single seam for catalog storage resolution. v1 reads one instance-wide
+object-storage target from env config (``FLOWFILE_CATALOG_STORAGE_URI`` +
+``FLOWFILE_CATALOG_STORAGE_CONNECTION``); when unset the catalog behaves exactly as
+before (local filesystem). Per-namespace / per-table resolution is an additive change
+to ``resolve_catalog_storage`` only — the ``namespace_id`` hook is accepted now and
+ignored in v1, and no call site changes when it is wired up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from flowfile_core.configs import settings
+from flowfile_core.database.connection import get_db_context
+from flowfile_core.flowfile.database_connection_manager.db_connections import get_cloud_connection_schema
+from flowfile_core.flowfile.flow_data_engine.cloud_storage_reader import CloudStorageReader
+from flowfile_core.schemas.cloud_storage_schemas import FullCloudStorageConnectionWorkerInterface
+from shared.storage_config import storage
+
+_CLOUD_URI_SCHEMES = ("s3://", "s3a://", "az://", "abfs://", "abfss://", "adl://", "gs://", "gcs://")
+
+
+def _is_cloud_uri(value: str) -> bool:
+    """Return ``True`` when *value* is an object-storage URI rather than a local path."""
+    return value.startswith(_CLOUD_URI_SCHEMES)
+
+
+def join_catalog_uri(base: str, dir_name: str) -> str:
+    """Join a catalog table directory name onto a base, for cloud or local roots.
+
+    Mirrors how the worker resolves a table: cloud bases keep the URI scheme intact,
+    local bases produce a filesystem path.
+    """
+    if _is_cloud_uri(base):
+        return base.rstrip("/") + "/" + dir_name
+    return str(Path(base) / dir_name)
+
+
+@dataclass(frozen=True)
+class CatalogStorageTarget:
+    """Where a catalog table's bytes live, plus the credentials to reach them.
+
+    ``storage_options`` are decrypted, for core's own in-process lazy reads (reader /
+    SQL nodes). ``worker_interface`` carries the same connection with owner-encrypted
+    secrets for the core→worker hand-off (the worker decrypts independently).
+    """
+
+    is_cloud: bool
+    base: str
+    storage_options: dict[str, str] = field(default_factory=dict)
+    connection_name: str | None = None
+    worker_interface: FullCloudStorageConnectionWorkerInterface | None = None
+
+    def to_worker_payload(self) -> dict | None:
+        """Serialize a ``CatalogStorageInterface`` for the worker, or ``None`` for local.
+
+        The worker joins ``base_uri`` with the bare table directory name and decrypts
+        ``connection`` itself, so secrets never cross the wire in plaintext.
+        """
+        if not self.is_cloud or self.worker_interface is None:
+            return None
+        return {"base_uri": self.base, "connection": self.worker_interface.model_dump()}
+
+
+def resolve_catalog_storage(user_id: int, *, namespace_id: int | None = None) -> CatalogStorageTarget:
+    """Resolve the catalog storage backend for *user_id*.
+
+    Unset config ⇒ a local target rooted at ``storage.catalog_tables_directory`` (today's
+    behavior, byte-for-byte). When ``FLOWFILE_CATALOG_STORAGE_URI`` is set, the named
+    ``CloudStorageConnection`` supplies credentials; a missing URI-companion connection,
+    or a connection name that does not resolve for the user, raises ``ValueError``.
+
+    *namespace_id* is accepted for the future per-schema backend and ignored in v1.
+    """
+    uri = settings.get_catalog_storage_uri()
+    if not uri:
+        return CatalogStorageTarget(is_cloud=False, base=str(storage.catalog_tables_directory))
+
+    connection_name = settings.get_catalog_storage_connection()
+    if not connection_name:
+        raise ValueError(
+            "FLOWFILE_CATALOG_STORAGE_URI is set but FLOWFILE_CATALOG_STORAGE_CONNECTION is not; "
+            "a cloud connection name is required to resolve catalog storage credentials."
+        )
+
+    with get_db_context() as db:
+        conn = get_cloud_connection_schema(db, connection_name, user_id)
+    if conn is None:
+        raise ValueError(
+            f"Catalog storage connection '{connection_name}' was not found or is not accessible " f"for user {user_id}."
+        )
+
+    return CatalogStorageTarget(
+        is_cloud=True,
+        base=uri.rstrip("/"),
+        storage_options=CloudStorageReader.get_storage_options(conn),
+        connection_name=connection_name,
+        worker_interface=conn.get_worker_interface(user_id),
+    )

--- a/flowfile_core/flowfile_core/configs/settings.py
+++ b/flowfile_core/flowfile_core/configs/settings.py
@@ -51,6 +51,23 @@ FLOWFILE_ENABLE_PROJECTS: MutableBool = MutableBool(
 )
 
 
+def get_catalog_storage_uri() -> str | None:
+    """Object-storage root for catalog table data, e.g. ``s3://bucket/catalog``.
+
+    Read per call (not cached at import) so it is honored when set at runtime / in tests.
+    ``None`` ⇒ catalog tables materialize on the local filesystem exactly as before.
+    """
+    return os.environ.get("FLOWFILE_CATALOG_STORAGE_URI") or None
+
+
+def get_catalog_storage_connection() -> str | None:
+    """Name of the ``CloudStorageConnection`` supplying credentials for the catalog backend.
+
+    Only consulted when ``get_catalog_storage_uri()`` is set; required in that case.
+    """
+    return os.environ.get("FLOWFILE_CATALOG_STORAGE_CONNECTION") or None
+
+
 def parse_args():
     """Parse command line arguments"""
     parser = argparse.ArgumentParser(description="Flowfile Backend Server")

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/subprocess_operations.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/subprocess_operations.py
@@ -275,11 +275,14 @@ def trigger_write_output(
 def trigger_catalog_materialize(
     source_file_path: str,
     table_name: str | None = None,
+    storage: dict | None = None,
 ):
     payload = {
         "source_file_path": source_file_path,
         "table_name": table_name,
     }
+    if storage is not None:
+        payload["storage"] = storage
     response = requests.post(f"{WORKER_URL}/catalog/materialize", json=payload)
     return response
 
@@ -313,17 +316,21 @@ def trigger_sql_query(
     tables: dict[str, str],
     max_rows: int = 10_000,
     virtual_refs: dict[str, str] | None = None,
+    storage: dict | None = None,
 ) -> dict:
     """Ask the worker to execute a SQL query against catalog tables.
 
     *tables* is a mapping of logical table name -> directory name.
     *virtual_refs* is an optional mapping of virtual table name -> bare IPC
     filename under the worker's catalog_virtual_results directory.
+    *storage* (when set) routes the physical-table scans to object storage.
     Returns the parsed JSON response dict.
     """
     payload: dict = {"query": query, "tables": tables, "max_rows": max_rows}
     if virtual_refs:
         payload["virtual_refs"] = virtual_refs
+    if storage is not None:
+        payload["storage"] = storage
     response = requests.post(f"{WORKER_URL}/catalog/sql_query", json=payload)
     if not response.ok:
         raise RuntimeError(f"Worker SQL query execution failed: {response.text}")
@@ -441,15 +448,17 @@ def trigger_visualize_evict(session_key: str) -> None:
         raise RuntimeError(f"Worker visualize_evict failed: {response.text}")
 
 
-def trigger_read_table_metadata(table_name: str) -> dict:
+def trigger_read_table_metadata(table_name: str, storage: dict | None = None) -> dict:
     """Ask the worker to read table metadata (schema, row_count, size_bytes).
 
     *table_name* is the bare directory name inside the catalog tables
-    directory (no path separators).
+    directory (no path separators). *storage* (when set) reads from object storage.
 
     Returns the parsed JSON dict on success, raises on failure.
     """
     payload = {"table_path": table_name}
+    if storage is not None:
+        payload["storage"] = storage
     response = requests.post(f"{WORKER_URL}/catalog/table_metadata", json=payload)
     if not response.ok:
         raise RuntimeError(f"Worker table metadata read failed: {response.text}")
@@ -459,12 +468,16 @@ def trigger_read_table_metadata(table_name: str) -> dict:
 def trigger_delta_history(
     table_name: str,
     limit: int | None = None,
+    storage: dict | None = None,
 ) -> DeltaTableHistory:
     """Ask the worker to read Delta table version history.
 
     *table_name* is the bare directory name inside the catalog tables directory.
+    *storage* (when set) reads from object storage.
     """
     payload = {"table_path": table_name, "limit": limit}
+    if storage is not None:
+        payload["storage"] = storage
     response = requests.post(f"{WORKER_URL}/catalog/delta_history", json=payload)
     if not response.ok:
         raise RuntimeError(f"Worker delta history read failed: {response.text}")
@@ -475,12 +488,16 @@ def trigger_delta_version_preview(
     table_name: str,
     version: int,
     n_rows: int = 100,
+    storage: dict | None = None,
 ) -> CatalogTablePreview:
     """Ask the worker to preview a Delta table at a specific version.
 
     *table_name* is the bare directory name inside the catalog tables directory.
+    *storage* (when set) reads from object storage.
     """
     payload = {"table_path": table_name, "version": version, "n_rows": n_rows}
+    if storage is not None:
+        payload["storage"] = storage
     response = requests.post(f"{WORKER_URL}/catalog/delta_version_preview", json=payload)
     if not response.ok:
         raise RuntimeError(f"Worker delta version preview failed: {response.text}")
@@ -490,12 +507,16 @@ def trigger_delta_version_preview(
 def trigger_optimize_catalog_table(
     table_name: str,
     z_order_columns: list[str] | None = None,
+    storage: dict | None = None,
 ) -> dict:
     """Ask the worker to optimize (compact / Z-order) a Delta catalog table.
 
     *table_name* is the bare directory name inside the catalog tables directory.
+    *storage* (when set) optimizes the table in object storage.
     """
     payload = {"table_path": table_name, "z_order_columns": z_order_columns}
+    if storage is not None:
+        payload["storage"] = storage
     response = requests.post(f"{WORKER_URL}/catalog/optimize", json=payload, timeout=600)
     if not response.ok:
         raise RuntimeError(f"Worker optimize failed: {response.text}")
@@ -506,12 +527,16 @@ def trigger_vacuum_catalog_table(
     table_name: str,
     retention_hours: int = 168,
     dry_run: bool = True,
+    storage: dict | None = None,
 ) -> dict:
     """Ask the worker to vacuum tombstoned files from a Delta catalog table.
 
     *table_name* is the bare directory name inside the catalog tables directory.
+    *storage* (when set) vacuums the table in object storage.
     """
     payload = {"table_path": table_name, "retention_hours": retention_hours, "dry_run": dry_run}
+    if storage is not None:
+        payload["storage"] = storage
     response = requests.post(f"{WORKER_URL}/catalog/vacuum", json=payload, timeout=600)
     if not response.ok:
         raise RuntimeError(f"Worker vacuum failed: {response.text}")

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -23,6 +23,7 @@ from flowfile_core.auth import sharing
 from flowfile_core.catalog import CatalogService
 from flowfile_core.catalog.delta_utils import check_source_versions_current, delete_table_storage, is_delta_table
 from flowfile_core.catalog.repository import SQLAlchemyCatalogRepository
+from flowfile_core.catalog.storage_backend import _is_cloud_uri, resolve_catalog_storage
 from flowfile_core.configs import logger
 from flowfile_core.configs.app_settings import get_google_oauth_config
 from flowfile_core.configs.flow_logger import FlowLogger, NodeLogger
@@ -460,7 +461,7 @@ def _resolve_catalog_sql_tables(node_id: int | str, user_id: int | None = None) 
                         t.id,
                         t.source_table_versions,
                     )
-                elif t.file_path and is_delta_table(Path(t.file_path)):
+                elif t.file_path and (_is_cloud_uri(t.file_path) or is_delta_table(Path(t.file_path))):
                     table_paths[t.name] = t.file_path
 
     except Exception:
@@ -569,7 +570,7 @@ def _resolve_catalog_table_info(node_catalog_reader: "input_schema.NodeCatalogRe
 
 def _write_catalog_delta_local(
     df: FlowDataEngine,
-    dest_path: Path,
+    dest_path: str | Path,
     delta_mode: str,
     merge_keys: list[str] | None,
     partition_by: list[str] | None = None,
@@ -632,14 +633,24 @@ def _effective_namespace_id(svc: CatalogService, settings) -> int | None:
 
 def _register_catalog_table(
     existing,
-    dest_path: Path,
+    dest_path: str | Path,
     settings: input_schema.CatalogWriteSettings,
     source_registration_id: int | None,
     user_id: int,
     meta_kwargs: TableWriteMetadata,
+    storage_options: dict[str, str] | None = None,
+    is_cloud: bool = False,
 ) -> None:
-    """Register or update the catalog table entry, cleaning up orphaned storage on failure for new tables."""
-    partition_columns = get_delta_partition_columns(dest_path) if is_delta_table(dest_path) else []
+    """Register or update the catalog table entry, cleaning up orphaned storage on failure for new tables.
+
+    For cloud targets *dest_path* is an object-storage URI: local-only probes
+    (``is_delta_table``, ``Path.exists``) are skipped and partition columns are read
+    via *storage_options*. Cloud orphans are not auto-cleaned (v1 default).
+    """
+    if is_cloud:
+        partition_columns = get_delta_partition_columns(dest_path, storage_options=storage_options)
+    else:
+        partition_columns = get_delta_partition_columns(dest_path) if is_delta_table(dest_path) else []
     try:
         with get_db_context() as db:
             repo = SQLAlchemyCatalogRepository(db)
@@ -667,9 +678,9 @@ def _register_catalog_table(
                     **meta_kwargs,
                 )
     except Exception:
-        if existing is None and dest_path.exists():
+        if existing is None and not is_cloud and Path(dest_path).exists():
             try:
-                delete_table_storage(dest_path)
+                delete_table_storage(Path(dest_path))
             except OSError:
                 logger.warning("Failed to clean up orphan table %s", dest_path, exc_info=True)
         raise
@@ -843,9 +854,13 @@ def _handle_physical_table_write(
 ) -> FlowDataEngine:
     """Handle physical-mode catalog write: materialize data as a Delta table and register it."""
     settings = node_catalog_writer.catalog_write_settings
+    user_id = node_catalog_writer.user_id or 1
 
-    catalog_dir = storage.catalog_tables_directory
-    catalog_dir.mkdir(parents=True, exist_ok=True)
+    # Resolve the storage backend (local filesystem by default, object storage when configured).
+    # namespace_id is the per-schema hook; it is ignored in v1.
+    target = resolve_catalog_storage(user_id)
+    if not target.is_cloud:
+        Path(target.base).mkdir(parents=True, exist_ok=True)
 
     with get_db_context() as db:
         repo = SQLAlchemyCatalogRepository(db)
@@ -854,24 +869,29 @@ def _handle_physical_table_write(
             table_name=settings.table_name,
             namespace_id=_effective_namespace_id(svc, settings),
             write_mode=settings.write_mode,
-            catalog_dir=catalog_dir,
+            target=target,
         )
+
+    storage_payload = target.to_worker_payload()
+    storage_options = target.storage_options if target.is_cloud else None
 
     if delta_mode in ("upsert", "update", "delete"):
         op_type = "merge_delta"
         op_kwargs = {
-            "output_path": str(dest_path),
+            "output_path": dest_path,
             "merge_mode": delta_mode,
             "merge_keys": settings.merge_keys,
             "partition_by": settings.partition_by,
         }
     else:
         op_type = "write_delta"
-        op_kwargs = {"output_path": str(dest_path), "mode": delta_mode, "partition_by": settings.partition_by}
+        op_kwargs = {"output_path": dest_path, "mode": delta_mode, "partition_by": settings.partition_by}
+    if storage_payload is not None:
+        op_kwargs["storage"] = storage_payload
 
-    if graph.flow_settings.execution_location == "local":
-        meta_kwargs = _write_catalog_delta_local(df, dest_path, delta_mode, settings.merge_keys, settings.partition_by)
-    else:
+    # Cloud writes must offload to the worker: core never collects a full LazyFrame, and the
+    # local merge path collects. The worker owns dataset memory and writes via storage_options.
+    if target.is_cloud or graph.flow_settings.execution_location != "local":
         meta_kwargs = _write_catalog_delta_remote(
             flow_id=graph.flow_id,
             node=graph.get_node(node_catalog_writer.node_id),
@@ -880,6 +900,8 @@ def _handle_physical_table_write(
             op_kwargs=op_kwargs,
             table_name=settings.table_name,
         )
+    else:
+        meta_kwargs = _write_catalog_delta_local(df, dest_path, delta_mode, settings.merge_keys, settings.partition_by)
 
     if meta_kwargs is None:
         return df
@@ -889,8 +911,10 @@ def _handle_physical_table_write(
         dest_path=dest_path,
         settings=settings,
         source_registration_id=graph._flow_settings.source_registration_id,
-        user_id=node_catalog_writer.user_id or 1,
+        user_id=user_id,
         meta_kwargs=meta_kwargs,
+        storage_options=storage_options,
+        is_cloud=target.is_cloud,
     )
     return df
 
@@ -1892,9 +1916,7 @@ class FlowGraph:
                 artifact_names=result.artifacts_deleted,
             )
 
-        primary_result = read_kernel_outputs(
-            output_dir=output_dir, output_names=output_names, result=result, node=node
-        )
+        primary_result = read_kernel_outputs(output_dir=output_dir, output_names=output_names, result=result, node=node)
 
         if primary_result is not None:
             return primary_result
@@ -3019,9 +3041,7 @@ class FlowGraph:
                 out_type = w.output_type or transform_schema.get_window_output_type(w.function, src_type)
                 if out_type is None:
                     out_type = src_type or "Float64"
-                output_schema.append(
-                    FlowfileColumn.from_input(data_type=out_type, column_name=w.new_column_name)
-                )
+                output_schema.append(FlowfileColumn.from_input(data_type=out_type, column_name=w.new_column_name))
             return output_schema
 
         node.schema_callback = schema_callback
@@ -3507,9 +3527,15 @@ class FlowGraph:
         def _func() -> FlowDataEngine:
             if not table_paths and not virtual_tables:
                 raise ValueError("No catalog tables available to query")
+            cloud_opts = None
+            if any(_is_cloud_uri(p) for p in table_paths.values()):
+                cloud_opts = resolve_catalog_storage(node_catalog_reader.user_id or 1).storage_options or None
             ctx = pl.SQLContext()
             for name, path in table_paths.items():
-                ctx.register(name, pl.scan_delta(path))
+                if _is_cloud_uri(path):
+                    ctx.register(name, pl.scan_delta(path, storage_options=cloud_opts))
+                else:
+                    ctx.register(name, pl.scan_delta(path))
             for name, (is_opt, ser_lf, tid, stv) in virtual_tables.items():
                 ctx.register(
                     name,
@@ -3597,10 +3623,14 @@ class FlowGraph:
 
             if not resolved_path:
                 raise ValueError("Catalog table could not be resolved — no file path found")
+            scan_kwargs = {}
+            if delta_version is not None:
+                scan_kwargs["version"] = delta_version
+            if _is_cloud_uri(resolved_path):
+                # Cloud catalog table: scan directly (stays lazy ⇒ no collect in core).
+                storage_options = resolve_catalog_storage(_user_id or 1).storage_options or None
+                return FlowDataEngine(pl.scan_delta(resolved_path, storage_options=storage_options, **scan_kwargs))
             if is_delta_table(resolved_path):
-                scan_kwargs = {}
-                if delta_version is not None:
-                    scan_kwargs["version"] = delta_version
                 return FlowDataEngine(pl.scan_delta(resolved_path, **scan_kwargs))
             return FlowDataEngine(pl.scan_parquet(resolved_path))
 

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -887,7 +887,7 @@ def _handle_physical_table_write(
         op_type = "write_delta"
         op_kwargs = {"output_path": dest_path, "mode": delta_mode, "partition_by": settings.partition_by}
     if storage_payload is not None:
-        op_kwargs["storage"] = storage_payload
+        op_kwargs["storage_payload"] = storage_payload
 
     # Cloud writes must offload to the worker: core never collects a full LazyFrame, and the
     # local merge path collects. The worker owns dataset memory and writes via storage_options.
@@ -3524,12 +3524,15 @@ class FlowGraph:
         table_paths = resolved.table_paths
         virtual_tables = resolved.virtual_tables
 
+        # Resolve cloud storage options once at wiring time (shared by all cloud tables in
+        # the query under the single v1 backend); skipped entirely when none are cloud.
+        cloud_opts = None
+        if any(_is_cloud_uri(p) for p in table_paths.values()):
+            cloud_opts = resolve_catalog_storage(node_catalog_reader.user_id or 1).storage_options or None
+
         def _func() -> FlowDataEngine:
             if not table_paths and not virtual_tables:
                 raise ValueError("No catalog tables available to query")
-            cloud_opts = None
-            if any(_is_cloud_uri(p) for p in table_paths.values()):
-                cloud_opts = resolve_catalog_storage(node_catalog_reader.user_id or 1).storage_options or None
             ctx = pl.SQLContext()
             for name, path in table_paths.items():
                 if _is_cloud_uri(path):
@@ -3603,6 +3606,12 @@ class FlowGraph:
         _authorized = info.authorized
         _user_id = node_catalog_reader.user_id
 
+        # Resolve cloud storage options once at wiring time (the credentials don't change
+        # between executions); local tables don't touch the DB.
+        _reader_storage_options = None
+        if resolved_path and _is_cloud_uri(resolved_path):
+            _reader_storage_options = resolve_catalog_storage(_user_id or 1).storage_options or None
+
         def _func() -> FlowDataEngine:
             if not _authorized:
                 raise PermissionError(
@@ -3628,8 +3637,9 @@ class FlowGraph:
                 scan_kwargs["version"] = delta_version
             if _is_cloud_uri(resolved_path):
                 # Cloud catalog table: scan directly (stays lazy ⇒ no collect in core).
-                storage_options = resolve_catalog_storage(_user_id or 1).storage_options or None
-                return FlowDataEngine(pl.scan_delta(resolved_path, storage_options=storage_options, **scan_kwargs))
+                return FlowDataEngine(
+                    pl.scan_delta(resolved_path, storage_options=_reader_storage_options, **scan_kwargs)
+                )
             if is_delta_table(resolved_path):
                 return FlowDataEngine(pl.scan_delta(resolved_path, **scan_kwargs))
             return FlowDataEngine(pl.scan_parquet(resolved_path))

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -872,8 +872,22 @@ def _handle_physical_table_write(
             target=target,
         )
 
-    storage_payload = target.to_worker_payload()
-    storage_options = target.storage_options if target.is_cloud else None
+    # Forward-only: the effective backend follows the *destination* (an existing table keeps its
+    # own location), not the global config — which only steers brand-new tables. A new table's
+    # dest already reflects the config, so this is consistent for both.
+    dest_is_cloud = _is_cloud_uri(dest_path)
+    if dest_is_cloud:
+        if not target.is_cloud:
+            raise ValueError(
+                f"Catalog table '{settings.table_name}' lives in object storage ({dest_path}) but "
+                "FLOWFILE_CATALOG_STORAGE_URI / FLOWFILE_CATALOG_STORAGE_CONNECTION are not configured; "
+                "set them to write to it."
+            )
+        storage_payload = target.to_worker_payload()
+        storage_options = target.storage_options
+    else:
+        storage_payload = None
+        storage_options = None
 
     if delta_mode in ("upsert", "update", "delete"):
         op_type = "merge_delta"
@@ -891,7 +905,7 @@ def _handle_physical_table_write(
 
     # Cloud writes must offload to the worker: core never collects a full LazyFrame, and the
     # local merge path collects. The worker owns dataset memory and writes via storage_options.
-    if target.is_cloud or graph.flow_settings.execution_location != "local":
+    if dest_is_cloud or graph.flow_settings.execution_location != "local":
         meta_kwargs = _write_catalog_delta_remote(
             flow_id=graph.flow_id,
             node=graph.get_node(node_catalog_writer.node_id),
@@ -914,7 +928,7 @@ def _handle_physical_table_write(
         user_id=user_id,
         meta_kwargs=meta_kwargs,
         storage_options=storage_options,
-        is_cloud=target.is_cloud,
+        is_cloud=dest_is_cloud,
     )
     return df
 

--- a/flowfile_core/tests/test_catalog_cloud_e2e.py
+++ b/flowfile_core/tests/test_catalog_cloud_e2e.py
@@ -1,0 +1,83 @@
+"""End-to-end coverage of the catalog object-storage credential bridge (core side).
+
+Creates a real ``CloudStorageConnection``, points the catalog storage config at it,
+and asserts ``resolve_catalog_storage`` produces a cloud target whose decrypted
+``storage_options`` are usable in-process and whose ``to_worker_payload`` carries the
+secret re-encrypted (owner-keyed) for the worker. The actual S3 byte I/O is covered by
+the Docker-gated shared/worker cloud suites.
+"""
+
+import pytest
+from pydantic import SecretStr
+
+from flowfile_core.catalog.storage_backend import resolve_catalog_storage
+from flowfile_core.database.connection import get_db_context
+from flowfile_core.flowfile.database_connection_manager.db_connections import store_cloud_connection
+from flowfile_core.schemas.cloud_storage_schemas import FullCloudStorageConnection
+
+_CONNECTION_NAME = "catalog-minio-e2e"
+_CATALOG_URI = "s3://flowfile-test/catalog"
+
+
+def _make_minio_connection() -> FullCloudStorageConnection:
+    return FullCloudStorageConnection(
+        connection_name=_CONNECTION_NAME,
+        storage_type="s3",
+        auth_method="access_key",
+        aws_access_key_id="minioadmin",
+        aws_secret_access_key=SecretStr("minioadmin"),
+        aws_region="us-east-1",
+        endpoint_url="http://localhost:9000",
+        aws_allow_unsafe_html=True,
+    )
+
+
+@pytest.fixture
+def _stored_connection():
+    with get_db_context() as db:
+        try:
+            store_cloud_connection(db, _make_minio_connection(), user_id=1)
+            db.commit()
+        except ValueError:
+            # A prior test in the same DB session already stored it; reuse it.
+            db.rollback()
+
+
+def test_resolve_returns_cloud_target_with_decrypted_options(monkeypatch, _stored_connection):
+    monkeypatch.setenv("FLOWFILE_CATALOG_STORAGE_URI", _CATALOG_URI)
+    monkeypatch.setenv("FLOWFILE_CATALOG_STORAGE_CONNECTION", _CONNECTION_NAME)
+
+    target = resolve_catalog_storage(1)
+
+    assert target.is_cloud is True
+    assert target.base == _CATALOG_URI
+    assert target.connection_name == _CONNECTION_NAME
+    # Decrypted, ready for core's own in-process scan_delta.
+    assert target.storage_options["aws_access_key_id"] == "minioadmin"
+    assert target.storage_options["aws_secret_access_key"] == "minioadmin"
+    assert target.storage_options["endpoint_url"] == "http://localhost:9000"
+    assert target.storage_options["aws_allow_http"] == "true"
+
+
+def test_worker_payload_carries_encrypted_secret(monkeypatch, _stored_connection):
+    monkeypatch.setenv("FLOWFILE_CATALOG_STORAGE_URI", _CATALOG_URI)
+    monkeypatch.setenv("FLOWFILE_CATALOG_STORAGE_CONNECTION", _CONNECTION_NAME)
+
+    payload = resolve_catalog_storage(1).to_worker_payload()
+
+    assert payload is not None
+    assert payload["base_uri"] == _CATALOG_URI
+    conn = payload["connection"]
+    assert conn["aws_access_key_id"] == "minioadmin"
+    secret = conn["aws_secret_access_key"]
+    # Encrypted for the worker (owner-keyed), never plaintext or masked.
+    assert secret.startswith("$ffsec$")
+    assert "minioadmin" not in secret
+
+
+def test_resolve_local_when_unset(monkeypatch):
+    monkeypatch.delenv("FLOWFILE_CATALOG_STORAGE_URI", raising=False)
+    monkeypatch.delenv("FLOWFILE_CATALOG_STORAGE_CONNECTION", raising=False)
+    target = resolve_catalog_storage(1)
+    assert target.is_cloud is False
+    assert target.to_worker_payload() is None

--- a/flowfile_core/tests/test_catalog_cloud_e2e.py
+++ b/flowfile_core/tests/test_catalog_cloud_e2e.py
@@ -38,8 +38,11 @@ def _stored_connection():
         try:
             store_cloud_connection(db, _make_minio_connection(), user_id=1)
             db.commit()
-        except ValueError:
-            # A prior test in the same DB session already stored it; reuse it.
+        except ValueError as e:
+            # Only tolerate the "already exists" collision when a prior test in the same
+            # DB session stored it; any other validation error is a real failure.
+            if "already exists" not in str(e):
+                raise
             db.rollback()
 
 

--- a/flowfile_core/tests/test_catalog_delta.py
+++ b/flowfile_core/tests/test_catalog_delta.py
@@ -25,6 +25,7 @@ from flowfile_core import main
 from flowfile_core.catalog import CatalogService, TableExistsError
 from flowfile_core.catalog.repository import SQLAlchemyCatalogRepository
 from flowfile_core.catalog.service import _parse_delta_history
+from flowfile_core.catalog.storage_backend import CatalogStorageTarget
 from flowfile_core.database.connection import get_db_context
 from flowfile_core.database.models import (
     CatalogNamespace,
@@ -403,7 +404,7 @@ class TestResolveWriteDestination:
                 table_name="brand_new",
                 namespace_id=schema_id,
                 write_mode="overwrite",
-                catalog_dir=tmp_path,
+                target=CatalogStorageTarget(is_cloud=False, base=str(tmp_path)),
             )
         assert existing is None
         assert delta_mode == "overwrite"
@@ -434,7 +435,7 @@ class TestResolveWriteDestination:
                     table_name="exist_table",
                     namespace_id=schema_id,
                     write_mode="error",
-                    catalog_dir=tmp_path,
+                    target=CatalogStorageTarget(is_cloud=False, base=str(tmp_path)),
                 )
 
     def test_existing_delta_table_overwrite_returns_same_path(self, tmp_path):
@@ -461,10 +462,10 @@ class TestResolveWriteDestination:
                 table_name="delta_ow_table",
                 namespace_id=schema_id,
                 write_mode="overwrite",
-                catalog_dir=tmp_path,
+                target=CatalogStorageTarget(is_cloud=False, base=str(tmp_path)),
             )
         assert existing is not None
-        assert dest_path == delta_dir
+        assert dest_path == str(delta_dir)
         assert delta_mode == "overwrite"
 
     def test_existing_legacy_parquet_overwrite(self, tmp_path):
@@ -495,14 +496,14 @@ class TestResolveWriteDestination:
                 table_name="legacy_table",
                 namespace_id=schema_id,
                 write_mode="overwrite",
-                catalog_dir=tmp_path,
+                target=CatalogStorageTarget(is_cloud=False, base=str(tmp_path)),
             )
         assert existing is not None
         assert delta_mode == "overwrite"
         # Old parquet must still exist (deleted only after new write succeeds)
         assert pq_file.exists()
         # New path should be a directory at the same stem
-        assert dest_path == tmp_path / "legacy"
+        assert dest_path == str(tmp_path / "legacy")
 
     def test_existing_delta_table_append(self, tmp_path):
         _, schema_id = _make_namespace()
@@ -528,10 +529,10 @@ class TestResolveWriteDestination:
                 table_name="delta_append_table",
                 namespace_id=schema_id,
                 write_mode="append",
-                catalog_dir=tmp_path,
+                target=CatalogStorageTarget(is_cloud=False, base=str(tmp_path)),
             )
         assert existing is not None
-        assert dest_path == delta_dir
+        assert dest_path == str(delta_dir)
         assert delta_mode == "append"
 
     def test_existing_delta_table_upsert(self, tmp_path):
@@ -558,10 +559,10 @@ class TestResolveWriteDestination:
                 table_name="delta_upsert_table",
                 namespace_id=schema_id,
                 write_mode="upsert",
-                catalog_dir=tmp_path,
+                target=CatalogStorageTarget(is_cloud=False, base=str(tmp_path)),
             )
         assert existing is not None
-        assert dest_path == delta_dir
+        assert dest_path == str(delta_dir)
         assert delta_mode == "upsert"
 
     def test_new_table_with_merge_mode(self, tmp_path):
@@ -573,7 +574,7 @@ class TestResolveWriteDestination:
                 table_name="new_upsert",
                 namespace_id=schema_id,
                 write_mode="upsert",
-                catalog_dir=tmp_path,
+                target=CatalogStorageTarget(is_cloud=False, base=str(tmp_path)),
             )
         assert existing is None
         assert delta_mode == "upsert"

--- a/flowfile_core/tests/test_catalog_delta.py
+++ b/flowfile_core/tests/test_catalog_delta.py
@@ -579,6 +579,64 @@ class TestResolveWriteDestination:
         assert existing is None
         assert delta_mode == "upsert"
 
+    def test_existing_local_table_stays_local_under_cloud_target(self, tmp_path):
+        """Forward-only: overwriting an existing LOCAL table keeps it local even when the
+        global config now points at object storage — the table is not relocated."""
+        _, schema_id = _make_namespace()
+        delta_dir = tmp_path / "stays_local"
+        delta_dir.mkdir()
+        (delta_dir / "_delta_log").mkdir()
+        with get_db_context() as db:
+            db.add(
+                CatalogTable(
+                    name="stays_local_tbl",
+                    namespace_id=schema_id,
+                    owner_id=1,
+                    file_path=str(delta_dir),
+                    storage_format="delta",
+                )
+            )
+            db.commit()
+
+        with get_db_context() as db:
+            svc = CatalogService(SQLAlchemyCatalogRepository(db))
+            existing, dest_path, delta_mode = svc.resolve_write_destination(
+                table_name="stays_local_tbl",
+                namespace_id=schema_id,
+                write_mode="overwrite",
+                target=CatalogStorageTarget(is_cloud=True, base="s3://bucket/catalog"),
+            )
+        assert existing is not None
+        assert dest_path == str(delta_dir)  # local, not relocated to s3://
+
+    def test_existing_cloud_table_uri_preserved_under_local_target(self):
+        """An existing object-storage table reuses its s3:// URI verbatim (no Path() mangling)
+        even when the global config is local/unset."""
+        _, schema_id = _make_namespace()
+        uri = "s3://bucket/catalog/cloud_tbl_abc123"
+        with get_db_context() as db:
+            db.add(
+                CatalogTable(
+                    name="cloud_tbl",
+                    namespace_id=schema_id,
+                    owner_id=1,
+                    file_path=uri,
+                    storage_format="delta",
+                )
+            )
+            db.commit()
+
+        with get_db_context() as db:
+            svc = CatalogService(SQLAlchemyCatalogRepository(db))
+            existing, dest_path, delta_mode = svc.resolve_write_destination(
+                table_name="cloud_tbl",
+                namespace_id=schema_id,
+                write_mode="overwrite",
+                target=CatalogStorageTarget(is_cloud=False, base="/tmp/local_catalog"),
+            )
+        assert existing is not None
+        assert dest_path == uri  # URI preserved, not corrupted to "s3:/bucket/..."
+
 
 # resolve_table_file_path
 

--- a/flowfile_core/tests/test_catalog_storage_backend.py
+++ b/flowfile_core/tests/test_catalog_storage_backend.py
@@ -1,0 +1,68 @@
+"""Unit tests for the catalog storage resolver (``catalog/storage_backend.py``).
+
+These exercise the config-driven resolution seam without object storage: the
+local default (the byte-for-byte zero-regression guard) and the error paths when
+the cloud URI is set without a usable connection.
+"""
+
+import pytest
+
+from flowfile_core.catalog.storage_backend import (
+    CatalogStorageTarget,
+    _is_cloud_uri,
+    join_catalog_uri,
+    resolve_catalog_storage,
+)
+from shared.storage_config import storage
+
+
+def test_is_cloud_uri():
+    assert _is_cloud_uri("s3://bucket/catalog")
+    assert _is_cloud_uri("gs://bucket/catalog")
+    assert _is_cloud_uri("abfss://container/catalog")
+    assert not _is_cloud_uri("/home/user/.flowfile/catalog_tables")
+    assert not _is_cloud_uri("relative/path")
+
+
+def test_join_catalog_uri_cloud_keeps_scheme():
+    assert join_catalog_uri("s3://bucket/catalog", "t_ab12") == "s3://bucket/catalog/t_ab12"
+    assert join_catalog_uri("s3://bucket/catalog/", "t_ab12") == "s3://bucket/catalog/t_ab12"
+
+
+def test_join_catalog_uri_local_is_filesystem_path():
+    assert join_catalog_uri("/a/b", "t_ab12") == "/a/b/t_ab12"
+
+
+def test_resolve_unset_returns_local_target(monkeypatch):
+    """Unset config ⇒ the local target, identical to today's behavior."""
+    monkeypatch.delenv("FLOWFILE_CATALOG_STORAGE_URI", raising=False)
+    monkeypatch.delenv("FLOWFILE_CATALOG_STORAGE_CONNECTION", raising=False)
+
+    target = resolve_catalog_storage(1)
+    assert target.is_cloud is False
+    assert target.base == str(storage.catalog_tables_directory)
+    assert target.storage_options == {}
+    assert target.connection_name is None
+    assert target.worker_interface is None
+    assert target.to_worker_payload() is None
+
+
+def test_resolve_uri_without_connection_raises(monkeypatch):
+    monkeypatch.setenv("FLOWFILE_CATALOG_STORAGE_URI", "s3://flowfile-test/catalog")
+    monkeypatch.delenv("FLOWFILE_CATALOG_STORAGE_CONNECTION", raising=False)
+
+    with pytest.raises(ValueError, match="FLOWFILE_CATALOG_STORAGE_CONNECTION"):
+        resolve_catalog_storage(1)
+
+
+def test_resolve_missing_connection_raises(monkeypatch):
+    monkeypatch.setenv("FLOWFILE_CATALOG_STORAGE_URI", "s3://flowfile-test/catalog")
+    monkeypatch.setenv("FLOWFILE_CATALOG_STORAGE_CONNECTION", "does-not-exist")
+
+    with pytest.raises(ValueError, match="does-not-exist"):
+        resolve_catalog_storage(1)
+
+
+def test_local_target_to_worker_payload_is_none():
+    target = CatalogStorageTarget(is_cloud=False, base="/tmp/catalog")
+    assert target.to_worker_payload() is None

--- a/flowfile_worker/flowfile_worker/catalog_reader.py
+++ b/flowfile_worker/flowfile_worker/catalog_reader.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import polars as pl
 
-from shared.delta_utils import validate_catalog_path
+from shared.delta_utils import validate_catalog_path, validate_catalog_uri
 from shared.storage_config import storage
 
 
@@ -26,8 +26,20 @@ def _virtual_results_path(name: str) -> Path:
     return validate_catalog_path(name, storage.catalog_virtual_results_directory)
 
 
-def open_catalog_table(name: str) -> pl.LazyFrame:
-    """Open a materialised catalog table by bare directory name."""
+def open_catalog_table(
+    name: str,
+    *,
+    base_uri: str | None = None,
+    storage_options: dict[str, str] | None = None,
+) -> pl.LazyFrame:
+    """Open a materialised catalog table by bare directory name.
+
+    Local by default. When *base_uri* is set the table lives in object storage:
+    the bare name is joined onto *base_uri* (same traversal guards) and scanned
+    with *storage_options*.
+    """
+    if base_uri is not None:
+        return pl.scan_delta(validate_catalog_uri(name, base_uri), storage_options=storage_options)
     return pl.scan_delta(str(_catalog_path(name)))
 
 

--- a/flowfile_worker/flowfile_worker/funcs.py
+++ b/flowfile_worker/flowfile_worker/funcs.py
@@ -614,7 +614,7 @@ def write_delta(
     output_path: str,
     mode: str = "overwrite",
     partition_by: list[str] | None = None,
-    storage: dict | None = None,
+    storage_payload: dict | None = None,
     flowfile_flow_id: int = -1,
     flowfile_node_id: int | str = -1,
 ):
@@ -624,16 +624,16 @@ def write_delta(
     a Delta table at *output_path*.  Metadata (schema, row_count, size_bytes)
     is returned via the queue so the core never needs to read the table.
 
-    *storage* (a serialized ``CatalogStorageInterface``) routes the write to object
-    storage; ``None`` writes to the local filesystem. *output_path* is already the
-    fully-resolved destination (local path or ``s3://`` URI).
+    *storage_payload* (a serialized ``CatalogStorageInterface``) routes the write to
+    object storage; ``None`` writes to the local filesystem. *output_path* is already
+    the fully-resolved destination (local path or ``s3://`` URI).
     """
     flowfile_logger = get_worker_logger(flowfile_flow_id, flowfile_node_id)
     flowfile_logger.info(f"Starting write_delta operation to: {output_path}")
     try:
         from shared.delta_utils import write_delta as _write_delta
 
-        storage_options = _resolve_storage_options(storage)
+        storage_options = _resolve_storage_options(storage_payload)
         lf = pl.LazyFrame.deserialize(io.BytesIO(polars_serializable_object))
         df = collect_lazy_frame(lf)
         wrote = _write_delta(df, output_path, mode=mode, partition_by=partition_by, storage_options=storage_options)
@@ -679,7 +679,7 @@ def merge_delta(
     merge_mode: str = "upsert",
     merge_keys: list[str] | None = None,
     partition_by: list[str] | None = None,
-    storage: dict | None = None,
+    storage_payload: dict | None = None,
     flowfile_flow_id: int = -1,
     flowfile_node_id: int | str = -1,
 ):
@@ -690,15 +690,15 @@ def merge_delta(
     - update: update only matched rows (no inserts)
     - delete: remove matched rows from target
 
-    *storage* (a serialized ``CatalogStorageInterface``) routes the merge to object
-    storage; ``None`` merges into a local-filesystem table.
+    *storage_payload* (a serialized ``CatalogStorageInterface``) routes the merge to
+    object storage; ``None`` merges into a local-filesystem table.
     """
     flowfile_logger = get_worker_logger(flowfile_flow_id, flowfile_node_id)
     flowfile_logger.info(f"Starting merge_delta ({merge_mode}) to: {output_path}")
     try:
         from shared.delta_utils import merge_into_delta
 
-        storage_options = _resolve_storage_options(storage)
+        storage_options = _resolve_storage_options(storage_payload)
         lf = pl.LazyFrame.deserialize(io.BytesIO(polars_serializable_object))
         df = collect_lazy_frame(lf)
         wrote = merge_into_delta(

--- a/flowfile_worker/flowfile_worker/funcs.py
+++ b/flowfile_worker/flowfile_worker/funcs.py
@@ -18,13 +18,40 @@ from flowfile_worker.external_sources.sql_source.main import write_df_to_databas
 from flowfile_worker.external_sources.sql_source.models import DatabaseWriteSettings
 from flowfile_worker.flow_logger import get_worker_logger
 from flowfile_worker.utils import collect_lazy_frame, collect_lazy_frame_and_get_streaming_info
-from shared.delta_utils import format_delta_timestamp, get_delta_size_bytes, make_json_safe, validate_catalog_path
+from shared.delta_utils import (
+    format_delta_timestamp,
+    get_delta_size_bytes,
+    make_json_safe,
+    validate_catalog_path,
+    validate_catalog_uri,
+)
 from shared.storage_config import storage
 
 
 def _validate_catalog_path(table_name: str) -> Path:
     """Validate and resolve *table_name* under the catalog tables directory."""
     return validate_catalog_path(table_name, storage.catalog_tables_directory)
+
+
+def _resolve_catalog_target(table_name: str, base_uri: str | None) -> str:
+    """Resolve a bare *table_name* to a local path or an object-storage URI."""
+    if base_uri is not None:
+        return validate_catalog_uri(table_name, base_uri)
+    return str(_validate_catalog_path(table_name))
+
+
+def _resolve_storage_options(storage_payload: dict | None) -> dict | None:
+    """Decrypt object-storage options from a serialized ``CatalogStorageInterface``.
+
+    Returns ``None`` for local writes. The connection's secrets are owner-encrypted
+    (``$ffsec$1$...``) and decrypted here, worker-side, never crossing the wire in plaintext.
+    """
+    if not storage_payload:
+        return None
+    from flowfile_worker.external_sources.s3_source.models import FullCloudStorageConnection
+
+    conn = FullCloudStorageConnection(**storage_payload["connection"])
+    return conn.get_storage_options()
 
 
 def _validate_virtual_results_path(name: str) -> Path:
@@ -36,9 +63,9 @@ def _row_count_ipc(p: Path) -> int:
     return int(pl.scan_ipc(str(p)).select(pl.len()).collect().item())
 
 
-def _get_delta_size_bytes(delta_dir: Path) -> int:
+def _get_delta_size_bytes(delta_dir: Path | str, storage_options: dict | None = None) -> int:
     """Delegate to ``shared.delta_utils.get_delta_size_bytes``."""
-    return get_delta_size_bytes(delta_dir)
+    return get_delta_size_bytes(delta_dir, storage_options=storage_options)
 
 
 # 'store', 'calculate_schema', 'calculate_number_of_records', 'write_output', 'fuzzy', 'store_sample']
@@ -126,9 +153,7 @@ def apply_model_task(
     from shared.ml.trainers import get_trainer
 
     flowfile_logger = get_worker_logger(flowfile_flow_id, flowfile_node_id)
-    flowfile_logger.info(
-        f"Starting apply_model_task, output_column={output_column}"
-    )
+    flowfile_logger.info(f"Starting apply_model_task, output_column={output_column}")
     try:
         with open(model_path, "rb") as f:
             model = _json.loads(f.read())
@@ -589,6 +614,7 @@ def write_delta(
     output_path: str,
     mode: str = "overwrite",
     partition_by: list[str] | None = None,
+    storage: dict | None = None,
     flowfile_flow_id: int = -1,
     flowfile_node_id: int | str = -1,
 ):
@@ -597,15 +623,20 @@ def write_delta(
     This offloads the collect() from core to the worker process, producing
     a Delta table at *output_path*.  Metadata (schema, row_count, size_bytes)
     is returned via the queue so the core never needs to read the table.
+
+    *storage* (a serialized ``CatalogStorageInterface``) routes the write to object
+    storage; ``None`` writes to the local filesystem. *output_path* is already the
+    fully-resolved destination (local path or ``s3://`` URI).
     """
     flowfile_logger = get_worker_logger(flowfile_flow_id, flowfile_node_id)
     flowfile_logger.info(f"Starting write_delta operation to: {output_path}")
     try:
         from shared.delta_utils import write_delta as _write_delta
 
+        storage_options = _resolve_storage_options(storage)
         lf = pl.LazyFrame.deserialize(io.BytesIO(polars_serializable_object))
         df = collect_lazy_frame(lf)
-        wrote = _write_delta(df, output_path, mode=mode, partition_by=partition_by)
+        wrote = _write_delta(df, output_path, mode=mode, partition_by=partition_by, storage_options=storage_options)
 
         if not wrote:
             queue.put({"skipped": True})
@@ -614,7 +645,7 @@ def write_delta(
                 progress.value = 100
             return
 
-        size_bytes = _get_delta_size_bytes(Path(output_path))
+        size_bytes = _get_delta_size_bytes(output_path, storage_options=storage_options)
         schema = [{"name": col, "dtype": str(df[col].dtype)} for col in df.columns]
 
         queue.put(
@@ -648,6 +679,7 @@ def merge_delta(
     merge_mode: str = "upsert",
     merge_keys: list[str] | None = None,
     partition_by: list[str] | None = None,
+    storage: dict | None = None,
     flowfile_flow_id: int = -1,
     flowfile_node_id: int | str = -1,
 ):
@@ -657,16 +689,25 @@ def merge_delta(
     - upsert: update matched rows + insert unmatched
     - update: update only matched rows (no inserts)
     - delete: remove matched rows from target
+
+    *storage* (a serialized ``CatalogStorageInterface``) routes the merge to object
+    storage; ``None`` merges into a local-filesystem table.
     """
     flowfile_logger = get_worker_logger(flowfile_flow_id, flowfile_node_id)
     flowfile_logger.info(f"Starting merge_delta ({merge_mode}) to: {output_path}")
     try:
         from shared.delta_utils import merge_into_delta
 
+        storage_options = _resolve_storage_options(storage)
         lf = pl.LazyFrame.deserialize(io.BytesIO(polars_serializable_object))
         df = collect_lazy_frame(lf)
         wrote = merge_into_delta(
-            df, output_path, merge_mode=merge_mode, merge_keys=merge_keys, partition_by=partition_by
+            df,
+            output_path,
+            merge_mode=merge_mode,
+            merge_keys=merge_keys,
+            partition_by=partition_by,
+            storage_options=storage_options,
         )
 
         if not wrote:
@@ -676,11 +717,11 @@ def merge_delta(
                 progress.value = 100
             return
 
-        result_df = pl.scan_delta(output_path)
+        result_df = pl.scan_delta(output_path, storage_options=storage_options)
         result_schema = result_df.collect_schema()
         schema = [{"name": n, "dtype": str(d)} for n, d in result_schema.items()]
         row_count = result_df.select(pl.len()).collect().item()
-        size_bytes = _get_delta_size_bytes(Path(output_path))
+        size_bytes = _get_delta_size_bytes(output_path, storage_options=storage_options)
 
         queue.put(
             {
@@ -709,9 +750,16 @@ def materialize_catalog_table_task(
     progress: Value,
     error_message: Array,
     queue: Queue,
+    storage_options: dict | None = None,
 ):
-    """Subprocess task: reads a source file and materializes it as a Delta table, returning metadata via queue."""
+    """Subprocess task: reads a source file and materializes it as a Delta table, returning metadata via queue.
+
+    *dest_path* is the fully-resolved destination (local path or ``s3://`` URI); the
+    route decrypts *storage_options* and passes them in for the object-storage case.
+    """
     try:
+        from shared.delta_utils import write_delta as _write_delta
+
         ext = os.path.splitext(source_file_path)[1].lower()
         if ext in (".csv", ".txt", ".tsv"):
             df = pl.scan_csv(source_file_path, infer_schema_length=10000, encoding="utf8-lossy")
@@ -725,10 +773,9 @@ def materialize_catalog_table_task(
         if isinstance(df, pl.LazyFrame):
             df = df.collect()
 
-        os.makedirs(dest_path, exist_ok=True)
-        df.write_delta(dest_path, mode="overwrite")
+        _write_delta(df, dest_path, mode="overwrite", storage_options=storage_options)
 
-        size_bytes = _get_delta_size_bytes(Path(dest_path))
+        size_bytes = _get_delta_size_bytes(dest_path, storage_options=storage_options)
         schema = [{"name": col, "dtype": str(df[col].dtype)} for col in df.columns]
 
         queue.put(
@@ -756,18 +803,20 @@ def optimize_catalog_table_task(
     progress: Value,
     error_message: Array,
     queue: Queue,
+    storage_options: dict | None = None,
 ):
     """Subprocess task: compact (and optionally Z-order) a Delta catalog table.
 
-    *table_path* is the absolute, already-validated table directory (the route
-    resolves it in the parent process so this works regardless of the child's
-    storage configuration).
+    *table_path* is the absolute, already-validated table directory or object-storage
+    URI (the route resolves it in the parent process so this works regardless of the
+    child's storage configuration). *storage_options* is set for the object-storage case.
     """
     try:
         from shared.delta_utils import optimize_delta
 
-        metrics = optimize_delta(table_path, z_order_columns=z_order_columns or None)
-        queue.put({"metrics": metrics, "size_bytes": _get_delta_size_bytes(Path(table_path))})
+        metrics = optimize_delta(table_path, z_order_columns=z_order_columns or None, storage_options=storage_options)
+        size_bytes = _get_delta_size_bytes(table_path, storage_options=storage_options)
+        queue.put({"metrics": metrics, "size_bytes": size_bytes})
         with progress.get_lock():
             progress.value = 100
     except Exception as e:
@@ -785,20 +834,24 @@ def vacuum_catalog_table_task(
     progress: Value,
     error_message: Array,
     queue: Queue,
+    storage_options: dict | None = None,
 ):
     """Subprocess task: vacuum tombstoned files from a Delta catalog table.
 
-    *table_path* is the absolute, already-validated table directory.
+    *table_path* is the absolute, already-validated table directory or object-storage
+    URI; *storage_options* is set for the object-storage case.
     """
     try:
         from shared.delta_utils import vacuum_delta
 
-        files = vacuum_delta(table_path, retention_hours=retention_hours, dry_run=dry_run)
+        files = vacuum_delta(
+            table_path, retention_hours=retention_hours, dry_run=dry_run, storage_options=storage_options
+        )
         queue.put(
             {
                 "files_removed": list(files),
                 "file_count": len(files),
-                "size_bytes": _get_delta_size_bytes(Path(table_path)),
+                "size_bytes": _get_delta_size_bytes(table_path, storage_options=storage_options),
             }
         )
         with progress.get_lock():
@@ -816,17 +869,20 @@ def execute_sql_query(
     tables: dict[str, str],
     max_rows: int = 10_000,
     virtual_refs: dict[str, str] | None = None,
+    base_uri: str | None = None,
+    storage_options: dict | None = None,
 ) -> dict:
     """Execute a SQL query against catalog tables using pl.SQLContext.
 
     *tables* is a mapping of logical table name -> directory name.  The
     directory name is resolved under the catalog tables directory using
-    ``_validate_catalog_path``.  Only tables actually referenced in the
-    query plan are reported in *used_tables*.
+    ``_validate_catalog_path`` (or, when *base_uri* is set, joined onto the
+    object-storage root and scanned with *storage_options*).  Only tables
+    actually referenced in the query plan are reported in *used_tables*.
 
     *virtual_refs* is an optional mapping of virtual table name -> bare IPC
     filename under the catalog_virtual_results directory; the worker scans
-    each via ``pl.scan_ipc``.
+    each via ``pl.scan_ipc`` (always local).
 
     Returns a dict matching the SqlQueryResponse schema.
     """
@@ -838,7 +894,7 @@ def execute_sql_query(
     ctx = pl.SQLContext()
     registered_names: list[str] = []
     for name, dir_name in tables.items():
-        ctx.register(name, open_catalog_table(dir_name))
+        ctx.register(name, open_catalog_table(dir_name, base_uri=base_uri, storage_options=storage_options))
         registered_names.append(name)
 
     if virtual_refs:
@@ -877,19 +933,20 @@ def execute_sql_query(
     }
 
 
-def read_table_metadata(table_name: str) -> dict:
-    """Read schema, row_count, column_count, size_bytes from a table on disk.
+def read_table_metadata(table_name: str, base_uri: str | None = None, storage_options: dict | None = None) -> dict:
+    """Read schema, row_count, column_count, size_bytes from a table.
 
     *table_name* is the bare directory name inside the catalog tables
-    directory (no path separators allowed).
+    directory (no path separators allowed); when *base_uri* is set the table
+    lives in object storage and is read with *storage_options*.
 
     Called by the worker endpoint so the core process never touches data files.
     """
-    lf = open_catalog_table(table_name)
+    lf = open_catalog_table(table_name, base_uri=base_uri, storage_options=storage_options)
     schema = lf.collect_schema()
     schema_list = [{"name": n, "dtype": str(d)} for n, d in schema.items()]
     row_count = lf.select(pl.len()).collect().item()
-    size_bytes = _get_delta_size_bytes(_validate_catalog_path(table_name))
+    size_bytes = _get_delta_size_bytes(_resolve_catalog_target(table_name, base_uri), storage_options=storage_options)
     return {
         "schema": schema_list,
         "row_count": row_count,
@@ -898,13 +955,19 @@ def read_table_metadata(table_name: str) -> dict:
     }
 
 
-def get_delta_history(table_name: str, limit: int | None = None) -> models.DeltaHistoryResponse:
+def get_delta_history(
+    table_name: str,
+    limit: int | None = None,
+    base_uri: str | None = None,
+    storage_options: dict | None = None,
+) -> models.DeltaHistoryResponse:
     """Read version history from a Delta table using the deltalake library.
 
-    *table_name* is the bare directory name inside the catalog tables directory.
+    *table_name* is the bare directory name inside the catalog tables directory,
+    or a key under *base_uri* in object storage when set.
     """
-    validated = _validate_catalog_path(table_name)
-    dt = DeltaTable(str(validated))
+    target = _resolve_catalog_target(table_name, base_uri)
+    dt = DeltaTable(target, storage_options=storage_options)
     history = dt.history(limit)
     current_version = dt.version()
     entries: list[models.DeltaVersionCommit] = []
@@ -920,13 +983,20 @@ def get_delta_history(table_name: str, limit: int | None = None) -> models.Delta
     return models.DeltaHistoryResponse(current_version=current_version, history=entries)
 
 
-def read_delta_version_preview(table_name: str, version: int, n_rows: int = 100) -> models.DeltaVersionPreviewResponse:
+def read_delta_version_preview(
+    table_name: str,
+    version: int,
+    n_rows: int = 100,
+    base_uri: str | None = None,
+    storage_options: dict | None = None,
+) -> models.DeltaVersionPreviewResponse:
     """Read a preview of a Delta table at a specific version using deltalake + PyArrow (no Polars).
 
-    *table_name* is the bare directory name inside the catalog tables directory.
+    *table_name* is the bare directory name inside the catalog tables directory,
+    or a key under *base_uri* in object storage when set.
     """
-    validated = _validate_catalog_path(table_name)
-    dt = DeltaTable(str(validated), version=version)
+    target = _resolve_catalog_target(table_name, base_uri)
+    dt = DeltaTable(target, version=version, storage_options=storage_options)
     dataset = dt.to_pyarrow_dataset()
     pa_table = dataset.head(n_rows)
     columns = pa_table.column_names

--- a/flowfile_worker/flowfile_worker/models.py
+++ b/flowfile_worker/flowfile_worker/models.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any, Literal
 from pl_fuzzy_frame_match import FuzzyMapping
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, PlainSerializer
 
-from flowfile_worker.external_sources.s3_source.models import CloudStorageWriteSettings
+from flowfile_worker.external_sources.s3_source.models import CloudStorageWriteSettings, FullCloudStorageConnection
 from flowfile_worker.external_sources.sql_source.models import DatabaseWriteSettings
 from shared.delta_models import DeltaVersionCommit as DeltaVersionCommit  # noqa: F401
 
@@ -191,9 +191,22 @@ class ColumnSchema(BaseModel):
     dtype: str
 
 
+class CatalogStorageInterface(BaseModel):
+    """Object-storage backend for a catalog operation.
+
+    ``base_uri`` is the catalog root in object storage (e.g. ``s3://bucket/catalog``);
+    ``connection`` carries owner-encrypted secrets the worker decrypts itself via
+    ``connection.get_storage_options()``. ``None`` on a request ⇒ local filesystem.
+    """
+
+    base_uri: str
+    connection: FullCloudStorageConnection
+
+
 class CatalogMaterializeRequest(BaseModel):
     source_file_path: str
     table_name: str | None = None
+    storage: CatalogStorageInterface | None = None
 
 
 class CatalogMaterializeResponse(BaseModel):
@@ -207,6 +220,7 @@ class CatalogMaterializeResponse(BaseModel):
 class CatalogOptimizeRequest(BaseModel):
     table_path: str  # Bare table directory name (no path separators)
     z_order_columns: list[str] | None = None
+    storage: CatalogStorageInterface | None = None
 
 
 class CatalogOptimizeResponse(BaseModel):
@@ -218,6 +232,7 @@ class CatalogVacuumRequest(BaseModel):
     table_path: str  # Bare table directory name (no path separators)
     retention_hours: int = 168
     dry_run: bool = True
+    storage: CatalogStorageInterface | None = None
 
 
 class CatalogVacuumResponse(BaseModel):
@@ -228,6 +243,7 @@ class CatalogVacuumResponse(BaseModel):
 
 class TableMetadataRequest(BaseModel):
     table_path: str  # Bare table directory name (no path separators)
+    storage: CatalogStorageInterface | None = None
 
 
 class TableMetadataResponse(BaseModel):
@@ -240,6 +256,7 @@ class TableMetadataResponse(BaseModel):
 class DeltaHistoryRequest(BaseModel):
     table_path: str  # Bare table directory name (no path separators)
     limit: int | None = None
+    storage: CatalogStorageInterface | None = None
 
 
 class DeltaHistoryResponse(BaseModel):
@@ -251,6 +268,7 @@ class DeltaVersionPreviewRequest(BaseModel):
     table_path: str  # Bare table directory name (no path separators)
     version: int
     n_rows: int = 100
+    storage: CatalogStorageInterface | None = None
 
 
 class DeltaVersionPreviewResponse(BaseModel):
@@ -266,6 +284,7 @@ class SqlQueryRequest(BaseModel):
     tables: dict[str, str]  # mapping of logical table name -> directory name
     max_rows: int = 10_000
     virtual_refs: dict[str, str] | None = None  # name -> bare ipc filename under catalog_virtual_results
+    storage: CatalogStorageInterface | None = None
 
 
 class SqlQueryResponse(BaseModel):

--- a/flowfile_worker/flowfile_worker/routes.py
+++ b/flowfile_worker/flowfile_worker/routes.py
@@ -27,6 +27,7 @@ from flowfile_worker.spawner import (
     start_process,
     start_train_model_process,
 )
+from shared.delta_utils import validate_catalog_uri
 from shared.kafka.models import KafkaReadSettings
 from shared.storage_config import storage
 
@@ -34,6 +35,24 @@ router = APIRouter()
 
 # Re-use the single validation helper from funcs (backed by shared.delta_utils).
 _validate_catalog_path = funcs._validate_catalog_path
+
+
+def _resolve_catalog_route(
+    table_path: str, storage_iface: "models.CatalogStorageInterface | None"
+) -> tuple[str, str | None, dict | None]:
+    """Guard the bare table name and resolve a catalog route's storage target.
+
+    Returns ``(resolved_target, base_uri, storage_options)``: a local path + ``None``
+    when *storage_iface* is ``None`` (today's behavior), or an object-storage URI plus
+    the decrypted ``storage_options`` otherwise. Raises ``ValueError`` on a bad name.
+    """
+    if storage_iface is None:
+        return str(_validate_catalog_path(table_path)), None, None
+    return (
+        validate_catalog_uri(table_path, storage_iface.base_uri),
+        storage_iface.base_uri,
+        storage_iface.connection.get_storage_options(),
+    )
 
 
 def create_and_get_default_cache_dir(flowfile_flow_id: int) -> str:
@@ -491,11 +510,15 @@ def resolve_virtual_table(payload: models.ResolveVirtualTableRequest) -> models.
 def catalog_sql_query(payload: models.SqlQueryRequest) -> models.SqlQueryResponse:
     """Execute a SQL query against catalog tables (physical + virtual)."""
     try:
+        base_uri = payload.storage.base_uri if payload.storage is not None else None
+        storage_options = payload.storage.connection.get_storage_options() if payload.storage is not None else None
         result = funcs.execute_sql_query(
             payload.query,
             payload.tables,
             payload.max_rows,
             virtual_refs=payload.virtual_refs,
+            base_uri=base_uri,
+            storage_options=storage_options,
         )
         return models.SqlQueryResponse(**result)
     except ValueError as e:
@@ -516,16 +539,20 @@ def materialize_catalog_table(payload: models.CatalogMaterializeRequest) -> mode
             detail={"error_type": "unsupported_file_type", "message": f"Unsupported file type: {ext}"},
         )
 
-    dest_dir = storage.catalog_tables_directory
-    dest_dir.mkdir(parents=True, exist_ok=True)
-
     # Generate a directory name for the Delta table (not a .parquet filename)
     if payload.table_name:
         dir_name = f"{payload.table_name}_{uuid.uuid4().hex[:8]}"
     else:
         dir_name = f"catalog_{uuid.uuid4().hex}"
 
-    dest_path = str(dest_dir / dir_name)
+    if payload.storage is not None:
+        dest_path = validate_catalog_uri(dir_name, payload.storage.base_uri)
+        storage_options = payload.storage.connection.get_storage_options()
+    else:
+        dest_dir = storage.catalog_tables_directory
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest_path = str(dest_dir / dir_name)
+        storage_options = None
 
     progress = mp_context.Value("i", 0)
     error_message = mp_context.Array("c", 1024)
@@ -539,6 +566,7 @@ def materialize_catalog_table(payload: models.CatalogMaterializeRequest) -> mode
             "progress": progress,
             "error_message": error_message,
             "queue": queue,
+            "storage_options": storage_options,
         },
     )
     p.start()
@@ -595,7 +623,7 @@ def _drain_then_join(p, queue) -> dict | None:
 def optimize_catalog_table(payload: models.CatalogOptimizeRequest) -> models.CatalogOptimizeResponse:
     """Compact (and optionally Z-order) a Delta catalog table in a spawned subprocess."""
     try:
-        resolved_path = str(_validate_catalog_path(payload.table_path))
+        resolved_path, _, storage_options = _resolve_catalog_route(payload.table_path, payload.storage)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -610,6 +638,7 @@ def optimize_catalog_table(payload: models.CatalogOptimizeRequest) -> models.Cat
             "progress": progress,
             "error_message": error_message,
             "queue": queue,
+            "storage_options": storage_options,
         },
     )
     p.start()
@@ -625,9 +654,7 @@ def optimize_catalog_table(payload: models.CatalogOptimizeRequest) -> models.Cat
                 status_code=500,
                 detail={"error_type": "optimize_failure", "message": err or "subprocess returned no result"},
             )
-        return models.CatalogOptimizeResponse(
-            metrics=result.get("metrics", {}), size_bytes=result.get("size_bytes")
-        )
+        return models.CatalogOptimizeResponse(metrics=result.get("metrics", {}), size_bytes=result.get("size_bytes"))
     finally:
         del p, progress, error_message, queue
         gc.collect()
@@ -637,7 +664,7 @@ def optimize_catalog_table(payload: models.CatalogOptimizeRequest) -> models.Cat
 def vacuum_catalog_table(payload: models.CatalogVacuumRequest) -> models.CatalogVacuumResponse:
     """Vacuum tombstoned files from a Delta catalog table in a spawned subprocess."""
     try:
-        resolved_path = str(_validate_catalog_path(payload.table_path))
+        resolved_path, _, storage_options = _resolve_catalog_route(payload.table_path, payload.storage)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -653,6 +680,7 @@ def vacuum_catalog_table(payload: models.CatalogVacuumRequest) -> models.Catalog
             "progress": progress,
             "error_message": error_message,
             "queue": queue,
+            "storage_options": storage_options,
         },
     )
     p.start()
@@ -685,8 +713,8 @@ def read_table_metadata(payload: models.TableMetadataRequest) -> models.TableMet
     This offloads metadata reading from the core process to the worker.
     """
     try:
-        _validate_catalog_path(payload.table_path)
-        result = funcs.read_table_metadata(payload.table_path)
+        _, base_uri, storage_options = _resolve_catalog_route(payload.table_path, payload.storage)
+        result = funcs.read_table_metadata(payload.table_path, base_uri=base_uri, storage_options=storage_options)
         column_schema = [models.ColumnSchema(name=s["name"], dtype=s["dtype"]) for s in result["schema"]]
         return models.TableMetadataResponse(
             column_schema=column_schema,
@@ -705,8 +733,10 @@ def read_table_metadata(payload: models.TableMetadataRequest) -> models.TableMet
 def get_delta_history(payload: models.DeltaHistoryRequest) -> models.DeltaHistoryResponse:
     """Read version history from a Delta table."""
     try:
-        _validate_catalog_path(payload.table_path)
-        return funcs.get_delta_history(payload.table_path, payload.limit)
+        _, base_uri, storage_options = _resolve_catalog_route(payload.table_path, payload.storage)
+        return funcs.get_delta_history(
+            payload.table_path, payload.limit, base_uri=base_uri, storage_options=storage_options
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
@@ -718,8 +748,10 @@ def get_delta_history(payload: models.DeltaHistoryRequest) -> models.DeltaHistor
 def get_delta_version_preview(payload: models.DeltaVersionPreviewRequest) -> models.DeltaVersionPreviewResponse:
     """Preview data from a Delta table at a specific version."""
     try:
-        _validate_catalog_path(payload.table_path)
-        return funcs.read_delta_version_preview(payload.table_path, payload.version, payload.n_rows)
+        _, base_uri, storage_options = _resolve_catalog_route(payload.table_path, payload.storage)
+        return funcs.read_delta_version_preview(
+            payload.table_path, payload.version, payload.n_rows, base_uri=base_uri, storage_options=storage_options
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
@@ -922,9 +954,7 @@ async def memory_usage(task_id: str):
 
 
 @router.post("/train_ml_model")
-async def train_ml_model(
-    polars_script: models.TrainModelInput, background_tasks: BackgroundTasks
-) -> models.Status:
+async def train_ml_model(polars_script: models.TrainModelInput, background_tasks: BackgroundTasks) -> models.Status:
     """Fit a regression model and write its serialised bytes to ``staging_path``.
 
     Core has already called ``ArtifactService.prepare_upload`` and reserved the
@@ -967,9 +997,7 @@ async def train_ml_model(
 
 
 @router.post("/apply_ml_model")
-async def apply_ml_model(
-    polars_script: models.ApplyModelInput, background_tasks: BackgroundTasks
-) -> models.Status:
+async def apply_ml_model(polars_script: models.ApplyModelInput, background_tasks: BackgroundTasks) -> models.Status:
     """Score input data using a previously trained model artifact."""
     logger.info("Starting apply_ml_model task: model_path=%s", polars_script.model_path)
     try:

--- a/flowfile_worker/tests/test_catalog_cloud.py
+++ b/flowfile_worker/tests/test_catalog_cloud.py
@@ -53,10 +53,11 @@ def _catalog_payload() -> dict:
     """Build a ``CatalogStorageInterface`` payload exactly as core sends it to the worker.
 
     ``aws_secret_access_key`` is an owner-encrypted ``$ffsec$…`` token (built here via
-    ``encrypt_secret``, mirroring core's worker-interface), so the test exercises the
-    real HKDF decrypt inside ``_resolve_storage_options`` rather than passing plaintext.
+    ``encrypt_secret`` with a user_id, mirroring core's worker-interface), so the test
+    exercises the real per-user HKDF decrypt inside ``_resolve_storage_options`` rather
+    than passing plaintext.
     """
-    encrypted_secret = encrypt_secret("minioadmin")
+    encrypted_secret = encrypt_secret("minioadmin", user_id=1)
     assert encrypted_secret.startswith("$ffsec$")
     return {
         "base_uri": _BASE_URI,

--- a/flowfile_worker/tests/test_catalog_cloud.py
+++ b/flowfile_worker/tests/test_catalog_cloud.py
@@ -1,0 +1,91 @@
+"""Object-storage coverage for the worker catalog read/write path (MinIO, Docker-gated).
+
+Validates the core→worker credential hand-off (``_resolve_storage_options`` decrypts
+the owner-encrypted connection), the cloud branch of ``open_catalog_table`` /
+``read_table_metadata``, and that a Delta table actually lands in object storage.
+"""
+
+import polars as pl
+import pytest
+
+from flowfile_worker import funcs
+from flowfile_worker.catalog_reader import open_catalog_table
+from shared.delta_utils import write_delta
+
+try:
+    from test_utils.s3.fixtures import get_minio_client, is_docker_available, managed_minio
+    from tests.utils import cloud_storage_connection_settings  # noqa: F401  (pytest fixture)
+except ModuleNotFoundError:  # pragma: no cover - import shim for ad-hoc runs
+    import os
+    import sys
+
+    sys.path.append(os.path.dirname(os.path.abspath("flowfile_worker/tests/utils.py")))
+    from test_utils.s3.fixtures import get_minio_client, is_docker_available, managed_minio
+    from utils import cloud_storage_connection_settings  # noqa: F401
+
+requires_docker = pytest.mark.skipif(not is_docker_available(), reason="Docker required for MinIO")
+
+_BASE_URI = "s3://worker-test-bucket/catalog"
+
+
+def _catalog_payload(conn) -> dict:
+    """Build a ``CatalogStorageInterface`` payload as core sends it to the worker.
+
+    The connection secrets are the *encrypted* tokens (plain strings, as the core
+    worker-interface model_dumps them), which the worker decrypts itself.
+    """
+    return {
+        "base_uri": _BASE_URI,
+        "connection": {
+            "storage_type": "s3",
+            "auth_method": "access_key",
+            "connection_name": "minio-test",
+            "aws_region": "us-east-1",
+            "aws_access_key_id": "minioadmin",
+            "aws_secret_access_key": conn.aws_secret_access_key.get_secret_value(),
+            "endpoint_url": "http://localhost:9000",
+            "aws_allow_unsafe_html": True,
+        },
+    }
+
+
+def test_resolve_storage_options_none_is_local():
+    assert funcs._resolve_storage_options(None) is None
+    assert funcs._resolve_storage_options({}) is None
+
+
+@requires_docker
+def test_storage_options_decrypt_roundtrip(cloud_storage_connection_settings):
+    """The worker decrypts the owner-encrypted connection back to usable options."""
+    payload = _catalog_payload(cloud_storage_connection_settings)
+    opts = funcs._resolve_storage_options(payload)
+    assert opts["aws_access_key_id"] == "minioadmin"
+    assert opts["aws_secret_access_key"] == "minioadmin"
+    assert opts["endpoint_url"] == "http://localhost:9000"
+    assert opts["aws_allow_http"] == "true"
+
+
+@requires_docker
+def test_worker_catalog_cloud_write_read_metadata(cloud_storage_connection_settings):
+    with managed_minio():
+        payload = _catalog_payload(cloud_storage_connection_settings)
+        opts = funcs._resolve_storage_options(payload)
+        name = "wtbl"
+        uri = _BASE_URI + "/" + name
+
+        write_delta(pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}), uri, mode="overwrite", storage_options=opts)
+
+        # Worker reader returns rows from object storage.
+        lf = open_catalog_table(name, base_uri=_BASE_URI, storage_options=opts)
+        assert lf.collect().height == 3
+
+        # Worker metadata reader reports the cloud table's shape/size.
+        meta = funcs.read_table_metadata(name, base_uri=_BASE_URI, storage_options=opts)
+        assert meta["row_count"] == 3
+        assert meta["column_count"] == 2
+        assert meta["size_bytes"] > 0
+
+        # The Delta log actually exists in object storage.
+        client = get_minio_client()
+        listed = client.list_objects_v2(Bucket="worker-test-bucket", Prefix="catalog/wtbl/_delta_log/")
+        assert listed.get("KeyCount", 0) > 0

--- a/flowfile_worker/tests/test_catalog_cloud.py
+++ b/flowfile_worker/tests/test_catalog_cloud.py
@@ -1,8 +1,10 @@
-"""Object-storage coverage for the worker catalog read/write path (MinIO, Docker-gated).
+"""Object-storage coverage for the worker catalog read/write path (MinIO).
 
-Validates the core→worker credential hand-off (``_resolve_storage_options`` decrypts
-the owner-encrypted connection), the cloud branch of ``open_catalog_table`` /
-``read_table_metadata``, and that a Delta table actually lands in object storage.
+Connects to the MinIO mock the test job already started (``poetry run start_minio``);
+it must NOT manage that container's lifecycle. Validates the core→worker credential
+hand-off (``_resolve_storage_options`` decrypts the owner-encrypted connection), the
+cloud branch of ``open_catalog_table`` / ``read_table_metadata``, and that a Delta
+table actually lands in object storage.
 """
 
 import polars as pl
@@ -10,30 +12,52 @@ import pytest
 
 from flowfile_worker import funcs
 from flowfile_worker.catalog_reader import open_catalog_table
+from flowfile_worker.secrets import encrypt_secret
 from shared.delta_utils import write_delta
 
 try:
-    from test_utils.s3.fixtures import get_minio_client, is_docker_available, managed_minio
-    from tests.utils import cloud_storage_connection_settings  # noqa: F401  (pytest fixture)
+    from test_utils.s3.fixtures import get_minio_client, is_docker_available
 except ModuleNotFoundError:  # pragma: no cover - import shim for ad-hoc runs
     import os
     import sys
 
-    sys.path.append(os.path.dirname(os.path.abspath("flowfile_worker/tests/utils.py")))
-    from test_utils.s3.fixtures import get_minio_client, is_docker_available, managed_minio
-    from utils import cloud_storage_connection_settings  # noqa: F401
+    sys.path.append(os.path.dirname(os.path.abspath("test_utils/s3/fixtures.py")))
+    from test_utils.s3.fixtures import get_minio_client, is_docker_available
 
-requires_docker = pytest.mark.skipif(not is_docker_available(), reason="Docker required for MinIO")
-
-_BASE_URI = "s3://worker-test-bucket/catalog"
+_BUCKET = "worker-test-bucket"
+_BASE_URI = f"s3://{_BUCKET}/catalog"
 
 
-def _catalog_payload(conn) -> dict:
-    """Build a ``CatalogStorageInterface`` payload as core sends it to the worker.
+def _minio_available() -> bool:
+    """True only when the shared MinIO mock is reachable (never starts/stops it)."""
+    if not is_docker_available():
+        return False
+    try:
+        get_minio_client().list_buckets()
+        return True
+    except Exception:
+        return False
 
-    The connection secrets are the *encrypted* tokens (plain strings, as the core
-    worker-interface model_dumps them), which the worker decrypts itself.
+
+requires_minio = pytest.mark.skipif(not _minio_available(), reason="MinIO mock S3 not available")
+
+
+def _ensure_bucket() -> None:
+    try:
+        get_minio_client().create_bucket(Bucket=_BUCKET)
+    except Exception:
+        pass  # already exists
+
+
+def _catalog_payload() -> dict:
+    """Build a ``CatalogStorageInterface`` payload exactly as core sends it to the worker.
+
+    ``aws_secret_access_key`` is an owner-encrypted ``$ffsec$…`` token (built here via
+    ``encrypt_secret``, mirroring core's worker-interface), so the test exercises the
+    real HKDF decrypt inside ``_resolve_storage_options`` rather than passing plaintext.
     """
+    encrypted_secret = encrypt_secret("minioadmin")
+    assert encrypted_secret.startswith("$ffsec$")
     return {
         "base_uri": _BASE_URI,
         "connection": {
@@ -42,7 +66,7 @@ def _catalog_payload(conn) -> dict:
             "connection_name": "minio-test",
             "aws_region": "us-east-1",
             "aws_access_key_id": "minioadmin",
-            "aws_secret_access_key": conn.aws_secret_access_key.get_secret_value(),
+            "aws_secret_access_key": encrypted_secret,
             "endpoint_url": "http://localhost:9000",
             "aws_allow_unsafe_html": True,
         },
@@ -54,38 +78,35 @@ def test_resolve_storage_options_none_is_local():
     assert funcs._resolve_storage_options({}) is None
 
 
-@requires_docker
-def test_storage_options_decrypt_roundtrip(cloud_storage_connection_settings):
+@requires_minio
+def test_storage_options_decrypt_roundtrip():
     """The worker decrypts the owner-encrypted connection back to usable options."""
-    payload = _catalog_payload(cloud_storage_connection_settings)
-    opts = funcs._resolve_storage_options(payload)
+    opts = funcs._resolve_storage_options(_catalog_payload())
     assert opts["aws_access_key_id"] == "minioadmin"
     assert opts["aws_secret_access_key"] == "minioadmin"
     assert opts["endpoint_url"] == "http://localhost:9000"
     assert opts["aws_allow_http"] == "true"
 
 
-@requires_docker
-def test_worker_catalog_cloud_write_read_metadata(cloud_storage_connection_settings):
-    with managed_minio():
-        payload = _catalog_payload(cloud_storage_connection_settings)
-        opts = funcs._resolve_storage_options(payload)
-        name = "wtbl"
-        uri = _BASE_URI + "/" + name
+@requires_minio
+def test_worker_catalog_cloud_write_read_metadata():
+    _ensure_bucket()
+    opts = funcs._resolve_storage_options(_catalog_payload())
+    name = "wtbl"
+    uri = _BASE_URI + "/" + name
 
-        write_delta(pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}), uri, mode="overwrite", storage_options=opts)
+    write_delta(pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]}), uri, mode="overwrite", storage_options=opts)
 
-        # Worker reader returns rows from object storage.
-        lf = open_catalog_table(name, base_uri=_BASE_URI, storage_options=opts)
-        assert lf.collect().height == 3
+    # Worker reader returns rows from object storage.
+    lf = open_catalog_table(name, base_uri=_BASE_URI, storage_options=opts)
+    assert lf.collect().height == 3
 
-        # Worker metadata reader reports the cloud table's shape/size.
-        meta = funcs.read_table_metadata(name, base_uri=_BASE_URI, storage_options=opts)
-        assert meta["row_count"] == 3
-        assert meta["column_count"] == 2
-        assert meta["size_bytes"] > 0
+    # Worker metadata reader reports the cloud table's shape/size.
+    meta = funcs.read_table_metadata(name, base_uri=_BASE_URI, storage_options=opts)
+    assert meta["row_count"] == 3
+    assert meta["column_count"] == 2
+    assert meta["size_bytes"] > 0
 
-        # The Delta log actually exists in object storage.
-        client = get_minio_client()
-        listed = client.list_objects_v2(Bucket="worker-test-bucket", Prefix="catalog/wtbl/_delta_log/")
-        assert listed.get("KeyCount", 0) > 0
+    # The Delta log actually exists in object storage.
+    listed = get_minio_client().list_objects_v2(Bucket=_BUCKET, Prefix="catalog/wtbl/_delta_log/")
+    assert listed.get("KeyCount", 0) > 0

--- a/shared/delta_utils.py
+++ b/shared/delta_utils.py
@@ -75,24 +75,45 @@ def get_delta_size_bytes(path: str | Path, storage_options: dict[str, str] | Non
         return sum(f.stat().st_size for f in Path(path).rglob("*.parquet"))
 
 
+def _open_delta_or_none(output_path: str, storage_options: dict[str, str] | None):
+    """Open the Delta table at *output_path*, or return ``None`` if it doesn't exist.
+
+    Only a genuine "table not found" yields ``None``. Any other failure (bad
+    credentials, network/DNS error, S3 timeout) propagates — a transient error must
+    never be mistaken for a missing table, which would silently create or overwrite.
+    """
+    from deltalake import DeltaTable
+    from deltalake.exceptions import TableNotFoundError
+
+    if storage_options is None:
+        import os
+
+        if not (os.path.isdir(output_path) and os.path.isdir(os.path.join(output_path, "_delta_log"))):
+            return None
+        try:
+            return DeltaTable(str(output_path))
+        except TableNotFoundError:
+            return None
+
+    try:
+        return DeltaTable(str(output_path), storage_options=storage_options)
+    except TableNotFoundError:
+        return None
+
+
 def _delta_table_exists(output_path: str, storage_options: dict[str, str] | None) -> bool:
     """Return ``True`` if a Delta table exists at *output_path* (local or object storage).
 
     Locally this is a cheap ``_delta_log`` directory probe; for object storage it
-    attempts to open the table, treating any failure as "does not exist".
+    attempts to open the table. A genuine "not found" returns ``False``; any other
+    error (auth / network / credentials) propagates rather than masquerading as missing.
     """
     if storage_options is None:
         import os
 
         return os.path.isdir(output_path) and os.path.isdir(os.path.join(output_path, "_delta_log"))
 
-    from deltalake import DeltaTable
-
-    try:
-        DeltaTable(str(output_path), storage_options=storage_options)
-        return True
-    except Exception:
-        return False
+    return _open_delta_or_none(output_path, storage_options) is not None
 
 
 # Catalog path validation
@@ -145,15 +166,15 @@ def write_delta(
         os.makedirs(output_path, exist_ok=True)
 
     # Skip no-op append: empty data with unchanged schema on existing table
-    if mode == "append" and _delta_table_exists(output_path, storage_options):
-        from deltalake import DeltaTable
-
-        existing_cols = {f.name for f in DeltaTable(str(output_path), storage_options=storage_options).schema().fields}
-        incoming_cols = _frame_column_names(df)
-        if incoming_cols == existing_cols:
-            row_count = df.select(pl_.len()).collect().item() if isinstance(df, pl_.LazyFrame) else df.height
-            if row_count == 0:
-                return False
+    if mode == "append":
+        existing_dt = _open_delta_or_none(output_path, storage_options)
+        if existing_dt is not None:
+            existing_cols = {f.name for f in existing_dt.schema().fields}
+            incoming_cols = _frame_column_names(df)
+            if incoming_cols == existing_cols:
+                row_count = df.select(pl_.len()).collect().item() if isinstance(df, pl_.LazyFrame) else df.height
+                if row_count == 0:
+                    return False
 
     delta_write_options: dict[str, object] = {}
     if mode == "overwrite":
@@ -200,12 +221,13 @@ def merge_into_delta(
 
     from deltalake import DeltaTable
 
-    table_exists = _delta_table_exists(output_path, storage_options)
+    # Open the target once (re-used below) rather than probing then re-opening.
+    dt = _open_delta_or_none(output_path, storage_options)
+    table_exists = dt is not None
 
     # Skip no-op update: empty data with unchanged schema on existing table
     if merge_mode == "update" and df.height == 0 and table_exists:
-        existing_cols = {f.name for f in DeltaTable(str(output_path), storage_options=storage_options).schema().fields}
-        if set(df.columns) == existing_cols:
+        if set(df.columns) == {f.name for f in dt.schema().fields}:
             return False
 
     create_kwargs: dict[str, object] = {}
@@ -228,8 +250,6 @@ def merge_into_delta(
             logger.warning("Ignoring partition_by on merge into existing table: Delta partitioning is immutable")
         if not merge_keys:
             raise ValueError("merge_keys is required for merge operations on existing tables")
-
-        dt = DeltaTable(str(output_path), storage_options=storage_options)
 
         # Schema evolution: add new source columns to the target before merging
         if merge_mode in ("upsert", "update"):

--- a/shared/delta_utils.py
+++ b/shared/delta_utils.py
@@ -50,24 +50,49 @@ def format_delta_timestamp(ts: object) -> str | None:
 # Delta table size
 
 
-def get_delta_size_bytes(path: str | Path) -> int:
+def get_delta_size_bytes(path: str | Path, storage_options: dict[str, str] | None = None) -> int:
     """Sum the sizes of active data files from the Delta transaction log.
 
     Uses the Delta log metadata rather than filesystem scanning, which
     correctly excludes tombstoned files from previous versions.
 
-    Falls back to filesystem scanning if the delta log can't be read.
+    Falls back to filesystem scanning if the delta log can't be read (local only;
+    when *storage_options* is set the table lives in object storage, so an
+    unreadable log yields ``0`` rather than a local filesystem scan).
     """
     from deltalake import DeltaTable
 
     try:
-        dt = DeltaTable(str(path))
+        dt = DeltaTable(str(path), storage_options=storage_options)
         add_actions = dt.get_add_actions(flatten=True)
         size_col = add_actions.column("size_bytes")
         return sum(v for v in size_col.to_pylist() if v is not None)
     except Exception:
+        if storage_options is not None:
+            logger.warning("Failed to read size from delta log for %s", path, exc_info=True)
+            return 0
         logger.warning("Failed to read size from delta log, falling back to filesystem scan", exc_info=True)
         return sum(f.stat().st_size for f in Path(path).rglob("*.parquet"))
+
+
+def _delta_table_exists(output_path: str, storage_options: dict[str, str] | None) -> bool:
+    """Return ``True`` if a Delta table exists at *output_path* (local or object storage).
+
+    Locally this is a cheap ``_delta_log`` directory probe; for object storage it
+    attempts to open the table, treating any failure as "does not exist".
+    """
+    if storage_options is None:
+        import os
+
+        return os.path.isdir(output_path) and os.path.isdir(os.path.join(output_path, "_delta_log"))
+
+    from deltalake import DeltaTable
+
+    try:
+        DeltaTable(str(output_path), storage_options=storage_options)
+        return True
+    except Exception:
+        return False
 
 
 # Catalog path validation
@@ -94,6 +119,7 @@ def write_delta(
     output_path: str,
     mode: str = "overwrite",
     partition_by: list[str] | None = None,
+    storage_options: dict[str, str] | None = None,
 ) -> bool:
     """Write a Polars DataFrame or LazyFrame to a Delta table.
 
@@ -105,18 +131,24 @@ def write_delta(
     is passed through to Delta for every mode: it defines partitioning when the
     table is created and, on writes to an existing table, Delta enforces that it
     matches the table's existing partitioning (raising on a mismatch).
+
+    When *storage_options* is set, *output_path* is an object-storage URI
+    (``s3://...``) and the write targets that backend; the same ``schema_mode`` /
+    ``partition_by`` semantics apply.  When ``None`` the behavior is identical to
+    a local filesystem write.
     """
     import os
 
     import polars as pl_
 
-    os.makedirs(output_path, exist_ok=True)
+    if storage_options is None:
+        os.makedirs(output_path, exist_ok=True)
 
     # Skip no-op append: empty data with unchanged schema on existing table
-    if mode == "append" and os.path.isdir(os.path.join(output_path, "_delta_log")):
+    if mode == "append" and _delta_table_exists(output_path, storage_options):
         from deltalake import DeltaTable
 
-        existing_cols = {f.name for f in DeltaTable(output_path).schema().fields}
+        existing_cols = {f.name for f in DeltaTable(str(output_path), storage_options=storage_options).schema().fields}
         incoming_cols = _frame_column_names(df)
         if incoming_cols == existing_cols:
             row_count = df.select(pl_.len()).collect().item() if isinstance(df, pl_.LazyFrame) else df.height
@@ -133,10 +165,14 @@ def write_delta(
         _validate_partition_columns(df, partition_by)
         delta_write_options["partition_by"] = partition_by
 
+    write_kwargs: dict[str, object] = {"mode": mode, "delta_write_options": delta_write_options}
+    if storage_options is not None:
+        write_kwargs["storage_options"] = storage_options
+
     if isinstance(df, pl_.LazyFrame):
-        df.sink_delta(output_path, mode=mode, delta_write_options=delta_write_options)
+        df.sink_delta(output_path, **write_kwargs)
     else:
-        df.write_delta(output_path, mode=mode, delta_write_options=delta_write_options)
+        df.write_delta(output_path, **write_kwargs)
     return True
 
 
@@ -146,11 +182,17 @@ def merge_into_delta(
     merge_mode: str = "upsert",
     merge_keys: list[str] | None = None,
     partition_by: list[str] | None = None,
+    storage_options: dict[str, str] | None = None,
 ) -> bool:
     """Merge a Polars DataFrame into a Delta table.
 
     Handles table creation when the target doesn't exist yet and supports
     three merge modes: ``upsert``, ``update``, and ``delete``.
+
+    When *storage_options* is set, *output_path* is an object-storage URI and the
+    merge runs against that backend; existence is probed by opening the table
+    rather than via local filesystem checks. ``None`` is identical to today's
+    local behavior.
 
     Returns ``True`` if data was written, ``False`` if the write was a no-op.
     """
@@ -158,39 +200,46 @@ def merge_into_delta(
 
     from deltalake import DeltaTable
 
-    table_exists = os.path.isdir(output_path) and os.path.isdir(os.path.join(output_path, "_delta_log"))
+    table_exists = _delta_table_exists(output_path, storage_options)
 
     # Skip no-op update: empty data with unchanged schema on existing table
     if merge_mode == "update" and df.height == 0 and table_exists:
-        existing_cols = {f.name for f in DeltaTable(output_path).schema().fields}
+        existing_cols = {f.name for f in DeltaTable(str(output_path), storage_options=storage_options).schema().fields}
         if set(df.columns) == existing_cols:
             return False
 
+    create_kwargs: dict[str, object] = {}
+    if storage_options is not None:
+        create_kwargs["storage_options"] = storage_options
+
     if not table_exists:
-        os.makedirs(output_path, exist_ok=True)
+        if storage_options is None:
+            os.makedirs(output_path, exist_ok=True)
         create_opts: dict[str, object] = {}
         if partition_by:
             _validate_partition_columns(df, partition_by)
             create_opts["partition_by"] = partition_by
         if merge_mode in ("delete", "update"):
-            df.clear().write_delta(output_path, mode="error", delta_write_options=create_opts)
+            df.clear().write_delta(output_path, mode="error", delta_write_options=create_opts, **create_kwargs)
         else:
-            df.write_delta(output_path, mode="error", delta_write_options=create_opts)
+            df.write_delta(output_path, mode="error", delta_write_options=create_opts, **create_kwargs)
     else:
         if partition_by:
             logger.warning("Ignoring partition_by on merge into existing table: Delta partitioning is immutable")
         if not merge_keys:
             raise ValueError("merge_keys is required for merge operations on existing tables")
 
-        dt = DeltaTable(output_path)
+        dt = DeltaTable(str(output_path), storage_options=storage_options)
 
         # Schema evolution: add new source columns to the target before merging
         if merge_mode in ("upsert", "update"):
             target_col_names = {field.name for field in dt.schema().fields}
             new_cols = [c for c in df.columns if c not in target_col_names]
             if new_cols:
-                df.clear().write_delta(output_path, mode="append", delta_write_options={"schema_mode": "merge"})
-                dt = DeltaTable(output_path)
+                df.clear().write_delta(
+                    output_path, mode="append", delta_write_options={"schema_mode": "merge"}, **create_kwargs
+                )
+                dt = DeltaTable(str(output_path), storage_options=storage_options)
 
         predicate = " AND ".join(f'target."{k}" = source."{k}"' for k in merge_keys)
         source_arrow = df.to_arrow()
@@ -275,6 +324,12 @@ def validate_catalog_path(table_name: str, catalog_dir: Path) -> Path:
 
     Raises ``ValueError`` when the input is invalid.
     """
+    _guard_bare_table_name(table_name)
+    return catalog_dir.resolve() / table_name
+
+
+def _guard_bare_table_name(table_name: str) -> None:
+    """Raise ``ValueError`` unless *table_name* is a simple, separator-free name."""
     if not table_name:
         raise ValueError("table_name must not be empty")
     if "\x00" in table_name:
@@ -284,4 +339,13 @@ def validate_catalog_path(table_name: str, catalog_dir: Path) -> Path:
     if ".." in table_name:
         raise ValueError("table_name must not contain '..'")
 
-    return catalog_dir.resolve() / table_name
+
+def validate_catalog_uri(table_name: str, base_uri: str) -> str:
+    """Validate *table_name* and join it onto an object-storage *base_uri*.
+
+    The cloud analogue of :func:`validate_catalog_path`: applies the same
+    bare-name guards (no separators, no ``..``, no null bytes) while producing a
+    URI (e.g. ``s3://bucket/prefix/table``) instead of resolving a local path.
+    """
+    _guard_bare_table_name(table_name)
+    return base_uri.rstrip("/") + "/" + table_name

--- a/shared/tests/test_delta_utils_cloud.py
+++ b/shared/tests/test_delta_utils_cloud.py
@@ -1,0 +1,119 @@
+"""Object-storage (S3/MinIO) coverage for the shared Delta helpers.
+
+The S3 round-trips are gated on Docker (MinIO via ``managed_minio``). The
+``validate_catalog_uri`` guards and the ``storage_options=None`` regression run
+everywhere — the latter is the byte-for-byte "unset config == today" guard.
+"""
+
+import polars as pl
+import pytest
+
+from shared.cloud_storage.storage_options import build_storage_options
+from shared.delta_utils import (
+    get_delta_size_bytes,
+    merge_into_delta,
+    validate_catalog_uri,
+    write_delta,
+)
+
+try:
+    from test_utils.s3.fixtures import get_minio_client, is_docker_available, managed_minio
+except ModuleNotFoundError:  # pragma: no cover - import shim for ad-hoc runs
+    import os
+    import sys
+
+    sys.path.append(os.path.dirname(os.path.abspath("test_utils/s3/fixtures.py")))
+    from test_utils.s3.fixtures import get_minio_client, is_docker_available, managed_minio
+
+requires_docker = pytest.mark.skipif(not is_docker_available(), reason="Docker required for MinIO")
+
+
+def _minio_storage_options() -> dict:
+    return build_storage_options(
+        storage_type="s3",
+        auth_method="access_key",
+        aws_region="us-east-1",
+        aws_access_key_id="minioadmin",
+        aws_secret_access_key="minioadmin",
+        endpoint_url="http://localhost:9000",
+        aws_allow_unsafe_html=True,
+    )
+
+
+# ---- Docker-free guards / regression --------------------------------------- #
+
+
+def test_validate_catalog_uri_joins_and_guards():
+    assert validate_catalog_uri("t1", "s3://bucket/catalog") == "s3://bucket/catalog/t1"
+    assert validate_catalog_uri("t1", "s3://bucket/catalog/") == "s3://bucket/catalog/t1"
+    for bad in ("../evil", "a/b", "a\\b", "", "x\x00y"):
+        with pytest.raises(ValueError):
+            validate_catalog_uri(bad, "s3://bucket/catalog")
+
+
+def test_write_delta_local_regression(tmp_path):
+    """storage_options=None ⇒ identical local behavior (no regression)."""
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    dest = str(tmp_path / "local_delta")
+    assert write_delta(df, dest, mode="overwrite") is True
+    assert get_delta_size_bytes(dest) > 0
+    assert pl.scan_delta(dest).collect().height == 3
+
+
+def test_merge_local_regression(tmp_path):
+    dest = str(tmp_path / "local_merge")
+    merge_into_delta(pl.DataFrame({"id": [1, 2], "v": ["a", "b"]}), dest, merge_mode="upsert", merge_keys=["id"])
+    merge_into_delta(pl.DataFrame({"id": [2, 3], "v": ["B", "c"]}), dest, merge_mode="upsert", merge_keys=["id"])
+    res = pl.scan_delta(dest).collect().sort("id")
+    assert res["v"].to_list() == ["a", "B", "c"]
+
+
+# ---- S3 round-trips (Docker) ----------------------------------------------- #
+
+
+@requires_docker
+def test_write_and_size_roundtrip_s3():
+    with managed_minio():
+        opts = _minio_storage_options()
+        uri = "s3://flowfile-test/du_write"
+        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+        assert write_delta(df, uri, mode="overwrite", storage_options=opts) is True
+        assert get_delta_size_bytes(uri, storage_options=opts) > 0
+        assert pl.scan_delta(uri, storage_options=opts).collect().height == 3
+        client = get_minio_client()
+        listed = client.list_objects_v2(Bucket="flowfile-test", Prefix="du_write/_delta_log/")
+        assert listed.get("KeyCount", 0) > 0
+
+
+@requires_docker
+def test_merge_upsert_update_delete_s3():
+    with managed_minio():
+        opts = _minio_storage_options()
+        uri = "s3://flowfile-test/du_merge"
+        merge_into_delta(
+            pl.DataFrame({"id": [1, 2], "v": ["a", "b"]}),
+            uri,
+            merge_mode="upsert",
+            merge_keys=["id"],
+            storage_options=opts,
+        )
+        # upsert: update id=2, insert id=3
+        merge_into_delta(
+            pl.DataFrame({"id": [2, 3], "v": ["B", "c"]}),
+            uri,
+            merge_mode="upsert",
+            merge_keys=["id"],
+            storage_options=opts,
+        )
+        res = pl.scan_delta(uri, storage_options=opts).collect().sort("id")
+        assert res["v"].to_list() == ["a", "B", "c"]
+        # delete id=1
+        merge_into_delta(
+            pl.DataFrame({"id": [1]}),
+            uri,
+            merge_mode="delete",
+            merge_keys=["id"],
+            storage_options=opts,
+        )
+        remaining = pl.scan_delta(uri, storage_options=opts).collect()
+        assert sorted(remaining["id"].to_list()) == [2, 3]

--- a/shared/tests/test_delta_utils_cloud.py
+++ b/shared/tests/test_delta_utils_cloud.py
@@ -1,8 +1,10 @@
 """Object-storage (S3/MinIO) coverage for the shared Delta helpers.
 
-The S3 round-trips are gated on Docker (MinIO via ``managed_minio``). The
-``validate_catalog_uri`` guards and the ``storage_options=None`` regression run
-everywhere — the latter is the byte-for-byte "unset config == today" guard.
+The S3 round-trips connect to the MinIO mock the test job already started (via
+``poetry run start_minio``); they must NOT manage that container's lifecycle —
+tearing it down here would break every other MinIO-dependent test in the job.
+The ``validate_catalog_uri`` guards and the ``storage_options=None`` regression
+run everywhere (the latter is the byte-for-byte "unset config == today" guard).
 """
 
 import polars as pl
@@ -17,15 +19,29 @@ from shared.delta_utils import (
 )
 
 try:
-    from test_utils.s3.fixtures import get_minio_client, is_docker_available, managed_minio
+    from test_utils.s3.fixtures import get_minio_client, is_docker_available
 except ModuleNotFoundError:  # pragma: no cover - import shim for ad-hoc runs
     import os
     import sys
 
     sys.path.append(os.path.dirname(os.path.abspath("test_utils/s3/fixtures.py")))
-    from test_utils.s3.fixtures import get_minio_client, is_docker_available, managed_minio
+    from test_utils.s3.fixtures import get_minio_client, is_docker_available
 
-requires_docker = pytest.mark.skipif(not is_docker_available(), reason="Docker required for MinIO")
+_BUCKET = "flowfile-test"
+
+
+def _minio_available() -> bool:
+    """True only when the shared MinIO mock is reachable (never starts/stops it)."""
+    if not is_docker_available():
+        return False
+    try:
+        get_minio_client().list_buckets()
+        return True
+    except Exception:
+        return False
+
+
+requires_minio = pytest.mark.skipif(not _minio_available(), reason="MinIO mock S3 not available")
 
 
 def _minio_storage_options() -> dict:
@@ -38,6 +54,14 @@ def _minio_storage_options() -> dict:
         endpoint_url="http://localhost:9000",
         aws_allow_unsafe_html=True,
     )
+
+
+def _ensure_bucket() -> None:
+    client = get_minio_client()
+    try:
+        client.create_bucket(Bucket=_BUCKET)
+    except Exception:
+        pass  # already exists
 
 
 # ---- Docker-free guards / regression --------------------------------------- #
@@ -68,52 +92,39 @@ def test_merge_local_regression(tmp_path):
     assert res["v"].to_list() == ["a", "B", "c"]
 
 
-# ---- S3 round-trips (Docker) ----------------------------------------------- #
+# ---- S3 round-trips (against the already-running MinIO mock) ---------------- #
 
 
-@requires_docker
+@requires_minio
 def test_write_and_size_roundtrip_s3():
-    with managed_minio():
-        opts = _minio_storage_options()
-        uri = "s3://flowfile-test/du_write"
-        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-        assert write_delta(df, uri, mode="overwrite", storage_options=opts) is True
-        assert get_delta_size_bytes(uri, storage_options=opts) > 0
-        assert pl.scan_delta(uri, storage_options=opts).collect().height == 3
-        client = get_minio_client()
-        listed = client.list_objects_v2(Bucket="flowfile-test", Prefix="du_write/_delta_log/")
-        assert listed.get("KeyCount", 0) > 0
+    _ensure_bucket()
+    opts = _minio_storage_options()
+    uri = f"s3://{_BUCKET}/du_cloud_write"
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    assert write_delta(df, uri, mode="overwrite", storage_options=opts) is True
+    assert get_delta_size_bytes(uri, storage_options=opts) > 0
+    assert pl.scan_delta(uri, storage_options=opts).collect().height == 3
+    listed = get_minio_client().list_objects_v2(Bucket=_BUCKET, Prefix="du_cloud_write/_delta_log/")
+    assert listed.get("KeyCount", 0) > 0
 
 
-@requires_docker
+@requires_minio
 def test_merge_upsert_update_delete_s3():
-    with managed_minio():
-        opts = _minio_storage_options()
-        uri = "s3://flowfile-test/du_merge"
-        merge_into_delta(
-            pl.DataFrame({"id": [1, 2], "v": ["a", "b"]}),
-            uri,
-            merge_mode="upsert",
-            merge_keys=["id"],
-            storage_options=opts,
-        )
-        # upsert: update id=2, insert id=3
-        merge_into_delta(
-            pl.DataFrame({"id": [2, 3], "v": ["B", "c"]}),
-            uri,
-            merge_mode="upsert",
-            merge_keys=["id"],
-            storage_options=opts,
-        )
-        res = pl.scan_delta(uri, storage_options=opts).collect().sort("id")
-        assert res["v"].to_list() == ["a", "B", "c"]
-        # delete id=1
-        merge_into_delta(
-            pl.DataFrame({"id": [1]}),
-            uri,
-            merge_mode="delete",
-            merge_keys=["id"],
-            storage_options=opts,
-        )
-        remaining = pl.scan_delta(uri, storage_options=opts).collect()
-        assert sorted(remaining["id"].to_list()) == [2, 3]
+    _ensure_bucket()
+    opts = _minio_storage_options()
+    uri = f"s3://{_BUCKET}/du_cloud_merge"
+    merge_into_delta(
+        pl.DataFrame({"id": [1, 2], "v": ["a", "b"]}), uri, merge_mode="upsert", merge_keys=["id"], storage_options=opts
+    )
+    # upsert: update id=2, insert id=3
+    merge_into_delta(
+        pl.DataFrame({"id": [2, 3], "v": ["B", "c"]}), uri, merge_mode="upsert", merge_keys=["id"], storage_options=opts
+    )
+    res = pl.scan_delta(uri, storage_options=opts).collect().sort("id")
+    assert res["v"].to_list() == ["a", "B", "c"]
+    # delete id=1
+    merge_into_delta(
+        pl.DataFrame({"id": [1]}), uri, merge_mode="delete", merge_keys=["id"], storage_options=opts
+    )
+    remaining = pl.scan_delta(uri, storage_options=opts).collect()
+    assert sorted(remaining["id"].to_list()) == [2, 3]


### PR DESCRIPTION
Add optional storage_options to write_delta, merge_into_delta and
get_delta_size_bytes so they can target object storage (S3) as well as the
local filesystem, and add validate_catalog_uri (the cloud analogue of
validate_catalog_path) plus a _delta_table_exists probe that works for both
backends. storage_options=None keeps byte-for-byte today's local behavior.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vaq1G46f5WBNiiuqkWLfSX