### PR TITLE
Fix json parsing on worker for custom nodes

### DIFF
--- a/flowfile_frontend/package.json
+++ b/flowfile_frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Flowfile",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A tool for designing and executing data flows",
   "scripts": {
     "dev": "tauri dev",

--- a/flowfile_frontend/src-tauri/Cargo.lock
+++ b/flowfile_frontend/src-tauri/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 
 [[package]]
 name = "flowfile"
-version = "0.12.5"
+version = "0.13.2"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/flowfile_frontend/src-tauri/Cargo.toml
+++ b/flowfile_frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flowfile"
-version = "0.13.1"
+version = "0.13.2"
 description = "Flowfile — visual ETL platform"
 authors = ["Edwardvaneechoud"]
 license = "MIT"

--- a/flowfile_frontend/src-tauri/tauri.conf.json
+++ b/flowfile_frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Flowfile",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "identifier": "com.flowfile.app",
   "build": {
     "frontendDist": "../build/renderer",

--- a/flowfile_worker/flowfile_worker/custom_node_runner.py
+++ b/flowfile_worker/flowfile_worker/custom_node_runner.py
@@ -8,6 +8,8 @@ blast-radius boundary; core only ever sees file paths and row counts.
 """
 
 import contextlib
+import datetime
+import decimal
 import io
 import json
 import logging
@@ -102,6 +104,21 @@ def _output_path(file_path: str, name: str, primary_name: str) -> str:
     if name == primary_name:
         return file_path
     return file_path.removesuffix(".arrow") + f"__{name}.arrow"
+
+
+def _json_default(obj):
+    # Preview rows carry native polars values (Date/Datetime/Time/Duration/Decimal/binary,
+    # or those nested in struct/list) that json can't encode — stringify them so a
+    # date-producing custom node still previews in the Test panel.
+    if isinstance(obj, datetime.datetime | datetime.date | datetime.time):
+        return obj.isoformat()
+    if isinstance(obj, datetime.timedelta):
+        return obj.total_seconds()
+    if isinstance(obj, decimal.Decimal):
+        return str(obj)
+    if isinstance(obj, bytes | bytearray):
+        return obj.hex()
+    return str(obj)
 
 
 def _preview_payload(df: pl.DataFrame, row_limit: int) -> dict:
@@ -201,7 +218,7 @@ def execute_custom_node_task(
             payload["preview"] = preview
             payload["logs"] = buffer_handler.records if buffer_handler else []
             payload["duration_ms"] = (time.perf_counter() - started) * 1000
-        queue.put(json.dumps(payload))
+        queue.put(json.dumps(payload, default=_json_default))
         with progress.get_lock():
             progress.value = 100
     except Exception as e:

--- a/flowfile_worker/tests/test_execute_custom_node.py
+++ b/flowfile_worker/tests/test_execute_custom_node.py
@@ -1,5 +1,7 @@
 """Tests for custom-node execution in the worker (child target + endpoint)."""
 
+import datetime
+import decimal
 import json
 import os
 import subprocess
@@ -12,7 +14,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from flowfile_worker import main, models, mp_context
-from flowfile_worker.custom_node_runner import execute_custom_node_task
+from flowfile_worker.custom_node_runner import _json_default, execute_custom_node_task
 from flowfile_worker.secrets import encrypt_secret
 
 client = TestClient(main.app)
@@ -96,6 +98,22 @@ class SecretNode(CustomNodeBase):
     def process(self, *inputs):
         key = self.settings_schema.main.api_key.secret_value.get_secret_value()
         return inputs[0].with_columns(pl.lit(key).alias("key"))
+'''
+
+
+TEMPORAL_NODE_SOURCE = '''
+import polars as pl
+from shared.node_designer import CustomNodeBase
+
+
+class TemporalNode(CustomNodeBase):
+    node_name: str = "Temporal Node"
+
+    def process(self, *inputs):
+        return inputs[0].with_columns(
+            pl.col("raw").str.to_date("%Y-%m-%d").alias("as_date"),
+            pl.col("raw").str.to_datetime("%Y-%m-%d").alias("as_dt"),
+        )
 '''
 
 
@@ -294,6 +312,34 @@ def test_dry_run_returns_preview_and_logs(tmp_path):
     assert {c["name"] for c in preview["columns"]} == {"name", "p_name"}
     assert payload["duration_ms"] > 0
     assert any("Executing custom node" in line for line in payload["logs"])
+
+
+def test_dry_run_preview_serializes_temporal_columns(tmp_path):
+    # Regression: a node emitting Date/Datetime columns must still serialize its dry-run
+    # preview. df.rows() yields native datetime.date/datetime cells that json.dumps can't
+    # encode, so the runner must pass the _json_default fallback — before the fix this
+    # raised "Object of type date is not JSON serializable" and progress went to -1.
+    df = pl.DataFrame({"raw": ["2021-03-04", "2020-12-31"]})
+    progress, error, payload, _ = run_task(
+        tmp_path, TEMPORAL_NODE_SOURCE, inputs=[serialize_input(df)], dry_run=True,
+    )
+    assert progress == 100, error
+    preview = payload["preview"]["main"]
+    cols = [c["name"] for c in preview["columns"]]
+    assert {"as_date", "as_dt"} <= set(cols)
+    row0 = preview["rows"][0]
+    assert row0[cols.index("as_date")] == "2021-03-04"
+    assert row0[cols.index("as_dt")].startswith("2021-03-04T00:00:00")
+
+
+def test_json_default_encodes_temporal_and_binary():
+    # Locks each branch of the preview fallback encoder.
+    assert _json_default(datetime.date(2021, 3, 4)) == "2021-03-04"
+    assert _json_default(datetime.datetime(2021, 3, 4, 10, 30)) == "2021-03-04T10:30:00"
+    assert _json_default(datetime.time(10, 30)) == "10:30:00"
+    assert _json_default(datetime.timedelta(hours=2)) == 7200.0
+    assert _json_default(decimal.Decimal("1.50")) == "1.50"
+    assert _json_default(b"\x00\x01") == "0001"
 
 
 def test_dry_run_captures_user_logging_and_print(tmp_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Flowfile"
-version = "0.13.1"
+version = "0.13.2"
 description = "Project combining flowfile core (backend) and flowfile_worker (compute offloader) and flowfile_frame (api)"
 readme = "readme-pypi.md"
 authors = ["Edward van Eechoud <evaneechoud@gmail.com>"]

--- a/shared/_version.py
+++ b/shared/_version.py
@@ -1,6 +1,6 @@
 """Flowfile version, kept in sync with pyproject by tools/bump_version.py (CI-guarded)."""
 
-__version__ = "0.13.1"
+__version__ = "0.13.2"
 
 
 def get_version() -> str:


### PR DESCRIPTION
This pull request improves how custom node execution handles JSON encoding for preview data, ensuring that complex data types (like dates, times, decimals, and binary data) are properly serialized and do not break the preview functionality in the Test panel. The main changes are:

**JSON serialization improvements:**

* Added a `_json_default` function to handle serialization of `datetime`, `date`, `time`, `timedelta`, `decimal.Decimal`, and binary types, converting them to string or numeric representations suitable for JSON encoding.
* Updated the call to `json.dumps` in `execute_custom_node_task` to use the new `_json_default` function, preventing errors when serializing preview payloads with complex data types.

**Dependency updates:**

* Imported the `datetime` and `decimal` modules to support the new serialization logic.