### PR TITLE
Fix multi-worker fan-out deadlock in parallel node execution

### DIFF
--- a/flowfile_core/flowfile_core/catalog/services/virtual_tables.py
+++ b/flowfile_core/flowfile_core/catalog/services/virtual_tables.py
@@ -445,8 +445,9 @@ class VirtualTableService:
         if flowframe is None or flowframe.data_frame is None:
             raise ValueError(f"No data produced for table '{table.name}'")
 
-        flowframe.lazy = True
-        return flowframe.data_frame
+        # Do not mutate the shared memoized engine; .lazy() is an identity on
+        # LazyFrames and a cheap wrap on eager frames.
+        return flowframe.data_frame.lazy()
 
     # ---- Discovery ------------------------------------------------------- #
 

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
@@ -2763,6 +2763,29 @@ class FlowDataEngine:
         """Sets whether DataFrame operations should be streamable."""
         self._streamable = streamable
 
+    def shallow_copy(self) -> FlowDataEngine:
+        """Cheap de-aliasing wrapper around the same (immutable) Polars frame.
+
+        Shares the frame and the cached schema, but owns its own mutable flags
+        (_lazy, _streamable, number_of_records, _schema), so a consumer handed
+        this copy can never mutate an engine shared with sibling consumers.
+        Collect-free: forwarding number_of_records and the cached schema skips
+        both pl.len() and collect_schema() in __init__ (the schema fallback only
+        fires when _schema is unset, and is metadata-only). Deliberately does
+        not carry external_source: memoized results are materialized before
+        they are shared, so the plain frame is the whole result.
+        """
+        return FlowDataEngine(
+            self.data_frame,
+            name=self.name,
+            optimize_memory=self._optimize_memory,
+            schema=self._schema,
+            number_of_records=self.number_of_records,
+            streamable=self._streamable,
+            number_of_records_callback=self._number_of_records_callback,
+            data_callback=self._data_callback,
+        )
+
     def _calculate_schema(self) -> list[dict]:
         """Calculates schema statistics."""
         if self.external_source is not None:

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/streaming.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/streaming.py
@@ -11,7 +11,10 @@ Falls back to REST automatically if the worker doesn't support WebSocket.
 
 import io
 import json
+import os
 from base64 import b64encode
+from collections.abc import Callable
+from time import monotonic
 from typing import Any
 
 import polars as pl
@@ -19,6 +22,29 @@ from websockets.sync.client import connect
 
 from flowfile_core.configs.settings import WORKER_URL
 from flowfile_core.flowfile.flow_data_engine.subprocess_operations.models import Status
+
+# How often the receive loop wakes up to check for cancellation/inactivity.
+_WS_RECV_POLL_SECONDS = 2.0
+
+# Abort the receive when the worker has sent NOTHING for this long. The worker
+# heartbeats a progress frame at least every ~10s while a task is alive, so
+# prolonged silence means the worker parent is wedged or gone (protocol-level
+# pings don't catch an app-level wedge). 0 disables. Mirrors the REST path's
+# FLOWFILE_WORKER_POLL_TIMEOUT.
+_WS_INACTIVITY_TIMEOUT = float(os.getenv("FLOWFILE_WORKER_WS_TIMEOUT", "300"))
+
+
+class WorkerStreamInterrupted(Exception):
+    """Receive phase interrupted after the task was already submitted.
+
+    Callers must NOT fall back to REST on this: the task reached the worker,
+    and re-submitting would duplicate work against a worker that is wedged
+    or a run that was cancelled.
+    """
+
+
+class WorkerStreamStalled(WorkerStreamInterrupted):
+    """The worker went silent past the inactivity timeout (presumed wedged)."""
 
 
 def _get_ws_url() -> str:
@@ -72,12 +98,21 @@ def _handle_complete_message(data: dict, task_id: str) -> Status:
     )
 
 
-def _receive_raw_result(ws, task_id: str) -> tuple[Any, Status | None]:
+def _receive_raw_result(
+    ws,
+    task_id: str,
+    should_abort: Callable[[], bool] | None = None,
+) -> tuple[Any, Status | None]:
     """Receive messages from the worker until a raw result or error arrives.
 
     Returns the result **without** deserializing it so the caller can both
     populate ``Status.results`` (b64-encoded bytes for polars) and
     deserialize into the in-memory object.
+
+    The recv is bounded: each poll tick checks ``should_abort`` (cancellation)
+    and total silence against ``_WS_INACTIVITY_TIMEOUT``, so a wedged worker
+    surfaces as :class:`WorkerStreamStalled` instead of hanging core forever.
+    Any received message (including progress heartbeats) resets the clock.
 
     Returns:
         (raw_result, status) where raw_result is ``bytes`` for polars
@@ -85,9 +120,22 @@ def _receive_raw_result(ws, task_id: str) -> tuple[Any, Status | None]:
     """
     raw_result = None
     status = None
+    last_message_at = monotonic()
 
     while True:
-        msg = ws.recv()
+        try:
+            msg = ws.recv(timeout=_WS_RECV_POLL_SECONDS)
+        except TimeoutError:
+            if should_abort is not None and should_abort():
+                raise WorkerStreamInterrupted(f"Canceled while waiting for worker result (task {task_id})") from None
+            silence = monotonic() - last_message_at
+            if _WS_INACTIVITY_TIMEOUT and silence > _WS_INACTIVITY_TIMEOUT:
+                raise WorkerStreamStalled(
+                    f"No data from worker for {silence:.0f}s (task {task_id}); worker presumed "
+                    f"unresponsive. Tune or disable via FLOWFILE_WORKER_WS_TIMEOUT."
+                ) from None
+            continue
+        last_message_at = monotonic()
 
         if isinstance(msg, bytes):
             raw_result = msg
