### PR TITLE
Fix multiprocessing deadlock on large result queue payloads

### DIFF
--- a/flowfile_worker/flowfile_worker/funcs.py
+++ b/flowfile_worker/flowfile_worker/funcs.py
@@ -162,8 +162,6 @@ def apply_model_task(
         scored_df = collect_lazy_frame(scored_lf)
         scored_df.write_ipc(file_path)
         flowfile_logger.info(f"apply_model_task scored {scored_df.height} rows")
-        with progress.get_lock():
-            progress.value = 100
     except Exception as e:
         flowfile_logger.error(f"Error during apply_model_task: {str(e)}")
         error_msg = str(e).encode()[:1024]
@@ -176,8 +174,12 @@ def apply_model_task(
         # plan over a non-existent file. The framework already inspects
         # progress.value before reading the queue; this keeps that contract.
         return
+    # put THEN signal done: consumers key completion off progress == 100, so the
+    # result must already be on the queue when that flips (matches store/fuzzy/train).
     lf = pl.scan_ipc(file_path)
     queue.put(lf.serialize())
+    with progress.get_lock():
+        progress.value = 100
 
 
 def fuzzy_join_task(

--- a/flowfile_worker/flowfile_worker/spawner.py
+++ b/flowfile_worker/flowfile_worker/spawner.py
@@ -1,8 +1,9 @@
 import gc
+import queue as _queue
 from base64 import b64encode
 from multiprocessing import Process
 from multiprocessing.queues import Queue
-from time import sleep
+from time import monotonic, sleep
 
 from flowfile_worker import funcs, models, mp_context, status_dict, status_dict_lock
 from flowfile_worker.process_manager import ProcessManager
@@ -10,6 +11,33 @@ from flowfile_worker.process_manager import ProcessManager
 process_manager = ProcessManager()
 
 flowfile_node_id_type = int | str
+
+# Bound the result drain so a wedged child can't hang the monitor forever, while
+# still allowing a large payload's feeder thread time to flush to the pipe.
+RESULT_QUEUE_TIMEOUT = 30.0
+
+
+def drain_result_queue(q: Queue, p: Process, timeout: float = RESULT_QUEUE_TIMEOUT):
+    """Read the single result a child puts on *q*, draining BEFORE the caller joins *p*.
+
+    A child that put() a payload larger than the OS pipe buffer (~64 KB) blocks in its
+    feeder thread until the parent reads it, so joining first would deadlock. Poll instead
+    of a single long get() so we bail the instant the child exits without a result (e.g. it
+    crashed after signalling completion but before put()), independent of put/signal order.
+    """
+    deadline = monotonic() + timeout
+    while True:
+        try:
+            return q.get(timeout=0.1)
+        except _queue.Empty:
+            if not p.is_alive():
+                # Child exited: any put() has been flushed. One last non-blocking read.
+                try:
+                    return q.get_nowait()
+                except _queue.Empty:
+                    return None
+            if monotonic() >= deadline:
+                return None
 
 
 def handle_task(task_id: str, p: Process, progress: mp_context.Value, error_message: mp_context.Array, q: Queue):
@@ -50,17 +78,31 @@ def handle_task(task_id: str, p: Process, progress: mp_context.Value, error_mess
                         status_dict[task_id].error_message = error_message.value.decode().rstrip("\x00")
                 break
 
+            # A child that put() a large result blocks in its feeder thread and never
+            # exits, so p.is_alive() would spin here forever. Break on the completion
+            # signal and let the drain below read the queue (which unblocks the child).
+            if current_progress == 100:
+                break
+
+        with status_dict_lock:
+            cancelled = status_dict[task_id].status == "Cancelled"
+        with progress.get_lock():
+            final_progress = progress.value
+
+        # Drain the queue BEFORE joining (see drain_result_queue). Only the success path
+        # (progress == 100) puts a result; errors travel via the shared Array.
+        result = None
+        if not cancelled and final_progress == 100:
+            result = drain_result_queue(q, p)
+
         p.join()
 
         with status_dict_lock:
             status = status_dict[task_id]
             if status.status != "Cancelled":
-                with progress.get_lock():
-                    final_progress = progress.value
                 if final_progress == 100:
                     status.status = "Completed"
-                    if not q.empty():
-                        result = q.get()
+                    if result is not None:
                         # b64-encode bytes for JSON-safe storage in status_dict (REST responses)
                         if isinstance(result, bytes):
                             status.results = b64encode(result).decode("ascii")

--- a/flowfile_worker/flowfile_worker/streaming.py
+++ b/flowfile_worker/flowfile_worker/streaming.py
@@ -27,7 +27,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from flowfile_worker import CACHE_DIR, funcs, models, mp_context, status_dict, status_dict_lock
 from flowfile_worker.configs import logger
-from flowfile_worker.spawner import process_manager
+from flowfile_worker.spawner import drain_result_queue, process_manager
 
 streaming_router = APIRouter()
 
@@ -167,6 +167,12 @@ async def _monitor_progress(websocket: WebSocket, p: Process, progress, error_me
             await websocket.send_json({"type": "error", "error_message": msg})
             return True
 
+        # A child that put() a large result blocks in its feeder thread and never
+        # exits, so p.is_alive() would spin here forever. Break on the completion
+        # signal; the caller drains the queue (which unblocks the child) before joining.
+        if current == 100:
+            return False
+
     return False
 
 
@@ -185,9 +191,14 @@ def _update_completed_status(task_id: str, result_data: Any) -> None:
                 status_dict[task_id].results = result_data
 
 
-async def _send_completion(websocket: WebSocket, task_id: str, result_type: str, file_path: str, queue: Queue) -> None:
-    """Send completion message and result data over WebSocket."""
-    result_data = queue.get() if not queue.empty() else None
+async def _send_completion(
+    websocket: WebSocket, task_id: str, result_type: str, file_path: str, result_data: Any
+) -> None:
+    """Send completion message and result data over WebSocket.
+
+    *result_data* is drained from the result queue by the caller before joining the
+    child, so this coroutine never touches the queue (draining after join can deadlock).
+    """
     _update_completed_status(task_id, result_data)
 
     has_result = result_data is not None
@@ -296,14 +307,17 @@ async def ws_submit(websocket: WebSocket):
         if had_error:
             return
 
-        p.join()
-
         with progress.get_lock():
             final = progress.value
 
         if final == 100:
-            await _send_completion(websocket, task_id, ctx.result_type, ctx.file_path, queue)
+            # Drain the queue BEFORE joining: a large put() blocks the child's feeder
+            # thread until read, so joining first would deadlock.
+            result_data = await asyncio.to_thread(drain_result_queue, queue, p)
+            p.join()
+            await _send_completion(websocket, task_id, ctx.result_type, ctx.file_path, result_data)
         else:
+            p.join()
             await _send_final_error(websocket, task_id, progress, error_message)
 
     except WebSocketDisconnect:

--- a/flowfile_worker/tests/test_result_queue_deadlock.py
+++ b/flowfile_worker/tests/test_result_queue_deadlock.py
@@ -1,0 +1,110 @@
+"""Regression tests for the result-queue drain (multiprocessing deadlock).
+
+A child that ``queue.put()`` a payload larger than the OS pipe buffer (~64 KB on
+Linux) blocks in its background feeder thread until the parent reads it. The old
+code called ``p.join()`` (and spun on ``while p.is_alive()``) *before* draining the
+queue, so a large result deadlocked the worker forever with no timeout. The monitor
+now breaks on the completion signal and drains the queue before joining.
+
+``calculate_schema`` on a wide table is the realistic trigger: its ``schema_stats``
+payload (per-column stat dicts) easily crosses the pipe buffer.
+"""
+
+import pickle
+import threading
+import time
+
+import polars as pl
+import pytest
+
+from flowfile_worker import models, mp_context, status_dict, status_dict_lock
+from flowfile_worker.funcs import calculate_schema
+from flowfile_worker.spawner import drain_result_queue, handle_task, process_manager
+
+
+def _wide_lf(n_cols: int = 2000, n_rows: int = 3) -> pl.LazyFrame:
+    """A frame wide enough that calculate_schema's queue payload exceeds ~64 KB."""
+    return pl.LazyFrame({f"col_{i}": list(range(n_rows)) for i in range(n_cols)})
+
+
+def _spawn_calculate_schema():
+    lf = _wide_lf()
+    progress = mp_context.Value("i", 0)
+    error_message = mp_context.Array("c", 1024)
+    q = mp_context.Queue(maxsize=1)
+    p = mp_context.Process(
+        target=calculate_schema,
+        kwargs=dict(
+            polars_serializable_object=lf.serialize(),
+            progress=progress,
+            error_message=error_message,
+            queue=q,
+            flowfile_flow_id=-1,
+            flowfile_node_id=-1,
+        ),
+    )
+    p.start()
+    return p, progress, error_message, q
+
+
+@pytest.mark.worker
+def test_drain_result_queue_large_payload_no_deadlock():
+    """Draining before join lets a child with a >64 KB result exit cleanly."""
+    p, progress, error_message, q = _spawn_calculate_schema()
+    try:
+        start = time.monotonic()
+        result = drain_result_queue(q, p, timeout=30.0)
+        p.join(timeout=30)
+        elapsed = time.monotonic() - start
+    finally:
+        if p.is_alive():
+            p.terminate()
+            p.join()
+
+    assert not p.is_alive(), "child never exited — result was not drained before join"
+    assert progress.value == 100, error_message[:].decode(errors="replace")
+    assert isinstance(result, list) and result
+    # Guard the premise: the payload must actually exceed the pipe buffer, else the
+    # test would pass even against the old join-before-drain code.
+    assert len(pickle.dumps(result)) > 64 * 1024
+    assert elapsed < 30
+
+
+@pytest.mark.worker
+def test_handle_task_completes_with_large_payload():
+    """End-to-end: handle_task must reach Completed (with results) for a large payload,
+    not hang on the ``while p.is_alive()`` spin."""
+    task_id = "test-wide-schema-deadlock"
+    p, progress, error_message, q = _spawn_calculate_schema()
+    process_manager.add_process(task_id, p)
+    with status_dict_lock:
+        status_dict[task_id] = models.Status(
+            background_task_id=task_id, status="Starting", file_ref="", result_type="other"
+        )
+
+    # Run in a thread so a regression can't hang the test suite (no pytest-timeout).
+    done = threading.Event()
+
+    def _run():
+        try:
+            handle_task(task_id, p, progress, error_message, q)
+        finally:
+            done.set()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    finished = done.wait(timeout=45)
+
+    try:
+        assert finished, "handle_task did not return — deadlocked on the result queue"
+        with status_dict_lock:
+            status = status_dict[task_id]
+        assert status.status == "Completed", status.error_message
+        assert status.results is not None and len(status.results) > 0
+    finally:
+        if p.is_alive():
+            p.terminate()
+            p.join()
+        with status_dict_lock:
+            status_dict.pop(task_id, None)
+        process_manager.remove_process(task_id)


### PR DESCRIPTION
## Summary

Fixes a critical deadlock in the worker's multiprocessing result queue handling. When a child process puts a result larger than the OS pipe buffer (~64 KB), it blocks in its background feeder thread until the parent reads the queue. The old code called `p.join()` before draining the queue, causing indefinite hangs. The fix drains the queue *before* joining and breaks the progress monitor loop on the completion signal (100%) rather than spinning on `p.is_alive()`.

## Key Changes

- **New `drain_result_queue()` function** in `spawner.py`: Polls the queue with a 0.1s timeout until either the result is read or the child exits, with a 30s overall deadline. Handles the case where a child exits without putting a result (e.g., crash after signalling completion).

- **Updated `handle_task()` in `spawner.py`**: 
  - Breaks the progress monitor loop when `progress == 100` (completion signal) instead of spinning on `p.is_alive()`
  - Calls `drain_result_queue()` *before* `p.join()` to unblock the child's feeder thread
  - Only drains on the success path (non-cancelled, progress == 100)

- **Updated `_monitor_progress()` in `streaming.py`**: Returns early when `current == 100` to break the WebSocket progress loop on completion, allowing the caller to drain the queue before joining.

- **Updated `ws_submit()` in `streaming.py`**: Drains the result queue via `asyncio.to_thread()` before joining the child process on the success path.

- **Fixed `apply_model_task()` in `funcs.py`**: Moved `progress.value = 100` to *after* `queue.put()` to ensure the result is on the queue before consumers see the completion signal (matches the pattern in `store_task`, `fuzzy_join_task`, and `train_task`).

- **Comprehensive regression tests** in `test_result_queue_deadlock.py`:
  - `test_drain_result_queue_large_payload_no_deadlock()`: Verifies `drain_result_queue()` handles >64 KB payloads without deadlock
  - `test_handle_task_completes_with_large_payload()`: End-to-end test that `handle_task()` completes with large results (runs in a thread to catch hangs)

## Implementation Details

The root cause is Python's multiprocessing queue implementation: when a child calls `queue.put(large_payload)`, the payload is serialized and written to a pipe. If the payload exceeds the OS pipe buffer, the write blocks until the parent reads from the queue. The old code's `p.join()` call would wait forever for the child to exit, but the child is blocked in its feeder thread waiting for the parent to read—a classic deadlock.

The fix uses polling with short timeouts (`0.1s`) to avoid busy-waiting while still being responsive. The deadline (`RESULT_QUEUE_TIMEOUT = 30.0`) bounds the drain so a truly wedged child can't hang the monitor indefinitely. The completion signal (progress == 100) is the key: it tells the monitor to stop waiting for progress updates and let the caller drain the queue, which unblocks the child.

The test uses `calculate_schema` on a 2000-column table to generate a >64 KB `schema_stats` payload—a realistic trigger from production workloads.

https://claude.ai/code/session_01Jdyi61Zd82p4V24YnjNcVs