### PR TITLE
Bump version and add smart suggest next node

### DIFF
--- a/flowfile_core/flowfile_core/ai/autocomplete.py
+++ b/flowfile_core/flowfile_core/ai/autocomplete.py
@@ -103,8 +103,21 @@ class _JoinKeyLLMOutput(BaseModel):
 
 
 def _column_names_for_node(node: FlowNode) -> list[str] | None:
-    """Return the predicted upstream column names; ``None`` only when the schema is missing (``[]`` stays ``[]``)."""
-    schema: list[FlowfileColumn] | None = node.node_schema.predicted_schema
+    """Return the predicted upstream column names, computing them on demand.
+
+    ``None`` only when the schema can't be produced; an empty schema stays
+    ``[]``. Uses ``get_predicted_schema`` rather than a raw
+    ``node_schema.predicted_schema`` read — that cache is nulled on every
+    settings edit, so a bare read is almost always ``None`` when a join panel
+    is open and the surface would wrongly degrade. Prediction is a lazy
+    ``collect_schema`` (no full-data collect); the async caller offloads it to
+    a thread. Never raises — a cold/broken upstream degrades to ``None``.
+    """
+    try:
+        schema: list[FlowfileColumn] | None = node.get_predicted_schema()
+    except Exception as exc:  # noqa: BLE001 — cold/broken upstream degrades, never raises
+        logger.debug("suggest_join_keys: get_predicted_schema failed: %s", exc)
+        return None
     if schema is None:
         return None
     return [col.column_name for col in schema]
@@ -278,8 +291,8 @@ async def suggest_join_keys(
             reason="Left or right node not found in flow.",
         )
 
-    left_columns = _column_names_for_node(left_node)
-    right_columns = _column_names_for_node(right_node)
+    left_columns = await asyncio.to_thread(_column_names_for_node, left_node)
+    right_columns = await asyncio.to_thread(_column_names_for_node, right_node)
 
     if left_columns is None or right_columns is None:
         latency_ms = int((time.monotonic() - started) * 1000)

--- a/flowfile_core/flowfile_core/ai/suggest_next_node.py
+++ b/flowfile_core/flowfile_core/ai/suggest_next_node.py
@@ -24,11 +24,18 @@ Design (mirrors the ``autocomplete`` posture):
   the ``ghost_node`` preset — if the LLM ignores the preset hint and
   proposes one anyway, it survives only if Pydantic + column-ref
   validation pass; we don't run a kernel dry-run on the ghost-node
-  hot path (latency budget is <2s TTFB).
-* Cache-only schema reads, no ``LazyFrame.collect()``.
-* When upstream schema is ``None``, ``degraded=True`` (the ghost
-  surface should never block a casual hover; users wanting to
-  populate schema for cold flows can run the upstream first).
+  path (that would need a live kernel and is out of scope for a
+  suggestion).
+* The upstream schema is computed on demand via
+  ``get_predicted_schema`` (offloaded to a thread) rather than read
+  from the raw cache — the cache is nulled on every settings edit, so
+  a bare read is almost always ``None`` at trigger time and the
+  surface would degrade before ever calling the LLM. Schema prediction
+  is a lazy ``collect_schema`` (no full-data ``LazyFrame.collect()``),
+  matching every other AI surface (context builder, planner, predictor,
+  live observation).
+* When the upstream schema can't be predicted at all, ``degraded=True``
+  with reason ``upstream_schema_unknown`` (run the upstream first).
 
 Wire-layer note: ``node_type`` is the un-namespaced flowfile name
 (``"filter"``), not the MCP-shaped tool name. The catalog uses
@@ -76,7 +83,10 @@ logger = logging.getLogger(__name__)
 
 SURFACE: str = "ghost_node"
 
-DEFAULT_TIMEOUT_SECONDS: float = 3.5
+DEFAULT_TIMEOUT_SECONDS: float = 20.0
+"""Generous by design: this is a deliberate right-click action (not a hover),
+so the user is willing to wait for a slower provider/model rather than see a
+premature "AI took too long" degrade."""
 
 MAX_SUGGESTIONS: int = 3
 """§3.3 spec: top-3 by upstream-schema fit."""
@@ -166,30 +176,59 @@ _ALLOWED_NODE_TYPES: frozenset[str] = _allowed_node_types()
 # Schema lookup
 
 
-def _column_names_for_node(node: FlowNode | None) -> list[str] | None:
-    """Return predicted column names, or ``None`` if unknown / missing.
+async def _predicted_columns_for_node(node: FlowNode | None) -> list[FlowfileColumn] | None:
+    """Return the upstream node's predicted output schema, computing it on
+    demand when the cache is cold.
 
-    Schema-only path, no force-recompute. Cold upstreams propagate as
-    ``None`` to the caller's degraded branch.
+    Every other AI surface calls ``get_predicted_schema`` rather than reading
+    ``node_schema.predicted_schema`` directly, because ``reset()`` nulls that
+    cache on every settings edit — a bare read is almost always ``None`` at
+    trigger time. Schema prediction is a lazy ``collect_schema`` (no full-data
+    ``LazyFrame.collect()``); we offload it to a thread so the async route
+    never blocks the event loop, and degrade cleanly to ``None`` on any error.
     """
     if node is None:
         return None
-    schema: list[FlowfileColumn] | None = node.node_schema.predicted_schema
-    if not schema:
+    try:
+        schema: list[FlowfileColumn] | None = await asyncio.to_thread(node.get_predicted_schema)
+    except Exception as exc:  # noqa: BLE001 — a cold/broken upstream degrades, never raises
+        logger.debug("suggest_next_node: get_predicted_schema failed: %s", exc)
         return None
-    return [col.column_name for col in schema]
-
-
-def _columns_for_node(node: FlowNode | None) -> list[FlowfileColumn] | None:
-    if node is None:
-        return None
-    schema: list[FlowfileColumn] | None = node.node_schema.predicted_schema
     if not schema:
         return None
     return list(schema)
 
 
 # Prompt construction
+
+
+# Worked settings shapes shown to the LLM so it emits the correct nested
+# structure per node type — without these, a cheap model guesses the shape and
+# every candidate fails Pydantic validation. Scoped to the single-input
+# transforms (join/union need a second input that a "next node after this one"
+# can't wire, so they're not exemplified). The illustrative columns are
+# replaced with real upstream columns at generation time. ``flow_id`` /
+# ``node_id`` are omitted on purpose — they're injected server-side before
+# validation (see ``_validate_candidate``). Validated against the settings
+# classes by ``test_ghost_settings_examples_are_valid``.
+_GHOST_SETTINGS_EXAMPLES: dict[str, dict[str, Any]] = {
+    "filter": {"filter_input": {"mode": "basic", "basic_filter": {"field": "region", "operator": "==", "value": "EU"}}},
+    "select": {"select_input": [{"old_name": "region", "new_name": "region", "keep": True}]},
+    "sort": {"sort_input": [{"column": "amount", "how": "desc"}]},
+    "formula": {"function": {"field": {"name": "total", "data_type": "Float64"}, "function": "[amount] * 1.1"}},
+    "group_by": {
+        "groupby_input": {
+            "agg_cols": [
+                {"old_name": "region", "agg": "groupby"},
+                {"old_name": "amount", "agg": "sum", "new_name": "total_amount"},
+            ]
+        }
+    },
+}
+
+
+def _format_settings_examples() -> str:
+    return "\n".join(f"{node_type}: {json.dumps(example)}" for node_type, example in _GHOST_SETTINGS_EXAMPLES.items())
 
 
 _SYSTEM_PROMPT = """\