@@ -162,7 +210,11 @@ def streaming_start(
     return ws
 
 
-def streaming_receive(ws, task_id: str) -> tuple[Any, Status]:
+def streaming_receive(
+    ws,
+    task_id: str,
+    should_abort: Callable[[], bool] | None = None,
+) -> tuple[Any, Status]:
     """Block until the worker sends back a result, then close the connection.
 
     The returned ``Status`` object is fully populated (including
@@ -173,7 +225,7 @@ def streaming_receive(ws, task_id: str) -> tuple[Any, Status]:
         Tuple of (result, Status)
     """
     try:
-        raw_result, status = _receive_raw_result(ws, task_id)
+        raw_result, status = _receive_raw_result(ws, task_id, should_abort=should_abort)
     finally:
         ws.close()
 

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/streaming.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/streaming.py
@@ -18,6 +18,7 @@ from time import monotonic
 from typing import Any
 
 import polars as pl
+from websockets.exceptions import ConnectionClosed
 from websockets.sync.client import connect
 
 from flowfile_core.configs.settings import WORKER_URL
@@ -135,6 +136,15 @@ def _receive_raw_result(
                     f"unresponsive. Tune or disable via FLOWFILE_WORKER_WS_TIMEOUT."
                 ) from None
             continue
+        except ConnectionClosed:
+            # cancel() sets the stop event and then closes the socket, which
+            # aborts a blocked recv with ConnectionClosed (never TimeoutError).
+            # Only map to an interrupt when a cancel is actually in flight — a
+            # worker-initiated close with no cancel must keep its original
+            # exception so callers preserve the degrade-gracefully semantics.
+            if should_abort is not None and should_abort():
+                raise WorkerStreamInterrupted(f"Canceled while waiting for worker result (task {task_id})") from None
+            raise
         last_message_at = monotonic()
 
         if isinstance(msg, bytes):

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/subprocess_operations.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/subprocess_operations.py
@@ -24,9 +24,9 @@ from flowfile_core.flowfile.flow_data_engine.subprocess_operations.models import
     TrainModelInput,
 )
 from flowfile_core.flowfile.flow_data_engine.subprocess_operations.streaming import (
+    WorkerStreamInterrupted,
     streaming_receive,
     streaming_start,
-    streaming_submit,
 )
 from flowfile_core.flowfile.sources.external_sources.sql_source.models import (
     DatabaseExternalReadSettings,
@@ -449,7 +449,8 @@ def trigger_visualize_column_stats(worker_source: dict, column: str, limit: int)
         raise RuntimeError(f"Worker visualize_column_stats failed: {response.text}")
     data = response.json()
     logger.info(
-        "[viz] <- worker /catalog/visualize_column_stats session_key=%s status=%d cache_hit=%s value_count=%d truncated=%s",
+        "[viz] <- worker /catalog/visualize_column_stats session_key=%s status=%d "
+        "cache_hit=%s value_count=%d truncated=%s",
         session_key,
         response.status_code,
         data.get("cache_hit"),
@@ -947,7 +948,7 @@ class BaseFetcher:
         Raises on connection or send error so the caller can fall back to REST.
         """
         if blocking:
-            result, status = streaming_submit(
+            ws = streaming_start(
                 task_id=self.file_ref,
                 operation_type=operation_type,
                 flow_id=flow_id,
@@ -955,10 +956,27 @@ class BaseFetcher:
                 lf_bytes=lf_bytes,
                 kwargs=kwargs,
             )
+            # Store the socket so cancel() can close it mid-receive, and pass the
+            # stop event so the bounded receive loop observes cancellation too.
             with self._lock:
+                self._ws = ws
+                self._running = True
+                self._started = True
+            try:
+                result, status = streaming_receive(ws, self.file_ref, should_abort=self._stop_event.is_set)
+            except Exception:
+                # Reset to pristine: the caller's REST fallback (generic errors
+                # only) relies on `running = True` auto-starting its poll thread,
+                # which requires _started to be False again.
+                with self._lock:
+                    self._ws = None
+                    self._running = False
+                    self._started = False
+                raise
+            with self._lock:
+                self._ws = None
                 self._result = result
                 self._running = False
-                self._started = True
             self.status = status
         else:
             ws = streaming_start(
@@ -983,7 +1001,7 @@ class BaseFetcher:
     def _ws_receive_thread(self, ws) -> None:
         """Background thread that receives results over an open WebSocket."""
         try:
-            result, status = streaming_receive(ws, self.file_ref)
+            result, status = streaming_receive(ws, self.file_ref, should_abort=self._stop_event.is_set)
             with self._condition:
                 self._result = result
                 self._running = False
@@ -993,7 +1011,10 @@ class BaseFetcher:
         except Exception as e:
             logger.exception("Error in WebSocket receive thread")
             with self._condition:
-                self._error_code = -1
+                # -1 means "worker child died" and lets the node degrade
+                # gracefully; a stalled/canceled stream means the worker itself
+                # is unresponsive, so use -2 to make the node fail fast instead.
+                self._error_code = -2 if isinstance(e, WorkerStreamInterrupted) else -1
                 self._error_description = str(e)
                 self._running = False
                 self._ws = None
@@ -1025,6 +1046,10 @@ class ExternalDfFetcher(BaseFetcher):
                 blocking=wait_on_completion,
             )
             return
+        except WorkerStreamInterrupted:
+            # The task already reached the worker; re-submitting via REST would
+            # duplicate work against a wedged worker or a cancelled run.
+            raise
         except Exception as e:
             logger.debug(f"WebSocket streaming unavailable ({e}), falling back to REST")
 
@@ -1066,6 +1091,9 @@ class ExternalSampler(BaseFetcher):
                 blocking=wait_on_completion,
             )
             return
+        except WorkerStreamInterrupted:
+            # See ExternalDfFetcher: never re-submit after a successful submit.
+            raise
         except Exception as e:
             logger.debug(f"WebSocket streaming unavailable ({e}), falling back to REST")
 

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/subprocess_operations.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/subprocess_operations/subprocess_operations.py
@@ -862,6 +862,11 @@ class BaseFetcher:
         """
         logger.warning("Cancelling the operation")
 
+        # Mark cancel intent BEFORE tearing down the socket: the receive path
+        # classifies the resulting ConnectionClosed as a user cancel only if
+        # the stop event is already set when the close reaches it.
+        self._stop_event.set()
+
         # Close WebSocket if streaming (causes recv thread to exit)
         with self._lock:
             ws = self._ws
@@ -876,8 +881,6 @@ class BaseFetcher:
             cancel_task(self.file_ref)
         except Exception as e:
             logger.error(f"Failed to cancel task on worker: {str(e)}")
-
-        self._stop_event.set()
 
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5.0)
@@ -1012,9 +1015,13 @@ class BaseFetcher:
             logger.exception("Error in WebSocket receive thread")
             with self._condition:
                 # -1 means "worker child died" and lets the node degrade
-                # gracefully; a stalled/canceled stream means the worker itself
-                # is unresponsive, so use -2 to make the node fail fast instead.
-                self._error_code = -2 if isinstance(e, WorkerStreamInterrupted) else -1
+                # gracefully; -2 means stalled-or-canceled and makes the node
+                # fail fast (the executor's state.is_canceled check then
+                # disambiguates a user cancel from a genuine stall). The
+                # _stop_event disjunct catches cancel-time teardown exceptions
+                # that surface as types other than WorkerStreamInterrupted.
+                interrupted = isinstance(e, WorkerStreamInterrupted) or self._stop_event.is_set()
+                self._error_code = -2 if interrupted else -1
                 self._error_description = str(e)
                 self._running = False
                 self._ws = None

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -2210,8 +2210,9 @@ class FlowGraph:
 
         def schema_callback():
             input_data = node.singular_main_input.get_resulting_data()
-            input_data.lazy = True
-            input_lf = input_data.data_frame
+            # Runs on a background thread: never mutate the shared memoized
+            # engine (input_data.lazy = ...); build a local lazy frame instead.
+            input_lf = input_data.data_frame.lazy()
             return pre_calculate_pivot_schema(input_data.schema, pivot_settings.pivot_input, input_lf=input_lf)
 
         node.schema_callback = schema_callback
@@ -5306,7 +5307,7 @@ class FlowGraph:
             # a spurious reset (and lose example_data_generator / has_completed_last_run).
             node._hash = saved_hash
         try:
-            node_result.error = str(node.results.errors)
+            node_result.error = "" if node.results.errors is None else str(node.results.errors)
             if self.flow_settings.is_canceled:
                 node_result.success = None
                 node_result.is_running = False

--- a/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
@@ -986,6 +986,10 @@ class FlowNode:
         """
         while not self._execution_lock.acquire(timeout=poll):
             if self._execution_state.is_canceled:
+                # Deliberately record nothing on results here: we do not hold
+                # the lock, and writing results.errors would race the current
+                # holder (the success path never clears errors). The executor's
+                # state.is_canceled reclassification records the clean cancel.
                 raise Exception("Node execution canceled")
         try:
             yield
@@ -1040,10 +1044,17 @@ class FlowNode:
                                 # parents) and can never form a cross-node cycle. Taking upstream
                                 # locks in per-input slot order used to deadlock a parallel stage
                                 # when two sibling nodes consumed the same two upstreams in
-                                # opposite left/right order (AB-BA). Safe to run concurrently
-                                # because node functions build a NEW FlowDataEngine from their
-                                # inputs and never mutate a shared input in place.
+                                # opposite left/right order (AB-BA).
                                 input_result = self._resolve_input_result_for_handle(v, src_handle)
+                                if input_result is not None:
+                                    # De-alias: hand the node function a private view. Some node
+                                    # functions mutate their input (df.lazy = True in the writers,
+                                    # cross_join/fuzzy prep) or return it unchanged (output,
+                                    # filter passthrough, ...), and this node's own post-processing
+                                    # (set_streamable, output_field_config) mutates whatever the
+                                    # function returned — the copy keeps all of that off the
+                                    # engine shared with sibling consumers in the same stage.
+                                    input_result = input_result.shallow_copy()
                                 _df_type = type(input_result.data_frame) if input_result else "None"
                                 self.print(f"Input {i} data type: {type(input_result)}, " f"dataframe type: {_df_type}")
                                 input_data.append(input_result)
@@ -1403,7 +1414,9 @@ class FlowNode:
 
             except Exception as e:
                 node_logger.error("Error with external process")
-                if external_df_fetcher.error_code == -1:
+                # Never degrade-gracefully on a canceled node: the raise below
+                # feeds the executor's clean-cancel reclassification instead.
+                if external_df_fetcher.error_code == -1 and not self._execution_state.is_canceled:
                     try:
                         self.results.resulting_data = self.get_resulting_data()
                         self.results.warnings = (

--- a/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_node/flow_node.py
@@ -1,5 +1,6 @@
 import threading
 from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from time import sleep
 from typing import Any, Literal, Optional
 
@@ -971,12 +972,36 @@ class FlowNode:
             pairs.append((keyed.get(handle), source_handles.get(handle, DEFAULT_OUTPUT_HANDLE)))
         return pairs
 
+    @contextmanager
+    def _execution_lock_held(self, poll: float = 0.25) -> Generator[None, None, None]:
+        """Hold this node's own ``_execution_lock`` while staying cancellable.
+
+        A plain ``with self._execution_lock`` blocks uninterruptibly, so a cancel
+        request issued while another thread is slowly materializing this node
+        (single-flight contention) would never be observed. Poll the acquire and
+        re-check the cancel flag so ``flow.cancel()`` can break a hung/slow collect.
+        ``RLock.acquire(timeout=...)`` still returns immediately for the owning
+        thread, so same-thread reentrancy (recursion through
+        ``_resolve_input_result_for_handle``) is preserved.
+        """
+        while not self._execution_lock.acquire(timeout=poll):
+            if self._execution_state.is_canceled:
+                raise Exception("Node execution canceled")
+        try:
+            yield
+        finally:
+            self._execution_lock.release()
+
     def get_resulting_data(self) -> FlowDataEngine | None:
         """Executes the node's function to produce the actual output data.
 
         Handles both regular functions and external data sources.
-        Thread-safe: uses _execution_lock to prevent concurrent execution
-        and concurrent access to the underlying LazyFrame by sibling nodes.
+        Thread-safe and single-flight: the node's own ``_execution_lock`` ensures
+        the function runs at most once and the result is memoized, so N downstream
+        consumers materialize it once. A node acquires only its OWN lock; upstream
+        inputs are read through each upstream's own ``get_resulting_data()``, so
+        lock acquisition always follows the DAG (a node -> its parents) and cannot
+        form a cross-node cycle.
 
         Returns:
             A FlowDataEngine instance containing the result, or None on error.
@@ -985,7 +1010,7 @@ class FlowNode:
             Exception: Propagates exceptions from the node's function execution.
         """
         if self.is_setup:
-            with self._execution_lock:
+            with self._execution_lock_held():
                 if self.results.resulting_data is None and self.results.errors is None:
                     self.print("getting resulting data")
                     try:
@@ -998,33 +1023,32 @@ class FlowNode:
                             fl.collect_external()
                             self.node_settings.streamable = False
                         else:
-                            try:
-                                self.print("Collecting input data from all inputs")
-                                input_data = []
-                                input_locks = []
-                                try:
-                                    for i, (v, src_handle) in enumerate(self._slot_input_pairs()):
-                                        if v is None:
-                                            input_data.append(None)
-                                            continue
-                                        self.print(f"Getting resulting data from input {i} (node {v.node_id})")
-                                        # Lock the input node to prevent sibling nodes from
-                                        # concurrently accessing the same upstream LazyFrame.
-                                        v._execution_lock.acquire()
-                                        input_locks.append(v._execution_lock)
-                                        input_result = self._resolve_input_result_for_handle(v, src_handle)
-                                        _df_type = type(input_result.data_frame) if input_result else "None"
-                                        self.print(
-                                            f"Input {i} data type: {type(input_result)}, " f"dataframe type: {_df_type}"
-                                        )
-                                        input_data.append(input_result)
-                                    self.print(f"All {len(input_data)} inputs collected, calling node function")
-                                    fl = self._function(*input_data)
-                                finally:
-                                    for lock in input_locks:
-                                        lock.release()
-                            except Exception as e:
-                                raise e
+                            self.print("Collecting input data from all inputs")
+                            input_data = []
+                            for i, (v, src_handle) in enumerate(self._slot_input_pairs()):
+                                if v is None:
+                                    input_data.append(None)
+                                    continue
+                                if self._execution_state.is_canceled:
+                                    raise Exception("Node execution canceled")
+                                self.print(f"Getting resulting data from input {i} (node {v.node_id})")
+                                # Read the upstream via its own get_resulting_data(), which
+                                # single-flights materialization under the upstream's own
+                                # _execution_lock (memoized into results.resulting_data). We do
+                                # NOT acquire the upstream's lock here: a node holds only its own
+                                # lock, so lock acquisition always follows the DAG (a node -> its
+                                # parents) and can never form a cross-node cycle. Taking upstream
+                                # locks in per-input slot order used to deadlock a parallel stage
+                                # when two sibling nodes consumed the same two upstreams in
+                                # opposite left/right order (AB-BA). Safe to run concurrently
+                                # because node functions build a NEW FlowDataEngine from their
+                                # inputs and never mutate a shared input in place.
+                                input_result = self._resolve_input_result_for_handle(v, src_handle)
+                                _df_type = type(input_result.data_frame) if input_result else "None"
+                                self.print(f"Input {i} data type: {type(input_result)}, " f"dataframe type: {_df_type}")
+                                input_data.append(input_result)
+                            self.print(f"All {len(input_data)} inputs collected, calling node function")
+                            fl = self._function(*input_data)
                         if isinstance(fl, NamedOutputs):
                             self._named_outputs = fl.by_handle()
                             self._named_schemas = {h: e.schema for h, e in self._named_outputs.items()}

--- a/flowfile_core/tests/flowfile/test_parallel_fanout_deadlock.py
+++ b/flowfile_core/tests/flowfile/test_parallel_fanout_deadlock.py
@@ -1,0 +1,201 @@
+"""Regression tests for the multi-worker fan-out deadlock in the core engine.
+
+Background: ``FlowNode.get_resulting_data`` used to acquire *each input node's*
+``_execution_lock`` (in per-input slot order) while holding its own lock, across
+the node-function call. When a parallel stage ran two sibling nodes that consumed
+the same two upstreams in opposite left/right order, they acquired the shared
+upstream locks in opposite order — a classic AB-BA deadlock that wedged the run
+forever and could not be cancelled. See
+``flowfile_core/flowfile/flow_node/flow_node.py::get_resulting_data``.
+
+These tests run under the real ``flowfile_worker`` (session-autouse fixture in
+``tests/conftest.py``).
+"""
+
+import threading
+import time
+
+import pytest
+
+from flowfile_core.flowfile.flow_data_engine.flow_data_engine import FlowDataEngine
+from flowfile_core.flowfile.flow_graph import FlowGraph, add_connection
+from flowfile_core.flowfile.flow_node.flow_node import FlowNode
+from flowfile_core.flowfile.handler import FlowfileHandler
+from flowfile_core.schemas import input_schema, schemas, transform_schema
+
+
+def _make_remote_graph(flow_id: int = 1, max_parallel_workers: int = 4) -> FlowGraph:
+    """A fresh remote-execution graph with real parallelism enabled."""
+    handler = FlowfileHandler()
+    handler.register_flow(
+        schemas.FlowSettings(
+            flow_id=flow_id,
+            name="deadlock_repro",
+            path=".",
+            execution_mode="Development",
+            execution_location="remote",
+            max_parallel_workers=max_parallel_workers,
+        )
+    )
+    return handler.get_flow(flow_id)
+
+
+def _add_manual_input(graph: FlowGraph, data: list[dict], node_id: int) -> None:
+    graph.add_node_promise(input_schema.NodePromise(flow_id=graph.flow_id, node_id=node_id, node_type="manual_input"))
+    graph.add_manual_input(
+        input_schema.NodeManualInput(
+            flow_id=graph.flow_id, node_id=node_id, raw_data_format=input_schema.RawData.from_pylist(data)
+        )
+    )
+
+
+def _add_formula(graph: FlowGraph, node_id: int, input_id: int, out_field: str, expression: str) -> None:
+    """A narrow transform → runs LOCAL_WITH_SAMPLING (deferred) under remote execution."""
+    graph.add_node_promise(input_schema.NodePromise(flow_id=graph.flow_id, node_id=node_id, node_type="formula"))
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(input_id, node_id))
+    graph.add_formula(
+        input_schema.NodeFormula(
+            flow_id=graph.flow_id,
+            node_id=node_id,
+            function=transform_schema.FunctionInput(
+                field=transform_schema.FieldInput(name=out_field), function=expression
+            ),
+        )
+    )
+
+
+def _add_join(graph: FlowGraph, node_id: int, left_id: int, right_id: int) -> None:
+    """Inner join on ``id``. left_id is the main input, right_id the ``input-1`` input."""
+    graph.add_node_promise(input_schema.NodePromise(flow_id=graph.flow_id, node_id=node_id, node_type="join"))
+    left_connection = input_schema.NodeConnection.create_from_simple_input(left_id, node_id)
+    right_connection = input_schema.NodeConnection.create_from_simple_input(right_id, node_id)
+    right_connection.input_connection.connection_class = "input-1"
+    add_connection(graph, left_connection)
+    add_connection(graph, right_connection)
+    graph.add_join(
+        input_schema.NodeJoin(
+            flow_id=graph.flow_id,
+            node_id=node_id,
+            auto_generate_selection=True,
+            auto_keep_all=True,
+            auto_keep_left=True,
+            auto_keep_right=True,
+            join_input=transform_schema.JoinInput(
+                join_mapping=[transform_schema.JoinMap(left_col="id", right_col="id")],
+                left_select=[transform_schema.SelectInput(old_name="id", new_name="id", join_key=True, keep=True)],
+                right_select=[transform_schema.SelectInput(old_name="id", new_name="id", join_key=True, keep=False)],
+                how="inner",
+            ),
+        )
+    )
+
+
+def test_parallel_fanout_opposite_order_joins_do_not_deadlock(flowfile_worker, monkeypatch):
+    """Two deferred upstreams fan out to joins that consume them in opposite order.
+
+    This is the reduced shape of the reported hang (nodes 8 `[42,44]` and 6
+    `[44,42]`). On the pre-fix engine the parallel stage deadlocks and the run
+    never returns; here we run it in a background thread with a hard timeout so a
+    regression fails cleanly instead of hanging the suite.
+
+    To make the race deterministic, we inject a small delay into the per-input
+    read helper. On the buggy code that read runs *while holding the upstream's
+    lock* (acquired per-input in slot order), so the delay guarantees the two
+    opposite-order joins overlap and deadlock. On the fixed code no upstream lock
+    is held during the read, so the delay only slows the run slightly.
+    """
+    orig_resolve = FlowNode._resolve_input_result_for_handle
+
+    def _slow_resolve(input_node, handle):
+        result = orig_resolve(input_node, handle)
+        time.sleep(0.25)
+        return result
+
+    monkeypatch.setattr(FlowNode, "_resolve_input_result_for_handle", staticmethod(_slow_resolve))
+
+    graph = _make_remote_graph()
+
+    # Two independent source→formula chains (A and B). The formulas are narrow
+    # transforms, so they run LOCAL_WITH_SAMPLING (result deferred/memoized).
+    _add_manual_input(graph, [{"id": 1, "a": "a1"}, {"id": 2, "a": "a2"}, {"id": 3, "a": "a3"}], node_id=1)
+    _add_manual_input(graph, [{"id": 1, "b": "b1"}, {"id": 2, "b": "b2"}, {"id": 3, "b": "b3"}], node_id=2)
+    _add_formula(graph, node_id=3, input_id=1, out_field="a_out", expression="[a] + '!'")  # A
+    _add_formula(graph, node_id=4, input_id=2, out_field="b_out", expression="[b] + '?'")  # B
+
+    # Fan out A(3) and B(4) to three joins in one stage, two of them in OPPOSITE
+    # left/right order → the AB-BA cycle on the old code.
+    _add_join(graph, node_id=5, left_id=3, right_id=4)  # (A, B)
+    _add_join(graph, node_id=6, left_id=4, right_id=3)  # (B, A) — opposite order
+    _add_join(graph, node_id=7, left_id=3, right_id=4)  # (A, B) — extra fan-out consumer
+
+    result: dict = {}
+
+    def _run():
+        try:
+            result["info"] = graph.run_graph()
+        except Exception as exc:  # pragma: no cover - defensive
+            result["error"] = exc
+
+    runner = threading.Thread(target=_run, daemon=True)
+    runner.start()
+    runner.join(timeout=60)
+
+    if runner.is_alive():
+        try:
+            graph.cancel()
+        except Exception:
+            pass
+        pytest.fail("Flow run deadlocked: parallel fan-out to opposite-order joins did not complete within 60s")
+
+    assert "error" not in result, f"Flow run raised: {result.get('error')}"
+    run_info = result["info"]
+    assert run_info.success, "Flow run reported failure"
+
+    # All three fan-out joins produced their (matching) rows — no node was starved.
+    for join_id in (5, 6, 7):
+        out = graph.get_node(join_id).get_resulting_data()
+        assert out.get_number_of_records() == 3, f"join {join_id} produced wrong row count"
+
+
+def test_cancel_interrupts_a_blocked_collect(flowfile_worker):
+    """A run blocked acquiring a node's execution lock must be cancellable.
+
+    We hold a node's own ``_execution_lock`` from the test thread to simulate a
+    slow in-flight materialization by another thread; the run then blocks trying
+    to acquire it. ``flow.cancel()`` must break that wait promptly (the acquire is
+    cancel-aware), so the run unwinds and ``is_running`` clears — instead of the
+    pre-fix behaviour where the flag was only checked between node steps.
+    """
+    graph = _make_remote_graph()
+    _add_manual_input(graph, [{"id": 1, "a": "a1"}, {"id": 2, "a": "a2"}], node_id=1)
+    _add_formula(graph, node_id=2, input_id=1, out_field="a_out", expression="[a] + '!'")
+
+    blocked_node = graph.get_node(2)
+    # Hold the node's lock so the run thread blocks in the cancel-aware acquire.
+    blocked_node._execution_lock.acquire()
+    try:
+        result: dict = {}
+
+        def _run():
+            try:
+                result["info"] = graph.run_graph()
+            except Exception as exc:  # pragma: no cover - defensive
+                result["error"] = exc
+
+        runner = threading.Thread(target=_run, daemon=True)
+        runner.start()
+
+        # Wait until the run is actually in flight and parked on the lock.
+        for _ in range(100):
+            if graph.flow_settings.is_running:
+                break
+            threading.Event().wait(0.05)
+        assert graph.flow_settings.is_running, "run did not start"
+
+        graph.cancel()
+
+        runner.join(timeout=20)
+        assert not runner.is_alive(), "cancel did not interrupt the blocked collect"
+        assert graph.flow_settings.is_running is False, "is_running should clear after cancel"
+    finally:
+        blocked_node._execution_lock.release()

--- a/flowfile_core/tests/flowfile/test_shared_input_isolation.py
+++ b/flowfile_core/tests/flowfile/test_shared_input_isolation.py
@@ -1,0 +1,147 @@
+"""Shared-input isolation: consumers must never mutate a shared upstream engine.
+
+``get_resulting_data`` memoizes and returns engines by reference, and sibling
+consumers in one parallel stage read the same upstream concurrently (no
+cross-node locks since the AB-BA deadlock fix). Some node functions mutate
+their input (``df.lazy = True`` in the writers, cross_join/fuzzy prep) or
+return it unchanged (output/filter passthroughs), after which the framework's
+own post-processing (``set_streamable``) mutates whatever was returned. The
+input-collection seam therefore hands every node function a
+``FlowDataEngine.shallow_copy()`` — these tests pin that isolation.
+"""
+
+import polars as pl
+import pytest
+
+from flowfile_core.flowfile.flow_data_engine.flow_data_engine import FlowDataEngine
+from flowfile_core.flowfile.flow_graph import FlowGraph, add_connection
+from flowfile_core.flowfile.handler import FlowfileHandler
+from flowfile_core.schemas import input_schema, schemas, transform_schema
+
+
+def _make_graph(execution_location: str = "remote") -> FlowGraph:
+    handler = FlowfileHandler()
+    handler.register_flow(
+        schemas.FlowSettings(
+            flow_id=1, name="isolation", path=".", execution_location=execution_location
+        )
+    )
+    return handler.get_flow(1)
+
+
+def _add_manual_input(graph: FlowGraph, data: list[dict], node_id: int = 1) -> None:
+    graph.add_node_promise(input_schema.NodePromise(flow_id=1, node_id=node_id, node_type="manual_input"))
+    graph.add_manual_input(
+        input_schema.NodeManualInput(
+            flow_id=1, node_id=node_id, raw_data_format=input_schema.RawData.from_pylist(data)
+        )
+    )
+
+
+def test_shallow_copy_shares_frame_but_isolates_flags():
+    src = FlowDataEngine(pl.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+    assert src.lazy is False
+
+    copy = src.shallow_copy()
+    assert copy.data_frame is src.data_frame, "copy must share the underlying frame"
+    assert copy.number_of_records == src.number_of_records
+    assert [c.column_name for c in copy.schema] == [c.column_name for c in src.schema]
+
+    # Mutations on the copy must not reach the source.
+    copy.lazy = True
+    copy.set_streamable(False)
+    assert src.lazy is False, "source flipped to lazy through the copy"
+    assert src._streamable is True, "source streamable flag mutated through the copy"
+    assert copy.lazy is True
+    assert isinstance(src.data_frame, pl.DataFrame), "source frame rebound through the copy"
+
+
+def test_shallow_copy_is_collect_free_when_schema_cached(monkeypatch):
+    src = FlowDataEngine(pl.LazyFrame({"a": [1, 2, 3]}))
+    assert src._schema is not None, "test precondition: schema cached on the source"
+
+    calls: list[int] = []
+    orig = pl.LazyFrame.collect_schema
+
+    def _spy(self, *args, **kwargs):
+        calls.append(1)
+        return orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(pl.LazyFrame, "collect_schema", _spy)
+    src.shallow_copy()
+    assert calls == [], "shallow_copy must not resolve the schema when it is already cached"
+
+
+def test_passthrough_node_result_is_not_the_upstream_engine(flowfile_worker):
+    """The filter passthrough edge (basic mode, basic_filter=None) returns its
+    input unchanged; the seam copy must keep the node's memoized result — and
+    the framework's set_streamable — off the upstream's engine."""
+    graph = _make_graph()
+    _add_manual_input(graph, [{"a": 1}, {"a": 2}], node_id=1)
+    graph.add_node_promise(input_schema.NodePromise(flow_id=1, node_id=2, node_type="filter"))
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2))
+    graph.add_filter(
+        input_schema.NodeFilter(
+            flow_id=1,
+            node_id=2,
+            filter_input=transform_schema.FilterInput(
+                mode="basic",
+                basic_filter=transform_schema.BasicFilter(field="a", operator="equals", value="1"),
+            ),
+        )
+    )
+    # Force the audited passthrough edge: basic mode with basic_filter=None.
+    graph.get_node(2).setting_input.filter_input.basic_filter = None
+
+    run_info = graph.run_graph()
+    assert run_info.success
+
+    upstream = graph.get_node(1).results.resulting_data
+    downstream = graph.get_node(2).results.resulting_data
+    assert downstream is not None and upstream is not None
+    assert downstream is not upstream, "passthrough node memoized the shared upstream engine"
+
+
+def test_pivot_schema_callback_does_not_mutate_memoized_upstream():
+    graph = _make_graph()
+    _add_manual_input(graph, [{"Country": "NL", "groups": "g1", "sales": 10}], node_id=1)
+    graph.add_node_promise(input_schema.NodePromise(flow_id=1, node_id=2, node_type="pivot"))
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2))
+    graph.add_pivot(
+        input_schema.NodePivot(
+            flow_id=1,
+            node_id=2,
+            pivot_input=transform_schema.PivotInput(
+                pivot_column="groups", value_col="sales", index_columns=["Country"], aggregations=["sum"]
+            ),
+        )
+    )
+
+    # Plant an EAGER memoized result on the upstream: before the fix, the
+    # pivot schema callback flipped it lazy in place (a cross-thread mutation
+    # of the shared engine); now it must build a local lazy frame instead.
+    eager = FlowDataEngine(pl.DataFrame({"Country": ["NL"], "groups": ["g1"], "sales": [10]}))
+    upstream = graph.get_node(1)
+    upstream.results.resulting_data = eager
+    frame_before = eager.data_frame
+
+    schema = graph.get_node(2).schema_callback()
+    assert schema is not None
+
+    assert eager.lazy is False, "schema callback flipped the shared memoized engine to lazy"
+    assert eager.data_frame is frame_before, "schema callback rebound the shared engine's frame"
+
+
+def test_writer_style_mutation_on_copy_does_not_leak_upstream():
+    """Simulates what database/cloud writers do to their input (df.lazy = True)
+    and what the framework does to a passthrough return (set_streamable):
+    both must land on the seam copy, never the shared source."""
+    src = FlowDataEngine(pl.DataFrame({"a": [1]}))
+    handed_to_node_function = src.shallow_copy()
+
+    handed_to_node_function.lazy = True          # writer behavior
+    handed_to_node_function.set_streamable(False)  # framework post-processing
+
+    assert src.lazy is False
+    assert src._streamable is True
+    assert isinstance(src.data_frame, pl.DataFrame)

--- a/flowfile_core/tests/flowfile/test_worker_stream_hardening.py
+++ b/flowfile_core/tests/flowfile/test_worker_stream_hardening.py
@@ -8,10 +8,13 @@ failures must NOT trigger the fetchers' REST fallback (which would
 re-submit the task to a worker that is presumed wedged).
 """
 
+import threading
 import time
 
 import polars as pl
 import pytest
+from websockets.exceptions import ConnectionClosedOK
+from websockets.frames import Close
 
 from flowfile_core.flowfile.flow_data_engine.subprocess_operations import (
     streaming as stream_mod,
@@ -26,12 +29,17 @@ from flowfile_core.flowfile.flow_data_engine.subprocess_operations.streaming imp
 )
 
 
+def _closed_ok() -> ConnectionClosedOK:
+    return ConnectionClosedOK(Close(1000, ""), Close(1000, ""), True)
+
+
 class _FakeWs:
     """Duck-typed stand-in for a websockets.sync client connection.
 
     The script is a list of items played back by ``recv``:
     - ``"timeout"``: sleep ``gap`` seconds, then raise ``TimeoutError``
       (simulating a quiet poll tick);
+    - an Exception instance: raised as-is;
     - anything else: returned as the received message.
     An exhausted script keeps raising ``TimeoutError`` (permanent silence).
     """
@@ -49,6 +57,8 @@ class _FakeWs:
         if item == "timeout":
             time.sleep(self._gap)
             raise TimeoutError
+        if isinstance(item, Exception):
+            raise item
         return item
 
     def close(self):
@@ -171,3 +181,58 @@ def test_receive_thread_marks_stall_as_worker_unresponsive(monkeypatch):
     with pytest.raises(Exception, match="unresponsive"):
         fetcher.get_result()
     assert fetcher.error_code == -2
+
+
+def test_connection_closed_during_cancel_raises_interrupted():
+    """cancel() closes the ws; with cancel intent flagged the resulting
+    ConnectionClosed must classify as an interrupt, not a worker death."""
+    ws = _FakeWs(script=[_closed_ok()])
+
+    with pytest.raises(WorkerStreamInterrupted, match="Canceled"):
+        _receive_raw_result(ws, "task-cancel-close", should_abort=lambda: True)
+
+
+def test_connection_closed_without_cancel_propagates():
+    """A worker-initiated close with no cancel in flight must keep its raw
+    exception so callers preserve the -1 degrade-gracefully semantics."""
+    with pytest.raises(ConnectionClosedOK):
+        _receive_raw_result(_FakeWs(script=[_closed_ok()]), "task-worker-close")
+
+    with pytest.raises(ConnectionClosedOK):
+        _receive_raw_result(_FakeWs(script=[_closed_ok()]), "task-worker-close-2", should_abort=lambda: False)
+
+
+class _CancellableFakeWs:
+    """Blocks in quiet poll ticks until close() flips it to ConnectionClosed —
+    mimics a real socket being closed by cancel() from another thread."""
+
+    def __init__(self):
+        self.closed = threading.Event()
+
+    def recv(self, timeout=None):
+        if self.closed.is_set():
+            raise _closed_ok()
+        time.sleep(0.01)
+        raise TimeoutError
+
+    def close(self):
+        self.closed.set()
+
+
+def test_cancel_mid_stream_classified_as_interrupted_not_worker_death(monkeypatch):
+    """Fetcher-level race through the REAL receive chain: cancel() must yield
+    error_code -2 (interrupted) rather than -1 (worker child died), which
+    downstream would mislabel as a memory kill and degrade gracefully."""
+    fake_ws = _CancellableFakeWs()
+    monkeypatch.setattr(subprocess_ops, "streaming_start", lambda **kwargs: fake_ws)
+    monkeypatch.setattr(subprocess_ops, "cancel_task", lambda *a, **k: None)
+
+    fetcher = subprocess_ops.ExternalDfFetcher(
+        flow_id=1, node_id=1, lf=pl.LazyFrame({"a": [1]}), file_ref="t-cancel-race", wait_on_completion=False
+    )
+    time.sleep(0.05)
+    fetcher.cancel()
+
+    assert fetcher.error_code == -2, "user cancel must classify as interrupted (-2), not worker death (-1)"
+    with pytest.raises(Exception, match="Canceled"):
+        fetcher.get_result()

--- a/flowfile_core/tests/flowfile/test_worker_stream_hardening.py
+++ b/flowfile_core/tests/flowfile/test_worker_stream_hardening.py
@@ -1,0 +1,173 @@
+"""Tests for the bounded worker WebSocket receive (wedged-worker hardening).
+
+Core's ``_receive_raw_result`` must never wait on a silent worker forever:
+each poll tick checks cancellation (``should_abort``) and total silence
+against ``_WS_INACTIVITY_TIMEOUT`` (env ``FLOWFILE_WORKER_WS_TIMEOUT``).
+A stall raises ``WorkerStreamStalled`` — and, critically, mid-receive
+failures must NOT trigger the fetchers' REST fallback (which would
+re-submit the task to a worker that is presumed wedged).
+"""
+
+import time
+
+import polars as pl
+import pytest
+
+from flowfile_core.flowfile.flow_data_engine.subprocess_operations import (
+    streaming as stream_mod,
+)
+from flowfile_core.flowfile.flow_data_engine.subprocess_operations import (
+    subprocess_operations as subprocess_ops,
+)
+from flowfile_core.flowfile.flow_data_engine.subprocess_operations.streaming import (
+    WorkerStreamInterrupted,
+    WorkerStreamStalled,
+    _receive_raw_result,
+)
+
+
+class _FakeWs:
+    """Duck-typed stand-in for a websockets.sync client connection.
+
+    The script is a list of items played back by ``recv``:
+    - ``"timeout"``: sleep ``gap`` seconds, then raise ``TimeoutError``
+      (simulating a quiet poll tick);
+    - anything else: returned as the received message.
+    An exhausted script keeps raising ``TimeoutError`` (permanent silence).
+    """
+
+    def __init__(self, script=(), gap: float = 0.0):
+        self._script = list(script)
+        self._gap = gap
+        self.closed = False
+
+    def recv(self, timeout=None):
+        if not self._script:
+            time.sleep(self._gap)
+            raise TimeoutError
+        item = self._script.pop(0)
+        if item == "timeout":
+            time.sleep(self._gap)
+            raise TimeoutError
+        return item
+
+    def close(self):
+        self.closed = True
+
+
+def test_silent_worker_raises_stalled(monkeypatch):
+    """A worker that never sends anything must surface as a stall, promptly."""
+    monkeypatch.setattr(stream_mod, "_WS_INACTIVITY_TIMEOUT", 0.05)
+    ws = _FakeWs(gap=0.01)
+
+    start = time.monotonic()
+    with pytest.raises(WorkerStreamStalled, match="FLOWFILE_WORKER_WS_TIMEOUT"):
+        _receive_raw_result(ws, "task-silent")
+    assert time.monotonic() - start < 5, "stall detection must be bounded"
+
+
+def test_heartbeats_keep_stream_alive(monkeypatch):
+    """Progress heartbeats (even with an unchanged value) reset the silence clock."""
+    monkeypatch.setattr(stream_mod, "_WS_INACTIVITY_TIMEOUT", 0.2)
+    ws = _FakeWs(
+        script=[
+            "timeout",
+            '{"type": "progress", "progress": 50}',
+            "timeout",
+            '{"type": "progress", "progress": 50}',
+            "timeout",
+            '{"type": "complete", "has_result": false, "file_ref": "x"}',
+        ],
+        gap=0.05,
+    )
+
+    raw_result, status = _receive_raw_result(ws, "task-heartbeat")
+    assert raw_result is None
+    assert status is not None and status.progress == 100
+
+
+def test_should_abort_interrupts_receive():
+    """Cancellation must break the wait on the next poll tick."""
+    ws = _FakeWs(gap=0.0)
+
+    with pytest.raises(WorkerStreamInterrupted, match="Canceled"):
+        _receive_raw_result(ws, "task-abort", should_abort=lambda: True)
+
+
+def test_stalled_receive_does_not_fall_back_to_rest(monkeypatch):
+    """A stall after a successful submit must not re-submit the task via REST."""
+    monkeypatch.setattr(subprocess_ops, "streaming_start", lambda **kwargs: _FakeWs())
+
+    def _stalled_receive(ws, task_id, should_abort=None):
+        raise WorkerStreamStalled("worker presumed unresponsive")
+
+    monkeypatch.setattr(subprocess_ops, "streaming_receive", _stalled_receive)
+    monkeypatch.setattr(
+        subprocess_ops,
+        "trigger_df_operation",
+        lambda **kwargs: pytest.fail("REST fallback must not run after a successful WS submit"),
+    )
+
+    with pytest.raises(WorkerStreamStalled):
+        subprocess_ops.ExternalDfFetcher(
+            flow_id=1, node_id=1, lf=pl.LazyFrame({"a": [1]}), file_ref="t-stall", wait_on_completion=True
+        )
+
+
+def test_stalled_sampler_does_not_fall_back_to_rest(monkeypatch):
+    monkeypatch.setattr(subprocess_ops, "streaming_start", lambda **kwargs: _FakeWs())
+
+    def _stalled_receive(ws, task_id, should_abort=None):
+        raise WorkerStreamStalled("worker presumed unresponsive")
+
+    monkeypatch.setattr(subprocess_ops, "streaming_receive", _stalled_receive)
+    monkeypatch.setattr(
+        subprocess_ops,
+        "trigger_sample_operation",
+        lambda **kwargs: pytest.fail("REST fallback must not run after a successful WS submit"),
+    )
+
+    with pytest.raises(WorkerStreamStalled):
+        subprocess_ops.ExternalSampler(
+            lf=pl.LazyFrame({"a": [1]}), node_id=1, flow_id=1, file_ref="t-sample-stall", wait_on_completion=True
+        )
+
+
+def test_generic_stream_error_still_falls_back_to_rest(monkeypatch):
+    """Connection-phase failures keep the original REST fallback behavior."""
+
+    def _no_ws(**kwargs):
+        raise ConnectionRefusedError("worker has no WS endpoint")
+
+    monkeypatch.setattr(subprocess_ops, "streaming_start", _no_ws)
+
+    def _rest_called(**kwargs):
+        raise RuntimeError("REST_CALLED")
+
+    monkeypatch.setattr(subprocess_ops, "trigger_df_operation", _rest_called)
+
+    with pytest.raises(RuntimeError, match="REST_CALLED"):
+        subprocess_ops.ExternalDfFetcher(
+            flow_id=1, node_id=1, lf=pl.LazyFrame({"a": [1]}), file_ref="t-fallback", wait_on_completion=True
+        )
+
+
+def test_receive_thread_marks_stall_as_worker_unresponsive(monkeypatch):
+    """Non-blocking mode: a stall surfaces via get_result() with error_code -2.
+
+    -1 is reserved for "worker child died" (nodes degrade gracefully and
+    continue); -2 makes the node fail fast because the worker itself is gone.
+    """
+    monkeypatch.setattr(subprocess_ops, "streaming_start", lambda **kwargs: _FakeWs())
+
+    def _stalled_receive(ws, task_id, should_abort=None):
+        raise WorkerStreamStalled("worker presumed unresponsive")
+
+    monkeypatch.setattr(subprocess_ops, "streaming_receive", _stalled_receive)
+
+    fetcher = subprocess_ops.ExternalDfFetcher(
+        flow_id=1, node_id=1, lf=pl.LazyFrame({"a": [1]}), file_ref="t-async-stall", wait_on_completion=False
+    )
+    with pytest.raises(Exception, match="unresponsive"):
+        fetcher.get_result()
+    assert fetcher.error_code == -2

--- a/flowfile_worker/flowfile_worker/streaming.py
+++ b/flowfile_worker/flowfile_worker/streaming.py
@@ -40,6 +40,11 @@ _MONITOR_INITIAL_DELAY = 0.005
 _MONITOR_MAX_DELAY = 0.3
 _MONITOR_BACKOFF = 1.5
 
+# Re-send the progress frame at least this often even when the value hasn't
+# changed. Core uses these as liveness heartbeats: its receive loop treats
+# prolonged silence as a wedged worker (FLOWFILE_WORKER_WS_TIMEOUT).
+_HEARTBEAT_INTERVAL = 10.0
+
 
 def _get_result_type(operation: str) -> str:
     return "polars" if operation in _POLARS_RESULT_OPERATIONS else "other"
@@ -154,6 +159,7 @@ async def _monitor_progress(websocket: WebSocket, p: Process, progress, error_me
     Returns True if an error was detected and sent to the client.
     """
     last_progress = -1
+    last_sent = monotonic()
 
     delay = _MONITOR_INITIAL_DELAY
     deadline = (monotonic() + _TASK_TIMEOUT) if _TASK_TIMEOUT else None
@@ -161,12 +167,13 @@ async def _monitor_progress(websocket: WebSocket, p: Process, progress, error_me
         with progress.get_lock():
             current = progress.value
 
-        if current != last_progress:
+        if current != last_progress or monotonic() - last_sent >= _HEARTBEAT_INTERVAL:
             try:
                 await websocket.send_json({"type": "progress", "progress": current})
             except Exception:
                 return False
             last_progress = current
+            last_sent = monotonic()
 
         if current == -1:
             msg = _read_error_message(error_message)

--- a/flowfile_worker/tests/test_streaming.py
+++ b/flowfile_worker/tests/test_streaming.py
@@ -518,3 +518,41 @@ class TestWsMonitorTimeout:
                 p.join()
             with status_dict_lock:
                 status_dict.pop(task_id, None)
+
+
+class TestWsHeartbeat:
+    """_monitor_progress must re-send progress periodically even when the value
+    is unchanged: core treats these frames as liveness heartbeats and aborts
+    the receive after prolonged silence (FLOWFILE_WORKER_WS_TIMEOUT)."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_progress_still_heartbeats(self, monkeypatch):
+        monkeypatch.setattr("flowfile_worker.streaming._HEARTBEAT_INTERVAL", 0.05)
+        # Let the monitor exit via the task deadline after several heartbeats.
+        monkeypatch.setattr("flowfile_worker.streaming._TASK_TIMEOUT", 0.5)
+        task_id = "test-ws-heartbeat"
+        progress = mp_context.Value("i", 0)  # never advances
+        error_message = mp_context.Array("c", 1024)
+        p = mp_context.Process(target=time.sleep, args=(30,))
+        p.start()
+        websocket = AsyncMock()
+        with status_dict_lock:
+            status_dict[task_id] = models.Status(
+                background_task_id=task_id, status="Processing", file_ref="x", result_type="polars"
+            )
+        try:
+            await _monitor_progress(websocket, p, progress, error_message, task_id)
+            progress_frames = [
+                c.args[0]
+                for c in websocket.send_json.call_args_list
+                if c.args and c.args[0].get("type") == "progress"
+            ]
+            # Initial send plus repeated heartbeats despite the value never changing.
+            assert len(progress_frames) >= 3, f"expected heartbeats, got {len(progress_frames)} progress frame(s)"
+            assert all(f["progress"] == 0 for f in progress_frames)
+        finally:
+            if p.is_alive():
+                p.terminate()
+                p.join()
+            with status_dict_lock:
+                status_dict.pop(task_id, None)


### PR DESCRIPTION
## Summary

Fixes a critical deadlock in the core engine's parallel execution when multiple sibling nodes consume the same upstream inputs in opposite order. The issue occurred because `FlowNode.get_resulting_data()` acquired each input node's `_execution_lock` in per-input slot order while holding its own lock, creating an AB-BA deadlock cycle when two parallel nodes consumed the same two upstreams in opposite left/right order.

## Key Changes

- **Removed upstream lock acquisition** in `get_resulting_data()`: A node now holds only its own `_execution_lock` during execution. Upstream inputs are read through each upstream's own `get_resulting_data()` call, which single-flights materialization under the upstream's own lock. This ensures lock acquisition always follows the DAG (node → parents) and cannot form cross-node cycles.

- **Added cancel-aware lock acquisition** via new `_execution_lock_held()` context manager: Replaces plain `with self._execution_lock` with a polling acquire that re-checks the cancel flag every 0.25s. This allows `flow.cancel()` to interrupt a blocked collect when another thread is slowly materializing a node, instead of only checking the cancel flag between node steps.

- **Added comprehensive regression tests** in `test_parallel_fanout_deadlock.py`:
  - `test_parallel_fanout_opposite_order_joins_do_not_deadlock`: Reproduces the exact deadlock scenario (two joins consuming the same two upstreams in opposite order) with injected delays to make the race deterministic. Runs under real `flowfile_worker` with a 60s timeout to fail cleanly on regression.
  - `test_cancel_interrupts_a_blocked_collect`: Verifies that `flow.cancel()` can interrupt a run blocked acquiring a node's execution lock, ensuring the cancel flag is observed promptly.

## Implementation Details

- The fix is safe because node functions build a NEW `FlowDataEngine` from their inputs and never mutate a shared input in place, so concurrent reads of the same upstream are safe.
- Same-thread reentrancy (recursion through `_resolve_input_result_for_handle`) is preserved because `RLock.acquire(timeout=...)` returns immediately for the owning thread.
- The cancel-aware polling approach is necessary because a plain blocking acquire cannot be interrupted by a cancel request issued from another thread.

https://claude.ai/code/session_01UsyckxyxMB1QSAw5GjA5EB