@@ -200,7 +239,7 @@ Output a single JSON object — no prose, no code blocks. Shape:
 
   {"suggestions": [
      {"node_type": "<one of the allowed types>",
-      "settings": { ... pydantic-valid settings for that node type ... },
+      "settings": { ... settings matching the shape for that node type ... },
       "label": "<short imperative label, max 50 chars>",
       "description": "<one-line elaboration, optional>",
       "rationale": "<why this fits, optional>"}
@@ -210,14 +249,20 @@ Hard rules:
 
 * `node_type` MUST be one of: {{ALLOWED_TYPES}}. Reject any other value;
   the user has scoped this surface to fast in-flow editing.
-* `settings` MUST validate against the Pydantic class for that node type.
-  When unsure of a field, omit it and let the default apply.
+* `settings` MUST copy the exact shape shown for that node type below,
+  substituting real upstream column names. Do NOT include `flow_id` or
+  `node_id` — they are filled in automatically.
 * You MAY only reference columns from the upstream schema you're given.
   Do not invent column names. Match capitalisation exactly.
 * Keep `label` short (<50 chars). Order suggestions by relevance —
-  most-likely-fit first.
-* Return at most {{MAX_SUGGESTIONS}} suggestions. If no plausible
-  suggestion exists, return `{"suggestions": []}`.
+  most-likely-fit first. Prefer the shapes below; if none fits the schema,
+  return `{"suggestions": []}`.
+* Return at most {{MAX_SUGGESTIONS}} suggestions.
+
+Settings shapes (copy these structures exactly; the example columns like
+"region"/"amount" are illustrative — replace them with real upstream columns):
+
+{{SETTINGS_EXAMPLES}}
 """
 
 
@@ -245,7 +290,11 @@ def _build_messages(
     # prompt use literal ``{`` / ``}``, which would be interpreted as
     # format placeholders. Same posture as the autocomplete path.
     allowed = ", ".join(sorted(_ALLOWED_NODE_TYPES))
-    system = _SYSTEM_PROMPT.replace("{{ALLOWED_TYPES}}", allowed).replace("{{MAX_SUGGESTIONS}}", str(max_suggestions))
+    system = (
+        _SYSTEM_PROMPT.replace("{{ALLOWED_TYPES}}", allowed)
+        .replace("{{MAX_SUGGESTIONS}}", str(max_suggestions))
+        .replace("{{SETTINGS_EXAMPLES}}", _format_settings_examples())
+    )
     return [
         Message(role="system", content=system),
         Message(role="user", content="\n".join(user_lines)),
@@ -347,8 +396,14 @@ def _validate_candidate(
         # effectively unreachable. Log if it fires.
         logger.debug("ghost_node candidate rejected: no settings class for %s", candidate.node_type)
         return None
+    # ``flow_id``/``node_id`` are required graph-structural ids the LLM can't
+    # know and consistently omits; the frontend overwrites them on materialise
+    # anyway. Inject placeholders so a correct-shaped candidate isn't dropped
+    # for lacking them (executor-seam normalisation — leniency lives here, not
+    # in the strict schema or the prompt). LLM-provided ids still win.
+    settings_payload = {"flow_id": 0, "node_id": 0, **candidate.settings}
     try:
-        settings_obj = settings_cls.model_validate(candidate.settings)
+        settings_obj = settings_cls.model_validate(settings_payload)
     except ValidationError as exc:
         logger.debug(
             "ghost_node candidate rejected: settings validation failed for %s: %s",
@@ -421,7 +476,6 @@ async def suggest_next_node(
     started = time.monotonic()
 
     upstream_node = graph.get_node(upstream_node_id)
-    upstream_columns = _column_names_for_node(upstream_node)
 
     if upstream_node is None:
         latency_ms = int((time.monotonic() - started) * 1000)
@@ -435,10 +489,12 @@ async def suggest_next_node(
         return NextNodeSuggestionsResponse(
             suggestions=[],
             degraded=True,
-            reason="Upstream node not found.",
+            reason="missing_upstream",
         )
 
-    if upstream_columns is None:
+    upstream_columns_full = await _predicted_columns_for_node(upstream_node)
+
+    if not upstream_columns_full:
         latency_ms = int((time.monotonic() - started) * 1000)
         record_autocomplete_call(
             surface=SURFACE,
@@ -450,10 +506,10 @@ async def suggest_next_node(
         return NextNodeSuggestionsResponse(
             suggestions=[],
             degraded=True,
-            reason="Upstream schema unknown — run the upstream node first.",
+            reason="upstream_schema_unknown",
         )
 
-    upstream_columns_full = _columns_for_node(upstream_node)
+    upstream_columns = [col.column_name for col in upstream_columns_full]
 
     # Cap on input + treat values <=0 as the default.
     effective_max = max(1, min(max_suggestions, MAX_SUGGESTIONS * 2))

--- a/flowfile_core/flowfile_core/ai/suggest_next_node_routes.py
+++ b/flowfile_core/flowfile_core/ai/suggest_next_node_routes.py
@@ -54,7 +54,7 @@ class SuggestNextNodeRequest(BaseModel):
     model: str | None = None
     intent: str | None = Field(default=None, max_length=500)
     max_suggestions: int = Field(default=MAX_SUGGESTIONS, ge=1, le=10)
-    timeout: float = Field(default=DEFAULT_TIMEOUT_SECONDS, gt=0.0, le=10.0)
+    timeout: float = Field(default=DEFAULT_TIMEOUT_SECONDS, gt=0.0, le=60.0)
 
 
 def _ensure_known_provider(name: str) -> None:

--- a/flowfile_core/tests/ai/test_autocomplete.py
+++ b/flowfile_core/tests/ai/test_autocomplete.py
@@ -65,12 +65,27 @@ def _columns(*names: str) -> list[_FakeColumn]:
     return [_FakeColumn(n) for n in names]
 
 
-def _make_node(node_id: int | str, *, predicted_schema: list[Any] | None, all_inputs: list[Any] | None = None) -> Any:
+def _make_node(
+    node_id: int | str,
+    *,
+    predicted_schema: list[Any] | None,
+    all_inputs: list[Any] | None = None,
+    compute_schema: list[Any] | None = None,
+) -> Any:
+    """Duck-typed FlowNode stand-in.
+
+    ``compute_schema`` (defaults to ``predicted_schema``) is what
+    ``get_predicted_schema()`` returns — the surface calls the method, not the
+    raw attribute, so a cold cache with a computable schema exercises the
+    on-demand warming path.
+    """
     schema = SimpleNamespace(predicted_schema=predicted_schema)
+    computed = compute_schema if compute_schema is not None else predicted_schema
     node = SimpleNamespace(
         node_id=node_id,
         node_schema=schema,
         all_inputs=all_inputs or [],
+        get_predicted_schema=lambda force=False: computed,
     )
     return node
 

--- a/flowfile_core/tests/ai/test_suggest_next_node.py
+++ b/flowfile_core/tests/ai/test_suggest_next_node.py
@@ -75,12 +75,23 @@ def _make_node(
     *,
     predicted_schema: list[Any] | None,
     node_type: str = "manual_input",
+    compute_schema: list[Any] | None = None,
 ) -> Any:
+    """Duck-typed FlowNode stand-in.
+
+    ``predicted_schema`` is the raw cache; ``compute_schema`` (defaults to the
+    same) is what ``get_predicted_schema()`` returns — the suggest path calls
+    the method, not the attribute, so a cold cache with a computable schema
+    (``predicted_schema=None`` but ``compute_schema=[...]``) exercises the
+    on-demand warming path.
+    """
     schema = SimpleNamespace(predicted_schema=predicted_schema)
+    computed = compute_schema if compute_schema is not None else predicted_schema
     return SimpleNamespace(
         node_id=node_id,
         node_type=node_type,
         node_schema=schema,
+        get_predicted_schema=lambda force=False: computed,
     )
 
 
@@ -296,6 +307,71 @@ async def test_drops_candidate_with_invalid_pydantic_settings() -> None:
     assert response.suggestions[0].node_type == "select"
 
 
+def test_ghost_settings_examples_are_valid() -> None:
+    """Every worked example shown to the LLM must validate against its settings
+    class (with the server-injected placeholder ids). A schema change that
+    breaks an example fails here instead of silently teaching the LLM a bad
+    shape that would drop every real suggestion."""
+    from flowfile_core.ai.suggest_next_node import _GHOST_SETTINGS_EXAMPLES
+    from flowfile_core.schemas.schemas import get_settings_class_for_node_type
+
+    assert _GHOST_SETTINGS_EXAMPLES
+    for node_type, example in _GHOST_SETTINGS_EXAMPLES.items():
+        assert node_type in _ALLOWED_NODE_TYPES, node_type
+        settings_cls = get_settings_class_for_node_type(node_type)
+        assert settings_cls is not None, node_type
+        # flow_id/node_id are injected server-side — mirror that here.
+        settings_cls.model_validate({"flow_id": 0, "node_id": 0, **example})
+
+
+def test_settings_examples_injected_into_prompt() -> None:
+    """The system prompt must carry the per-node-type settings shapes so a
+    cheap model isn't guessing the nested structure (the root cause of the
+    'no schema-grounded suggestion' degrade)."""
+    from flowfile_core.ai.suggest_next_node import _build_messages
+
+    system = _build_messages(
+        upstream_columns=["region", "amount"],
+        upstream_node_type="read_csv",
+        intent=None,
+        max_suggestions=3,
+    )[0].content
+    assert "filter_input" in system
+    assert "groupby_input" in system
+    assert "flow_id" in system  # tells the model these are auto-filled
+
+
+@pytest.mark.asyncio
+async def test_accepts_candidate_without_flow_id_node_id() -> None:
+    """Regression: a real LLM omits flow_id/node_id (it can't know them). The
+    executor-seam injection means a correct-shaped candidate still validates
+    and is returned, rather than dropped as no_valid_suggestions."""
+    upstream = _make_node("u1", predicted_schema=_columns("region", "amount"))
+    graph = _FakeGraph({"u1": upstream})
+
+    provider = _FakeProvider(
+        content=_payload(
+            [
+                {
+                    "node_type": "filter",
+                    # No flow_id / node_id — exactly what a real LLM emits.
+                    "settings": {
+                        "filter_input": {
+                            "mode": "basic",
+                            "basic_filter": {"field": "region", "operator": "==", "value": "EU"},
+                        }
+                    },
+                    "label": "Filter by region",
+                },
+            ]
+        )
+    )
+    response = await suggest_next_node(graph, "u1", provider=provider, scheduler=_scheduler())
+    assert response.degraded is False
+    assert len(response.suggestions) == 1
+    assert response.suggestions[0].node_type == "filter"
+
+
 @pytest.mark.asyncio
 async def test_drops_candidate_outside_ghost_node_preset() -> None:
     """Defence-in-depth: even if the LLM ignores the prompt and proposes a
@@ -331,8 +407,39 @@ async def test_drops_candidate_outside_ghost_node_preset() -> None:
 
 
 @pytest.mark.asyncio
+async def test_warms_cold_schema_cache_on_demand() -> None:
+    """Regression: the raw ``predicted_schema`` cache is cold (``None``) but
+    ``get_predicted_schema()`` can compute it. The suggest path must call the
+    method (like every other AI surface) and produce suggestions rather than
+    degrading early with ``upstream_schema_unknown`` — the bug that made the
+    ghost surface appear to never work."""
+    upstream = _make_node("u1", predicted_schema=None, compute_schema=_columns("region"))
+    graph = _FakeGraph({"u1": upstream})
+
+    provider = _FakeProvider(
+        content=_payload(
+            [
+                {
+                    "node_type": "filter",
+                    "settings": _filter_settings(field="region"),
+                    "label": "Filter by region",
+                },
+            ]
+        )
+    )
+    response = await suggest_next_node(graph, "u1", provider=provider, scheduler=_scheduler())
+    assert response.degraded is False
+    assert len(response.suggestions) == 1
+    assert response.suggestions[0].node_type == "filter"
+    # The LLM must have been consulted — schema was warmed, not degraded early.
+    assert provider.last_call_kwargs != {}
+
+
+@pytest.mark.asyncio
 async def test_degrades_on_cold_upstream() -> None:
-    """Upstream node has ``predicted_schema=None`` — must NOT call the LLM."""
+    """Upstream schema is genuinely unpredictable (both cache and
+    ``get_predicted_schema()`` yield ``None``) — must NOT call the LLM, and
+    must degrade with the machine-code reason the frontend switches on."""
     upstream = _make_node("u1", predicted_schema=None)
     graph = _FakeGraph({"u1": upstream})
 
@@ -340,7 +447,7 @@ async def test_degrades_on_cold_upstream() -> None:
     response = await suggest_next_node(graph, "u1", provider=provider, scheduler=_scheduler())
     assert response.degraded is True
     assert response.suggestions == []
-    assert response.reason
+    assert response.reason == "upstream_schema_unknown"
     # We must NOT have hit the LLM in the cold-flow branch.
     assert provider.last_call_kwargs == {}
 
@@ -351,6 +458,7 @@ async def test_degrades_when_upstream_missing() -> None:
     provider = _FakeProvider(content=_payload([]))
     response = await suggest_next_node(graph, "missing-id", provider=provider, scheduler=_scheduler())
     assert response.degraded is True
+    assert response.reason == "missing_upstream"
     assert provider.last_call_kwargs == {}
 
 

--- a/flowfile_frontend/package.json
+++ b/flowfile_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Flowfile",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "A tool for designing and executing data flows",
   "scripts": {
     "dev": "tauri dev",

--- a/flowfile_frontend/src-tauri/Cargo.toml
+++ b/flowfile_frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowfile"
-version = "0.12.7"
+version = "0.12.8"
 description = "Flowfile — visual ETL platform"
 authors = ["Edwardvaneechoud"]
 license = "MIT"

--- a/flowfile_frontend/src-tauri/tauri.conf.json
+++ b/flowfile_frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Flowfile",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "identifier": "com.flowfile.app",
   "build": {
     "frontendDist": "../build/renderer",

--- a/flowfile_frontend/src/renderer/app/components/nodes/NodeWrapper.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/NodeWrapper.vue
@@ -156,6 +156,22 @@
             </svg>
             <span>Go to Flow</span>
           </div>
+          <div class="context-menu-item" @click="suggestNextNode">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M5 12h14"></path>
+              <path d="m12 5 7 7-7 7"></path>
+            </svg>
+            <span>Suggest next node…</span>
+          </div>
           <div class="context-menu-divider"></div>
           <div class="context-menu-item" @click="runNode">
             <svg
@@ -235,12 +251,13 @@
 //   - NodeContextMenu.vue (~lines 92-161, with positioning at ~263-283)
 //   - NodeDescriptionEditor.vue (~lines 11-48)
 //   - NodeHandles.vue: handle rendering loops (~lines 64-89)
-import { Handle } from "@vue-flow/core";
+import { Handle, useNode } from "@vue-flow/core";
 import { computed, ref, onMounted, nextTick, watch, onUnmounted } from "vue";
 import { ElMessage } from "element-plus";
 import { useNodeStore } from "../../stores/column-store";
 import { useFlowStore } from "../../stores/flow-store";
 import { useEditorStore } from "../../stores/editor-store";
+import { useAiGhostNodeStore } from "../../stores/ai-ghost-node-store";
 import { VueFlowStore } from "@vue-flow/core";
 import { NodeCopyValue } from "../../views/DesignerView/types";
 import { toSnakeCase } from "../../views/DesignerView/utils";
@@ -254,6 +271,10 @@ import type { NodeTemplate, NodeHandle, RunFlowReference } from "../../types";
 const nodeStore = useNodeStore();
 const flowStore = useFlowStore();
 const editorStore = useEditorStore();
+const ghostStore = useAiGhostNodeStore();
+// This component is the registered "custom-node", so VueFlow injects its node
+// context — read the node's own live position from it rather than a lookup.
+const currentVueFlowNode = useNode();
 const nodeEl = ref<HTMLElement | null>(null);
 const menuEl = ref<HTMLElement | null>(null);
 
@@ -384,6 +405,26 @@ const openSettings = () => {
 const viewData = () => {
   editorStore.requestNodeData(props.data.id);
   closeContextMenu();
+};
+
+const suggestNextNode = () => {
+  closeContextMenu();
+  const flowId = flowStore.flowId;
+  if (flowId === null) return;
+  // Popover anchors at the menu's screen position; the materialised node is
+  // placed relative to this node's own flow-coords position.
+  const pos = currentVueFlowNode.node.computedPosition ??
+    currentVueFlowNode.node.position ?? { x: 0, y: 0 };
+  ghostStore.beginIntent(
+    {
+      upstreamNodeId: props.data.id,
+      screenX: contextMenuX.value,
+      screenY: contextMenuY.value,
+      nodeX: pos.x,
+      nodeY: pos.y,
+    },
+    flowId,
+  );
 };
 
 const openTargetFlow = async () => {

--- a/flowfile_frontend/src/renderer/app/features/ai/AiGhostNode.vue
+++ b/flowfile_frontend/src/renderer/app/features/ai/AiGhostNode.vue
@@ -6,9 +6,20 @@
     @mousedown.stop
     @click.stop
   >
-    <div v-if="isLoading" class="ai-ghost-loading">
-      <span class="ai-ghost-spark">✨</span>
-      <span>Suggesting next node…</span>
+    <div v-if="awaitingIntent" class="ai-ghost-input">
+      <input
+        ref="intentInputRef"
+        v-model="intentText"
+        class="ai-ghost-intent-field"
+        type="text"
+        placeholder="Describe the next step…"
+        @keydown.enter.stop.prevent="onSubmitIntent"
+        @keydown.esc.stop.prevent="onDismiss"
+      />
+    </div>
+    <div v-else-if="isLoading" class="ai-ghost-loading">
+      <span class="ai-ghost-spinner" aria-hidden="true"></span>
+      <span>Finding next node…</span>
     </div>
     <div v-else-if="aiDisabled" class="ai-ghost-empty">
       AI features are disabled. Ask an admin to enable them in settings.
@@ -25,11 +36,7 @@
         @click.stop="onAccept(index)"
       >
         <div class="ai-ghost-item-header">
-          <span class="ai-ghost-spark">✨</span>
           <span class="ai-ghost-label">{{ suggestion.label || suggestion.nodeType }}</span>
-        </div>
-        <div class="ai-ghost-item-meta">
-          <span class="ai-ghost-type">{{ suggestion.nodeType }}</span>
           <span v-if="suggestion.predictedOutputSchema" class="ai-ghost-cols">
             {{ suggestion.predictedOutputSchema.length }} cols
           </span>
@@ -43,7 +50,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 
 import { useGhostNodeSuggestions } from "./useGhostNodeSuggestions";
 
@@ -52,16 +59,36 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const emit = defineEmits<{ (e: "accepted"): void }>();
 const pendingIndex = ref<number | null>(null);
+const intentText = ref("");
+const intentInputRef = ref<HTMLInputElement | null>(null);
 
 const isVisible = computed(() => props.composable.isVisible.value);
+const awaitingIntent = computed(() => props.composable.awaitingIntent.value);
 const isLoading = computed(() => props.composable.isLoading.value);
 const aiDisabled = computed(() => props.composable.aiDisabled.value);
 const degradedReason = computed(() => props.composable.degradedReason.value);
 const suggestions = computed(() => props.composable.suggestions.value);
 
-const anchorX = computed(() => props.composable.anchor.value?.edgeMidX ?? 0);
-const anchorY = computed(() => props.composable.anchor.value?.edgeMidY ?? 0);
+const anchorX = computed(() => props.composable.anchor.value?.screenX ?? 0);
+const anchorY = computed(() => props.composable.anchor.value?.screenY ?? 0);
+
+// Focus (and reset) the inline box each time it opens.
+watch(awaitingIntent, (open) => {
+  if (open) {
+    intentText.value = "";
+    void nextTick(() => intentInputRef.value?.focus());
+  }
+});
+
+const onSubmitIntent = (): void => {
+  props.composable.submitIntent(intentText.value);
+};
+
+const onDismiss = (): void => {
+  props.composable.clear();
+};
 
 const degradedMessage = computed(() => {
   switch (degradedReason.value) {
@@ -76,7 +103,7 @@ const degradedMessage = computed(() => {
     case "parse_error":
       return "AI returned an invalid response.";
     case "no_valid_suggestions":
-      return "No schema-grounded suggestion fits this edge.";
+      return "No suggestion fits this node's schema — try rephrasing.";
     default:
       return "AI couldn't suggest a next node.";
   }
@@ -86,7 +113,8 @@ const onAccept = async (index: number): Promise<void> => {
   if (pendingIndex.value !== null) return;
   pendingIndex.value = index;
   try {
-    await props.composable.acceptSuggestion(index);
+    const newNodeId = await props.composable.acceptSuggestion(index);
+    if (newNodeId !== null) emit("accepted");
   } finally {
     pendingIndex.value = null;
   }
@@ -95,29 +123,71 @@ const onAccept = async (index: number): Promise<void> => {
 
 <style scoped>
 .ai-ghost-popover {
-  position: absolute;
-  z-index: 999;
-  min-width: 280px;
-  max-width: 360px;
-  padding: 8px;
-  border: 1.5px dashed #6366f1;
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.97);
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.12);
-  backdrop-filter: blur(2px);
+  position: fixed;
+  z-index: var(--z-index-canvas-context-menu, 100002);
+  min-width: 260px;
+  max-width: 340px;
+  padding: 4px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: 6px;
+  background-color: var(--color-background-primary);
+  box-shadow: var(--shadow-lg);
   pointer-events: auto;
-  font-size: 13px;
-  color: #1f2937;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
+}
+
+.ai-ghost-input {
+  padding: 4px;
+}
+
+.ai-ghost-intent-field {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 7px 9px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: 4px;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
+  background-color: var(--color-background-primary);
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+.ai-ghost-intent-field::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+.ai-ghost-intent-field:focus {
+  border-color: var(--color-accent);
 }
 
 .ai-ghost-loading,
 .ai-ghost-empty {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
-  color: #4b5563;
-  font-style: italic;
+  gap: 8px;
+  padding: 10px 12px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.ai-ghost-spinner {
+  flex: 0 0 auto;
+  width: 13px;
+  height: 13px;
+  border: 2px solid var(--color-border-primary);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: ai-ghost-spin 0.7s linear infinite;
+}
+
+@keyframes ai-ghost-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .ai-ghost-list {
@@ -126,56 +196,28 @@ const onAccept = async (index: number): Promise<void> => {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 4px;
 }
 
 .ai-ghost-item {
-  padding: 6px 8px;
-  border-radius: 6px;
+  padding: 8px 10px;
+  border-radius: 4px;
   cursor: pointer;
-  transition: background 0.12s ease;
-  opacity: 0.85;
+  transition: background-color 0.15s ease;
 }
 
 .ai-ghost-item:hover {
-  background: rgba(99, 102, 241, 0.08);
-  opacity: 1;
+  background-color: var(--color-background-hover);
 }
 
 .ai-ghost-item--busy {
   pointer-events: none;
-  opacity: 0.5;
+  opacity: 0.55;
 }
 
 .ai-ghost-item-header {
   display: flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 600;
-}
-
-.ai-ghost-item-meta {
-  display: flex;
+  align-items: baseline;
   gap: 8px;
-  margin-top: 2px;
-  color: #6b7280;
-  font-size: 11px;
-}
-
-.ai-ghost-type {
-  font-family: ui-monospace, SFMono-Regular, monospace;
-}
-
-.ai-ghost-desc {
-  margin: 4px 0 0;
-  color: #4b5563;
-  font-size: 12px;
-  line-height: 1.4;
-}
-
-.ai-ghost-spark {
-  color: #6366f1;
-  font-size: 14px;
 }
 
 .ai-ghost-label {
@@ -183,5 +225,20 @@ const onAccept = async (index: number): Promise<void> => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.ai-ghost-cols {
+  flex: 0 0 auto;
+  color: var(--color-text-tertiary);
+  font-size: var(--font-size-xs);
+}
+
+.ai-ghost-desc {
+  margin: 3px 0 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
 }
 </style>

--- a/flowfile_frontend/src/renderer/app/features/ai/useGhostNodeSuggestions.ts
+++ b/flowfile_frontend/src/renderer/app/features/ai/useGhostNodeSuggestions.ts
@@ -1,178 +1,112 @@
-// Edge-hover wiring for the ghost-node surface.
+// Popover-side wiring for the ghost-node surface.
 //
-// VueFlow exposes per-edge mouse events on
-// `<VueFlow @edge-mouse-enter>` / `@edge-mouse-leave`. This
-// composable wraps those into a debounced request to the AI store,
-// anchored at the edge midpoint, and returns visibility state the
-// popup component can render against.
+// The suggestion is "what node should follow THIS node?" — triggered by a
+// deliberate action on a node (right-click → "Suggest next node…"), which
+// calls `store.beginIntent()`. This composable powers the Canvas-rendered
+// popover that completes the flow:
+//   1. (trigger, elsewhere) store.beginIntent(anchor, flowId) — opens the
+//      inline intent input at the right-clicked node.
+//   2. submitIntent(text) — sends the user's intent to the AI store; the
+//      popover shows loading, then the proposed node(s) as a ghost to confirm.
+//   3. acceptSuggestion(index) — materialises the chosen ghost as a real node
+//      wired downstream of the source node.
 //
-// Debounce is 400 ms — short enough that a deliberate hover commits,
-// long enough that a hover-flick across multiple edges doesn't fire
-// N requests. Rate-limit accounting still applies if the timer leaks
-// (it shouldn't), so this is best-effort UX rather than a hard
-// contract.
-//
-// Lifecycle:
-//   - on edge-mouse-enter: schedule a request after the debounce window
-//   - on edge-mouse-leave: cancel any pending timer + cancel the inflight call
-//   - on viewport click: clear the popup (handled by the consumer; the
-//     composable just exposes `clear()`)
-//
-// The composable is read-only — `requestSuggestions` and `materialize` go
-// through the Pinia store so cancellation semantics are shared with any
-// other surface that wants to interrupt the hover request.
+// The composable is thin — flow id, cancellation, request state, and
+// materialisation all live in the Pinia store so the trigger (a node
+// component) and the popover (Canvas) share the same state.
 
-import type { GraphEdge } from "@vue-flow/core";
-import { computed, onUnmounted, ref } from "vue";
+import { computed, onUnmounted } from "vue";
 
 import { NextNodeSuggestion } from "../../api/ai.api";
 import { useAiGhostNodeStore } from "../../stores/ai-ghost-node-store";
 
-const DEBOUNCE_MS = 400;
+// Rightward offset (flow coords) for the materialised node relative to its
+// source. Flows read left→right (outputs on the right, inputs on the left), so
+// the next node lands to the right of the one it follows rather than below it.
+const NODE_DROP_OFFSET_X = 220;
 
 export interface GhostNodeOptions {
-  /** Provider override — defaults to the store's default (anthropic). */
+  /** Provider override — defaults to the store's per-surface resolution. */
   provider?: string;
-  /** When set, requests skip the debounce window (used in tests). */
-  skipDebounce?: boolean;
+  /** Cap on how many candidates the AI returns. */
+  maxSuggestions?: number;
 }
-
-/** Subset of VueFlow's ``GraphEdge`` we read.
- *
- * Pulled out so the composable doesn't pin a specific edge `Data` /
- * `CustomEvents` shape — VueFlow's full ``GraphEdge`` type takes generics
- * that bubble up nastily through the props chain.
- */
-type GhostEdgePayload = Pick<
-  GraphEdge,
-  "id" | "source" | "target" | "sourceX" | "sourceY" | "targetX" | "targetY"
->;
 
 export const useGhostNodeSuggestions = (options: GhostNodeOptions = {}) => {
   const store = useAiGhostNodeStore();
-  let pendingTimer: ReturnType<typeof setTimeout> | null = null;
-  const flowIdRef = ref<number | null>(null);
-  const lastEdgeId = ref<string | null>(null);
 
-  const _clearTimer = (): void => {
-    if (pendingTimer !== null) {
-      clearTimeout(pendingTimer);
-      pendingTimer = null;
-    }
+  /** Fire the request once the user has typed (or skipped) their intent. */
+  const submitIntent = (intent: string): void => {
+    const anchor = store.anchor;
+    const flowId = store.flowId;
+    if (anchor === null || flowId === null) return;
+    void store.requestSuggestions(
+      {
+        flowId,
+        upstreamNodeId: anchor.upstreamNodeId,
+        provider: options.provider,
+        intent: intent.trim() || null,
+        maxSuggestions: options.maxSuggestions,
+      },
+      anchor,
+    );
   };
 
-  /** Caller wires this into VueFlow's `<VueFlow @edge-mouse-enter>` event.
-   *
-   * `flowId` MUST be supplied — there's no canonical "current flow" coupling
-   * at the composable layer because consumers vary (designer vs preview).
-   * Calling without a `flowId` is a no-op.
-   */
-  const onEdgeMouseEnter = (
-    payload: { edge: GhostEdgePayload; event?: unknown },
-    flowId: number | null,
-  ): void => {
-    if (flowId === null) return;
-    flowIdRef.value = flowId;
-    const edge = payload.edge;
-    if (!edge?.source) return;
-    lastEdgeId.value = edge.id ?? `${edge.source}->${edge.target}`;
-
-    const upstreamNodeId = edge.source;
-    const sourceX = edge.sourceX ?? 0;
-    const sourceY = edge.sourceY ?? 0;
-    const targetX = edge.targetX ?? sourceX;
-    const targetY = edge.targetY ?? sourceY;
-
-    const anchor = {
-      upstreamNodeId,
-      edgeMidX: (sourceX + targetX) / 2,
-      edgeMidY: (sourceY + targetY) / 2,
-    };
-
-    _clearTimer();
-
-    const fire = () => {
-      pendingTimer = null;
-      void store.requestSuggestions(
-        {
-          flowId,
-          upstreamNodeId,
-          provider: options.provider,
-        },
-        anchor,
-      );
-    };
-
-    if (options.skipDebounce) {
-      fire();
-    } else {
-      pendingTimer = setTimeout(fire, DEBOUNCE_MS);
-    }
-  };
-
-  const onEdgeMouseLeave = (): void => {
-    _clearTimer();
-    // Don't clear suggestions immediately — the user may be moving toward the
-    // popup. Component-level handlers close the popup on outside click.
-  };
-
-  /** Caller wires this into the canvas's pane click handler so the popup
-   * disappears when the user clicks anywhere off the suggestion list. */
+  /** Caller wires this into the canvas pane click so an outside click dismisses
+   * the popup (input or suggestions). Ignored while a request is in flight —
+   * a stray canvas click shouldn't discard a suggestion mid-generation. */
   const onViewportClick = (): void => {
-    _clearTimer();
+    if (store.isLoading) return;
     store.clear();
   };
 
   const acceptSuggestion = async (
     indexOrSuggestion: number | NextNodeSuggestion,
   ): Promise<number | null> => {
-    if (flowIdRef.value === null) return null;
+    const flowId = store.flowId;
     const currentAnchor = store.anchor;
-    if (currentAnchor === null) return null;
+    if (flowId === null || currentAnchor === null) return null;
     const list = store.suggestions;
     const suggestion =
       typeof indexOrSuggestion === "number" ? list[indexOrSuggestion] : indexOrSuggestion;
     if (!suggestion) return null;
-    // Round-trip the upstream id through Number() — the AI route accepts
-    // string OR number; the materialise path needs an integer for
-    // ``editor/add_node/``'s NodePromise shape.
+    // The AI route accepts string OR number, but the materialise path needs an
+    // integer node id for ``editor/add_node/``'s NodePromise shape.
     const upstreamId = Number(currentAnchor.upstreamNodeId);
     if (Number.isNaN(upstreamId)) return null;
     return store.materialize(
       suggestion,
-      flowIdRef.value,
+      flowId,
       upstreamId,
-      currentAnchor.edgeMidX,
-      currentAnchor.edgeMidY + 80,
+      currentAnchor.nodeX + NODE_DROP_OFFSET_X,
+      currentAnchor.nodeY,
     );
   };
 
   const isVisible = computed(
     () =>
       store.anchor !== null &&
-      (store.suggestions.length > 0 || store.isLoading || store.degradedReason !== null),
+      (store.awaitingIntent ||
+        store.suggestions.length > 0 ||
+        store.isLoading ||
+        store.degradedReason !== null),
   );
 
   onUnmounted(() => {
-    _clearTimer();
     store.cancel();
   });
 
   return {
     isVisible,
+    awaitingIntent: computed(() => store.awaitingIntent),
     suggestions: computed(() => store.suggestions),
     anchor: computed(() => store.anchor),
     isLoading: computed(() => store.isLoading),
     aiDisabled: computed(() => store.aiDisabled),
     degradedReason: computed(() => store.degradedReason),
-    lastEdgeId: computed(() => lastEdgeId.value),
-    onEdgeMouseEnter,
-    onEdgeMouseLeave,
+    submitIntent,
     onViewportClick,
     acceptSuggestion,
-    clear: () => {
-      _clearTimer();
-      store.clear();
-    },
+    clear: () => store.clear(),
   };
 };

--- a/flowfile_frontend/src/renderer/app/stores/ai-ghost-node-store.test.ts
+++ b/flowfile_frontend/src/renderer/app/stores/ai-ghost-node-store.test.ts
@@ -1,0 +1,129 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchNextNodeSuggestions: vi.fn(),
+  resolveSurface: vi.fn(() => ({ provider: "anthropic", model: "m" })),
+  insertNode: vi.fn(),
+  connectNode: vi.fn(),
+  axiosPost: vi.fn(),
+}));
+
+vi.mock("../api/ai.api", () => ({
+  fetchNextNodeSuggestions: mocks.fetchNextNodeSuggestions,
+  AiDisabledError: class AiDisabledError extends Error {},
+}));
+
+vi.mock("../api/flow.api", () => ({
+  FlowApi: { insertNode: mocks.insertNode, connectNode: mocks.connectNode },
+}));
+
+vi.mock("axios", () => ({ default: { post: mocks.axiosPost } }));
+
+vi.mock("./ai-store", () => ({
+  useAiStore: () => ({ resolveSurface: mocks.resolveSurface }),
+}));
+
+import { GhostNodeAnchor, useAiGhostNodeStore } from "./ai-ghost-node-store";
+import type { NextNodeSuggestion } from "../api/ai.api";
+
+const anchor = (): GhostNodeAnchor => ({
+  upstreamNodeId: "3",
+  screenX: 100,
+  screenY: 200,
+  nodeX: 10,
+  nodeY: 20,
+});
+
+describe("useAiGhostNodeStore — intent flow", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mocks.fetchNextNodeSuggestions.mockReset();
+    mocks.insertNode.mockReset().mockResolvedValue({});
+    mocks.connectNode.mockReset().mockResolvedValue({});
+    mocks.axiosPost.mockReset().mockResolvedValue({});
+    mocks.resolveSurface.mockReturnValue({ provider: "anthropic", model: "m" });
+  });
+
+  it("beginIntent opens the inline box at the anchor without firing a request", () => {
+    const store = useAiGhostNodeStore();
+    store.beginIntent(anchor(), 1);
+    expect(store.awaitingIntent).toBe(true);
+    expect(store.anchor).toEqual(anchor());
+    expect(store.suggestions).toEqual([]);
+    expect(store.degradedReason).toBeNull();
+    expect(mocks.fetchNextNodeSuggestions).not.toHaveBeenCalled();
+  });
+
+  it("clear() resets the intent state and anchor", () => {
+    const store = useAiGhostNodeStore();
+    store.beginIntent(anchor(), 1);
+    store.clear();
+    expect(store.awaitingIntent).toBe(false);
+    expect(store.anchor).toBeNull();
+  });
+
+  it("requestSuggestions leaves the intent state and fills the resolved provider + intent", async () => {
+    mocks.fetchNextNodeSuggestions.mockResolvedValue({
+      suggestions: [
+        {
+          nodeType: "filter",
+          settings: {},
+          label: "Filter",
+          description: null,
+          predictedOutputSchema: null,
+          rationale: null,
+        },
+      ],
+      degraded: false,
+      reason: null,
+    });
+    const store = useAiGhostNodeStore();
+    store.beginIntent(anchor(), 1);
+    await store.requestSuggestions(
+      { flowId: 1, upstreamNodeId: "3", intent: "filter to EU" },
+      anchor(),
+    );
+    expect(store.awaitingIntent).toBe(false);
+    expect(store.isLoading).toBe(false);
+    expect(store.suggestions).toHaveLength(1);
+    const sentBody = mocks.fetchNextNodeSuggestions.mock.calls[0][0];
+    expect(sentBody.provider).toBe("anthropic");
+    expect(sentBody.intent).toBe("filter to EU");
+  });
+
+  it("maps a degraded response's reason into degradedReason (frontend contract)", async () => {
+    mocks.fetchNextNodeSuggestions.mockResolvedValue({
+      suggestions: [],
+      degraded: true,
+      reason: "upstream_schema_unknown",
+    });
+    const store = useAiGhostNodeStore();
+    await store.requestSuggestions({ flowId: 1, upstreamNodeId: "3" }, anchor());
+    expect(store.degradedReason).toBe("upstream_schema_unknown");
+    expect(store.suggestions).toEqual([]);
+  });
+
+  it("materialize sends pos_x/pos_y in the settings body so update_settings keeps the position", async () => {
+    const suggestion = {
+      nodeType: "filter",
+      settings: { flow_id: 999, node_id: 999, filter_input: {} },
+      label: "Filter",
+      description: null,
+      predictedOutputSchema: null,
+      rationale: null,
+    } as unknown as NextNodeSuggestion;
+
+    const store = useAiGhostNodeStore();
+    const newNodeId = await store.materialize(suggestion, 1, 4, 520, 150);
+
+    expect(newNodeId).not.toBeNull();
+    // add_node was placed at the computed position.
+    expect(mocks.insertNode).toHaveBeenCalledWith(1, newNodeId, "filter", 520, 150);
+    // update_settings replaces the whole setting_input, so the position must ride
+    // along or the node snaps back to (0,0).
+    const [url, body] = mocks.axiosPost.mock.calls[0];
+    expect(url).toBe("update_settings/");
+    expect(body).toMatchObject({ flow_id: 1, node_id: newNodeId, pos_x: 520, pos_y: 150 });
+  });
+});

--- a/flowfile_frontend/src/renderer/app/stores/ai-ghost-node-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/ai-ghost-node-store.ts
@@ -43,8 +43,14 @@ const isAbortError = (err: unknown): boolean => {
 
 export interface GhostNodeAnchor {
   upstreamNodeId: number | string;
-  edgeMidX: number;
-  edgeMidY: number;
+  // Screen (client) coords — where the inline input / preview popover renders
+  // (position: fixed), taken from the right-click that triggered it.
+  screenX: number;
+  screenY: number;
+  // Flow coords of the upstream node — where the materialised node is placed
+  // on the canvas (distinct from the screen coords above).
+  nodeX: number;
+  nodeY: number;
 }
 
 export const useAiGhostNodeStore = defineStore("aiGhostNode", () => {
@@ -55,6 +61,12 @@ export const useAiGhostNodeStore = defineStore("aiGhostNode", () => {
   const lastError = ref<unknown>(null);
   const aiDisabled = ref(false);
   const degradedReason = ref<string | null>(null);
+  // True between the deliberate trigger (right-click → begin) and the intent
+  // submit — the popover shows its inline "what do you want?" input.
+  const awaitingIntent = ref(false);
+  // Held on the store (not the composable) so a node component can trigger the
+  // flow and the Canvas-rendered popover can complete it against the same id.
+  const flowId = ref<number | null>(null);
 
   const cancel = (): void => {
     if (inflight.value !== null) {
@@ -69,6 +81,22 @@ export const useAiGhostNodeStore = defineStore("aiGhostNode", () => {
     suggestions.value = [];
     anchor.value = null;
     degradedReason.value = null;
+    awaitingIntent.value = false;
+    flowId.value = null;
+  };
+
+  /** Open the inline intent input at the given anchor without firing a request
+   * yet — the user types what they want, then `requestSuggestions` runs. This
+   * is the entry point for the trigger (a node's context menu). */
+  const beginIntent = (anchorPos: GhostNodeAnchor, flowIdArg: number): void => {
+    cancel();
+    suggestions.value = [];
+    degradedReason.value = null;
+    lastError.value = null;
+    aiDisabled.value = false;
+    anchor.value = anchorPos;
+    flowId.value = flowIdArg;
+    awaitingIntent.value = true;
   };
 
   const _replaceController = (): AbortController => {
@@ -84,6 +112,7 @@ export const useAiGhostNodeStore = defineStore("aiGhostNode", () => {
   ): Promise<NextNodeSuggestionsResponse | null> => {
     const controller = _replaceController();
     isLoading.value = true;
+    awaitingIntent.value = false;
     anchor.value = anchorPos;
     suggestions.value = [];
     degradedReason.value = null;
@@ -165,10 +194,15 @@ export const useAiGhostNodeStore = defineStore("aiGhostNode", () => {
       // settings carry flow_id / node_id from the LLM's perspective — overwrite
       // with the real ones before sending. The backend update_settings handler
       // ignores stale flow_id but accurate values keep audit logs honest.
+      // pos_x/pos_y MUST be sent too: update_settings replaces the node's whole
+      // setting_input, and NodeBase defaults pos_x/pos_y to 0 — omitting them
+      // would reset the node to (0,0), undoing the position add_node just set.
       const settingsBody = {
         ...suggestion.settings,
         flow_id: flowId,
         node_id: newNodeId,
+        pos_x: posX,
+        pos_y: posY,
       };
       await axios.post("update_settings/", settingsBody, {
         params: { node_type: suggestion.nodeType },
@@ -205,8 +239,11 @@ export const useAiGhostNodeStore = defineStore("aiGhostNode", () => {
     lastError,
     aiDisabled,
     degradedReason,
+    awaitingIntent,
+    flowId,
     cancel,
     clear,
+    beginIntent,
     requestSuggestions,
     materialize,
   };

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
@@ -161,10 +161,10 @@ provide("hoveredEdgeId", hoveredEdgeId);
 provide("cancelEdgeLeave", cancelEdgeLeave);
 provide("scheduleEdgeLeave", scheduleEdgeLeave);
 
-// — schema-grounded next-node suggestions on edge hover. The composable
-// owns its own debounce + AbortController so a hover-flick doesn't fire N
-// requests; clear is wired into handleCanvasClick below so a click anywhere
-// off the popover dismisses it.
+// Schema-grounded "suggest next node" — a deliberate action (right-click a
+// node → "Suggest next node…") that opens an inline intent box and, on submit,
+// previews AI-proposed downstream nodes to confirm. The popover + request
+// state live in the composable/store; dismiss is wired into handleCanvasClick.
 const ghostNode = useGhostNodeSuggestions();
 
 function onEdgeMouseEnter(payload: {
@@ -173,19 +173,11 @@ function onEdgeMouseEnter(payload: {
 }) {
   cancelEdgeLeave();
   hoveredEdgeId.value = payload.edge.id;
-  // VueFlow's GraphEdge carries sourceX/Y/targetX/Y at runtime even though
-  // the public ``EdgeMouseEvent`` declares the narrower ``Edge`` shape; the
-  // composable defaults missing coords to 0 so this cast is safe.
-  ghostNode.onEdgeMouseEnter(
-    payload as Parameters<typeof ghostNode.onEdgeMouseEnter>[0],
-    flowStore.flowId,
-  );
 }
 
 function onEdgeMouseLeave({ edge }: { edge: { id: string } }) {
   if (hoveredEdgeId.value !== edge.id) return;
   scheduleEdgeLeave(edge.id);
-  ghostNode.onEdgeMouseLeave();
 }
 
 /**
@@ -1362,8 +1354,8 @@ defineExpose({
         @move-end="handleMoveEnd"
       >
         <MiniMap />
-        <AiGhostNode :composable="ghostNode" />
       </VueFlow>
+      <AiGhostNode :composable="ghostNode" @accepted="reloadCurrentFlow" />
       <context-menu
         v-if="showContextMenu"
         :x="clickedPosition.x"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Flowfile"
-version = "0.12.7"
+version = "0.12.8"
 description = "Project combining flowfile core (backend) and flowfile_worker (compute offloader) and flowfile_frame (api)"
 readme = "readme-pypi.md"
 authors = ["Edward van Eechoud <evaneechoud@gmail.com>"]

--- a/shared/_version.py
+++ b/shared/_version.py
@@ -1,6 +1,6 @@
 """Flowfile version, kept in sync with pyproject by tools/bump_version.py (CI-guarded)."""
 
-__version__ = "0.12.7"
+__version__ = "0.12.8"
 
 
 def get_version() -> str:


### PR DESCRIPTION
This pull request improves the reliability and UX of AI-powered node suggestions in Flowfile by ensuring schema prediction is always attempted on demand (not just via cache), strengthening prompt construction for LLMs, and hardening degraded/failure handling. It also introduces comprehensive tests to prevent regressions and clarify the contract between the backend and LLM. The changes touch both the core suggestion logic and its tests.

**Schema prediction and suggestion logic improvements:**

* All AI surfaces (including join key and next node suggestions) now use `get_predicted_schema()` to compute the upstream schema on demand, rather than relying on the possibly-stale `predicted_schema` cache. This ensures suggestions work even after settings edits or when the cache is cold, matching the behavior of other AI features. (`flowfile_core/flowfile_core/ai/autocomplete.py`, `flowfile_core/flowfile_core/ai/suggest_next_node.py`) [[1]](diffhunk://#diff-6ba5d9f7cba84e6618ccfcf0fe5e6df189d123a20b25aefd37cb1f909019969fL106-R120) [[2]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L169-L186) [[3]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L438-R497) [[4]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L453-R512) [[5]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L424) [[6]](diffhunk://#diff-6ba5d9f7cba84e6618ccfcf0fe5e6df189d123a20b25aefd37cb1f909019969fL281-R295)
* The degraded/failure states now use consistent, machine-readable reason codes (e.g., `"upstream_schema_unknown"`, `"missing_upstream"`) for better frontend handling. (`flowfile_core/flowfile_core/ai/suggest_next_node.py`) [[1]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L438-R497) [[2]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L453-R512)

**LLM prompt and validation enhancements:**

* The system prompt for node suggestions now includes concrete, per-node-type settings examples, ensuring the LLM generates the correct nested structure and reducing the risk of invalid suggestions. These examples are validated against the Pydantic settings classes to catch schema changes early. (`flowfile_core/flowfile_core/ai/suggest_next_node.py`, `flowfile_core/tests/ai/test_suggest_next_node.py`) [[1]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776R205-R233) [[2]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L203-R242) [[3]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L213-R265) [[4]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L248-R297) [[5]](diffhunk://#diff-179ae7d807da9e13cf18fbd1432a31086716bf3f20d4aab0d78beeb261c30c0fR310-R374)
* The backend now injects placeholder `flow_id` and `node_id` into settings before validation, so LLM suggestions that omit these (as expected) are still accepted. (`flowfile_core/flowfile_core/ai/suggest_next_node.py`)

**Timeout and UX adjustments:**

* The default timeout for node suggestions is increased from 3.5s to 20s (and the API allows up to 60s), recognizing that this is a deliberate user action where waiting a bit longer is acceptable. (`flowfile_core/flowfile_core/ai/suggest_next_node.py`, `flowfile_core/flowfile_core/ai/suggest_next_node_routes.py`) [[1]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L79-R89) [[2]](diffhunk://#diff-126820b516a413ca40e60b0dc05ad43dfd15555977c186aa7a7c2d750343e8f3L57-R57)

**Testing and regression coverage:**

* New and updated tests ensure: the schema-warming path is exercised, settings examples remain valid, prompt injection works, and degraded/cold-flow paths behave as intended. (`flowfile_core/tests/ai/test_autocomplete.py`, `flowfile_core/tests/ai/test_suggest_next_node.py`) [[1]](diffhunk://#diff-aa8731d89f24eca326568d8adb932acc5f75a6a4597e6de1075b9ce6be0f6204L68-R88) [[2]](diffhunk://#diff-179ae7d807da9e13cf18fbd1432a31086716bf3f20d4aab0d78beeb261c30c0fR78-R94) [[3]](diffhunk://#diff-179ae7d807da9e13cf18fbd1432a31086716bf3f20d4aab0d78beeb261c30c0fR310-R374) [[4]](diffhunk://#diff-179ae7d807da9e13cf18fbd1432a31086716bf3f20d4aab0d78beeb261c30c0fR409-R450)

**Documentation updates:**

* Docstrings and comments are updated to clarify the new schema prediction behavior and prompt contract. (`flowfile_core/flowfile_core/ai/suggest_next_node.py`, `flowfile_core/flowfile_core/ai/suggest_next_node.py`) [[1]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L27-R38) [[2]](diffhunk://#diff-d346eb2ac7d305420e06137bf08d262a6d4dc90a68f62d8b8b5f5447d98fb776L169-L186)

These improvements make the AI suggestion surfaces more robust, user-friendly, and maintainable.