### PR TITLE
Handle missing join keys gracefully in semi/anti joins

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/code_generator/join_handlers.py
+++ b/flowfile_core/flowfile_core/flowfile/code_generator/join_handlers.py
@@ -33,11 +33,12 @@ class JoinHandlersMixin(ConverterMixinBase):
     def _handle_semi_anti_join(
         self, settings: input_schema.NodeJoin, var_name: str, left_df: str, right_df: str
     ) -> None:
-        """Handle semi and anti joins which only return rows from the left DataFrame.
+        """Handle semi and anti joins, which return the left rows unchanged.
 
-        Semi joins return rows from left DataFrame that have matches in right.
-        Anti joins return rows from left DataFrame that have no matches in right.
-        These joins are simpler as they don't require column management from right DataFrame.
+        Semi joins return rows from the left DataFrame that have a match in the right;
+        anti joins return the left rows with no match. The full left input passes
+        through unchanged (all columns, no rename or drop); the right frame only
+        supplies the join keys for matching. Mirrors FlowDataEngine.join.
 
         Args:
             settings: NodeJoin settings containing join configuration
@@ -48,44 +49,16 @@ class JoinHandlersMixin(ConverterMixinBase):
         Returns:
             None: Modifies internal state by adding generated code
         """
-        join_input_manager = transform_schema.JoinInputManager(settings.join_input)
-        join_input_manager.auto_rename()
-        left_on, right_on = self._get_join_keys(join_input_manager)
-
-        # Semi/anti joins only return left columns, so apply the left-side
-        # select/drop/rename (the right side is suppressed) to mirror FlowDataEngine.join.
-        left_renames = {
-            column.old_name: column.new_name
-            for column in join_input_manager.left_select.renames
-            if column.old_name != column.new_name and (column.keep or column.join_key)
-        }
-        left_drop_columns = [
-            column.old_name
-            for column in join_input_manager.left_select.renames
-            if not column.keep and not column.join_key
-        ]
-        # Write transforms to a node-local temp so a fanned-out upstream frame isn't rebound.
-        left_tmp = f"_join_{settings.node_id}_left"
-        if left_renames:
-            self._add_code(f"{left_tmp} = {left_df}.rename({left_renames})")
-            left_df = left_tmp
-        if left_drop_columns:
-            self._add_code(f"{left_tmp} = {left_df}.drop({left_drop_columns})")
-            left_df = left_tmp
-
-        # Mirror FlowDataEngine.join: drop the left join-key columns the user marked not-keep.
-        after_join_drop_cols = [k.new_name for k in join_input_manager.left_select.join_key_selects if not k.keep]
-        has_post = bool(after_join_drop_cols)
-        self._add_code(f"{var_name} = {'(' if has_post else ''}{left_df}.join(")
-        self._add_code(f"        {right_df},")
+        left_on = [jm.left_col for jm in settings.join_input.join_mapping]
+        right_on = [jm.right_col for jm in settings.join_input.join_mapping]
+        right_keys = list(dict.fromkeys(right_on))
+        right_sel = f"{right_df}.select([{', '.join(self._py_str(k) for k in right_keys)}])"
+        self._add_code(f"{var_name} = {left_df}.join(")
+        self._add_code(f"        {right_sel},")
         self._add_code(f"        left_on={left_on},")
         self._add_code(f"        right_on={right_on},")
         self._add_code(f'        how="{settings.join_input.how}"')
         self._add_code("    )")
-        if after_join_drop_cols:
-            self._add_code(f".drop([{', '.join(self._py_str(c) for c in after_join_drop_cols)}])")
-        if has_post:
-            self._add_code(")")
 
     def _handle_standard_join(
         self, settings: input_schema.NodeJoin, var_name: str, left_df: str, right_df: str

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
@@ -42,9 +42,9 @@ from flowfile_core.flowfile.flow_data_engine.flow_file_column.utils import (
 from flowfile_core.flowfile.flow_data_engine.fuzzy_matching.prepare_for_fuzzy_match import prepare_for_fuzzy_match
 from flowfile_core.flowfile.flow_data_engine.join import (
     get_col_name_to_delete,
+    get_join_map_problems,
     get_undo_rename_mapping_join,
     rename_df_table_for_join,
-    verify_join_map_integrity,
     verify_join_select_integrity,
 )
 from flowfile_core.flowfile.flow_data_engine.polars_code_parser import polars_code_parser
@@ -2027,8 +2027,21 @@ class FlowDataEngine:
             if jk.right_col not in {c.old_name for c in join_manager.right_select.renames}:
                 join_manager.right_select.append(transform_schemas.SelectInput(jk.right_col, keep=False))
         verify_join_select_integrity(join_manager.input, left_columns=self.columns, right_columns=other.columns)
-        if not verify_join_map_integrity(join_manager.input, left_columns=self.schema, right_columns=other.schema):
-            raise Exception("Join is not valid by the data fields")
+        join_map_problems = get_join_map_problems(
+            join_manager.input, left_columns=self.schema, right_columns=other.schema
+        )
+        if join_map_problems:
+            raise Exception("Join is not valid: " + "; ".join(join_map_problems))
+
+        if join_manager.how in ("semi", "anti"):
+            # Semi/anti joins push the full left input downstream unchanged (all columns,
+            # original order, no rename or drop); the right frame only supplies the join
+            # keys for matching. Stale entries in left_select are therefore irrelevant here.
+            left_on = [jm.left_col for jm in join_manager.join_mapping]
+            right_on = [jm.right_col for jm in join_manager.join_mapping]
+            right = other.data_frame.select(list(dict.fromkeys(right_on)))
+            joined_df = self.data_frame.join(other=right, left_on=left_on, right_on=right_on, how=join_manager.how)
+            return FlowDataEngine(joined_df, calculate_schema_stats=False, number_of_records=0, streamable=False)
 
         if auto_generate_selection:
             join_manager.auto_rename()

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
@@ -123,22 +123,6 @@ def _handle_duplication_join_keys(
     return left_df, right_df, reverse_actions
 
 
-def ensure_right_unselect_for_semi_and_anti_joins(join_input: transform_schemas.JoinInput) -> None:
-    """Modifies JoinInput for semi/anti joins to not keep right-side columns.
-
-    For 'semi' and 'anti' joins, Polars only returns columns from the left
-    DataFrame. This function enforces that behavior by modifying the `join_input`
-    in-place, setting the `keep` flag to `False` for all columns in the
-    right-side selection.
-
-    Args:
-        join_input: The JoinInput settings object to modify.
-    """
-    if join_input.how in ("semi", "anti"):
-        for jk in join_input.right_select.renames:
-            jk.keep = False
-
-
 def get_select_columns(full_select_input: list[transform_schemas.SelectInput]) -> list[str]:
     """Extracts a list of column names to be selected from a SelectInput list.
 
@@ -2020,7 +2004,6 @@ class FlowDataEngine:
         join_manager = transform_schemas.JoinInputManager(join_input)
         _ensure_all_columns_have_select(left_cols=self.columns, right_cols=other.columns, manager=join_manager)
         join_manager.set_join_keys()
-        ensure_right_unselect_for_semi_and_anti_joins(join_manager.input)
         for jk in join_manager.join_mapping:
             if jk.left_col not in {c.old_name for c in join_manager.left_select.renames}:
                 join_manager.left_select.append(transform_schemas.SelectInput(jk.left_col, keep=False))

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/fuzzy_matching/prepare_for_fuzzy_match.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/fuzzy_matching/prepare_for_fuzzy_match.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 import polars as pl
 
-from flowfile_core.flowfile.flow_data_engine.join import verify_join_map_integrity, verify_join_select_integrity
+from flowfile_core.flowfile.flow_data_engine.join import get_join_map_problems, verify_join_select_integrity
 from flowfile_core.schemas.transform_schema import FuzzyMatchInputManager, JoinInputs, SelectInput
 
 if TYPE_CHECKING:
@@ -68,10 +68,11 @@ def prepare_for_fuzzy_match(
     verify_join_select_integrity(
         fuzzy_match_input_manager.fuzzy_input, left_columns=left.columns, right_columns=right.columns
     )
-    if not verify_join_map_integrity(
+    join_map_problems = get_join_map_problems(
         fuzzy_match_input_manager.fuzzy_input, left_columns=left.schema, right_columns=right.schema
-    ):
-        raise Exception("Join is not valid by the data fields")
+    )
+    if join_map_problems:
+        raise Exception("Join is not valid: " + "; ".join(join_map_problems))
 
     fuzzy_match_input_manager.auto_rename()
 

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/join/__init__.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/join/__init__.py
@@ -8,6 +8,9 @@ from flowfile_core.flowfile.flow_data_engine.join.utils import (
     rename_df_table_for_join as rename_df_table_for_join,
 )
 from flowfile_core.flowfile.flow_data_engine.join.verify_integrity import (
+    get_join_map_problems as get_join_map_problems,
+)
+from flowfile_core.flowfile.flow_data_engine.join.verify_integrity import (
     verify_join_map_integrity as verify_join_map_integrity,
 )
 from flowfile_core.flowfile.flow_data_engine.join.verify_integrity import (

--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/join/verify_integrity.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/join/verify_integrity.py
@@ -30,6 +30,45 @@ def verify_join_select_integrity(
             c.is_available = True
 
 
+def get_join_map_problems(
+    join_input: transform_schema.JoinInput | transform_schema.FuzzyMatchInput | transform_schema.JoinInputManager,
+    left_columns: list[FlowfileColumn],
+    right_columns: list[FlowfileColumn],
+) -> list[str]:
+    """Collect human-readable reasons a join mapping is invalid.
+
+    A join key referencing a column that no longer exists upstream, or a pair of
+    keys with incompatible data types, each produces a message naming the column.
+
+    Args:
+        join_input: Join configuration with mappings between columns
+        left_columns: Schema columns from left table
+        right_columns: Schema columns from right table
+    Returns:
+        list[str]: One message per problem; empty when the mapping is valid.
+    """
+    problems: list[str] = []
+    left_column_dict = {lc.name: lc for lc in left_columns}
+    right_column_dict = {rc.name: rc for rc in right_columns}
+    for join_mapping in join_input.join_mapping:
+        left_column_info: FlowfileColumn | None = left_column_dict.get(join_mapping.left_col)
+        right_column_info: FlowfileColumn | None = right_column_dict.get(join_mapping.right_col)
+        if left_column_info is None:
+            problems.append(f"left join key '{join_mapping.left_col}' no longer exists in the left input")
+        if right_column_info is None:
+            problems.append(f"right join key '{join_mapping.right_col}' no longer exists in the right input")
+        if (
+            left_column_info is not None
+            and right_column_info is not None
+            and left_column_info.generic_datatype() != right_column_info.generic_datatype()
+        ):
+            problems.append(
+                f"join keys '{join_mapping.left_col}' ({left_column_info.generic_datatype()}) and "
+                f"'{join_mapping.right_col}' ({right_column_info.generic_datatype()}) have incompatible types"
+            )
+    return problems
+
+
 def verify_join_map_integrity(
     join_input: transform_schema.JoinInput | transform_schema.FuzzyMatchInput | transform_schema.JoinInputManager,
     left_columns: list[FlowfileColumn],
@@ -45,14 +84,4 @@ def verify_join_map_integrity(
     Returns:
         bool: True if join mapping is valid, False otherwise
     """
-    join_mappings = join_input.join_mapping
-    left_column_dict = {lc.name: lc for lc in left_columns}
-    right_column_dict = {rc.name: rc for rc in right_columns}
-    for join_mapping in join_mappings:
-        left_column_info: FlowfileColumn | None = left_column_dict.get(join_mapping.left_col)
-        right_column_info: FlowfileColumn | None = right_column_dict.get(join_mapping.right_col)
-        if not left_column_info or not right_column_info:
-            return False
-        if left_column_info.generic_datatype() != right_column_info.generic_datatype():
-            return False
-    return True
+    return len(get_join_map_problems(join_input, left_columns, right_columns)) == 0

--- a/flowfile_core/flowfile_core/flowfile/schema_callbacks.py
+++ b/flowfile_core/flowfile_core/flowfile/schema_callbacks.py
@@ -165,16 +165,21 @@ def calculate_join_schema(
     - if `auto_generate_selection` is True, overlapping names are renamed with
       a `_right` suffix via `auto_rename`.
     """
+    if j_input.input.how in ("semi", "anti"):
+        # Semi/anti joins pass the full left input through unchanged and drop the
+        # right side (mirrors FlowDataEngine.join), so the output schema is exactly
+        # the left schema.
+        return [
+            FlowfileColumn.from_input(col.column_name, col.data_type, example_values=col.example_values)
+            for col in left_schema
+        ]
+
     _ensure_all_columns_have_select(
         left_cols=[col.column_name for col in left_schema],
         right_cols=[col.column_name for col in right_schema],
         manager=j_input,
     )
     j_input.set_join_keys()
-
-    if j_input.input.how in ("semi", "anti"):
-        for jk in j_input.input.right_select.renames:
-            jk.keep = False
 
     left_old_names = {c.old_name for c in j_input.input.left_select.renames}
     right_old_names = {c.old_name for c in j_input.input.right_select.renames}

--- a/flowfile_core/flowfile_core/schemas/transform_schema.py
+++ b/flowfile_core/flowfile_core/schemas/transform_schema.py
@@ -1218,7 +1218,11 @@ class SelectInputsManager:
 
     def get_select_cols(self, include_join_key: bool = True) -> list[str]:
         """Gets a list of original column names to select from the source DataFrame."""
-        return [v.old_name for v in self.select_inputs.renames if v.keep or (v.join_key and include_join_key)]
+        return [
+            v.old_name
+            for v in self.select_inputs.renames
+            if v.is_available and (v.keep or (v.join_key and include_join_key))
+        ]
 
     def has_drop_cols(self) -> bool:
         """Checks if any column is marked to be dropped from the selection."""

--- a/flowfile_core/tests/flowfile/flowfile_table/test_flow_data_engine.py
+++ b/flowfile_core/tests/flowfile/flowfile_table/test_flow_data_engine.py
@@ -382,7 +382,9 @@ def test_join_anti():
     result_df.assert_equal(expected_df)
 
 
-def test_join_anti_not_selecting_join_key():
+def test_join_anti_passthrough_ignores_left_select():
+    # Semi/anti joins push the full left input through unchanged; left_select
+    # keep/rename flags are ignored, so 'name' (marked keep=False) is still returned.
     join_input = transform_schema.JoinInput(
         join_mapping=[transform_schema.JoinMap('name')],
         left_select=transform_schema.JoinInputs(renames=[transform_schema.SelectInput(old_name='name', keep=False), transform_schema.SelectInput(old_name='other')]),
@@ -395,8 +397,8 @@ def test_join_anti_not_selecting_join_key():
     right_df = FlowDataEngine([{"name": "edward", "other": 1}])
     result_df = left_df.join(join_input=join_input, other=right_df, verify_integrity=False,
                              auto_generate_selection=True)
-    expected_df = FlowDataEngine([{"other": 1},
-                                  {"other": 1}])
+    expected_df = FlowDataEngine([{"name": "eduward", "other": 1},
+                                  {"name": "courtney", "other": 1}])
     result_df.assert_equal(expected_df)
 
 

--- a/flowfile_core/tests/flowfile/test_code_generator.py
+++ b/flowfile_core/tests/flowfile/test_code_generator.py
@@ -6419,8 +6419,9 @@ def test_catalog_sql_reader_flowframe_emits_valid_call():
 
 @pytest.mark.parametrize("export_func", [export_flow_to_polars, export_flow_to_flowframe], ids=["polars", "flowframe"])
 @pytest.mark.parametrize("how", ["semi", "anti"])
-def test_semi_anti_join_applies_left_select(join_input_large_dataset, how, export_func):
-    """Semi/anti joins must honor the left-side rename + drop, matching the runtime."""
+def test_semi_anti_join_passes_left_through_unchanged(join_input_large_dataset, how, export_func):
+    """Semi/anti joins pass all left columns through unchanged (left rename/drop ignored), and
+    the generated code matches the runtime."""
     flow = create_basic_flow()
     left_data, right_data = join_input_large_dataset
     flow.add_manual_input(left_data)
@@ -6452,6 +6453,10 @@ def test_semi_anti_join_applies_left_select(join_input_large_dataset, how, expor
 
     code = export_func(flow)
     verify_if_execute(code)
+    # Left passes through unchanged: the left_select rename (Name -> left_name) and drop
+    # (Address keep=False) are ignored for semi/anti joins.
+    runtime_cols = set(flow.get_node(3).get_resulting_data().columns)
+    assert runtime_cols == {"ID", "Name", "Address", "Zipcode"}
     result = normalize_result(get_result_from_generated_code(code))
     expected = normalize_result(flow.get_node(3).get_resulting_data().data_frame)
     assert_frame_equal(result, expected, check_column_order=False, check_row_order=False)

--- a/flowfile_core/tests/flowfile/test_code_generator_edge_cases.py
+++ b/flowfile_core/tests/flowfile/test_code_generator_edge_cases.py
@@ -1195,11 +1195,11 @@ class TestJoinDoesNotClobberSharedUpstream:
         verify_code_executes(code)
 
 
-class TestSemiAntiJoinDropsHiddenKeys:
-    """Semi/anti joins must drop left join-key columns marked keep=False, mirroring the runtime."""
+class TestSemiAntiJoinPassesLeftThrough:
+    """Semi/anti joins pass all left columns through unchanged, ignoring left_select keep/rename."""
 
     @pytest.mark.parametrize("how", ["semi", "anti"])
-    def test_left_join_key_keep_false_is_dropped(self, how):
+    def test_left_columns_pass_through_unchanged(self, how):
         flow = create_basic_flow()
         flow.add_manual_input(input_schema.NodeManualInput(
             flow_id=1, node_id=1, raw_data_format=input_schema.RawData(
@@ -1232,7 +1232,7 @@ class TestSemiAntiJoinDropsHiddenKeys:
         verify_code_executes(code)
         result = get_result_from_generated_code(code)
         cols = result.collect().columns if hasattr(result, "collect") else result.columns
-        assert "id" not in cols  # the keep=False join key is dropped post-join
+        assert "id" in cols  # left passes through unchanged; keep=False on a join key is ignored
         assert "name" in cols
         assert_flow_result_matches_generated(flow, output_node_id=3, code=code)
 

--- a/flowfile_core/tests/flowfile/test_flowfile.py
+++ b/flowfile_core/tests/flowfile/test_flowfile.py
@@ -1226,6 +1226,141 @@ def test_join_schema_auto_pass_through_after_upstream_rename(execution_location)
     )
 
 
+def _build_join_flow(graph, left_data, right_data, join_input: transform_schema.JoinInput):
+    """manual_input(left) -> select(identity) -> join <- manual_input(right)."""
+    add_manual_input(graph, data=left_data, node_id=1)
+    add_manual_input(graph, data=right_data, node_id=2)
+
+    identity = [transform_schema.SelectInput(old_name=c, new_name=c, keep=True) for c in left_data[0]]
+    add_node_promise_on_type(graph, 'select', 3)
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 3))
+    graph.add_select(input_schema.NodeSelect(flow_id=1, node_id=3, select_input=identity, keep_missing=False))
+
+    add_node_promise_on_type(graph, 'join', 4)
+    left_connection = input_schema.NodeConnection.create_from_simple_input(3, 4)
+    right_connection = input_schema.NodeConnection.create_from_simple_input(2, 4)
+    right_connection.input_connection.connection_class = 'input-1'
+    add_connection(graph, left_connection)
+    add_connection(graph, right_connection)
+
+    graph.add_join(input_schema.NodeJoin(
+        flow_id=1, node_id=4, join_input=join_input, auto_generate_selection=True, depending_on_ids=[3, 2],
+    ))
+
+
+def _reselect(graph, select_input):
+    """Re-configure the upstream select node (node 3) to change the join's incoming schema."""
+    graph.reset()
+    graph.add_select(input_schema.NodeSelect(
+        flow_id=1, node_id=3, select_input=select_input, keep_missing=False,
+    ))
+
+
+def test_join_drops_removed_non_key_column(execution_location):
+    """A kept non-join-key column removed upstream is dropped gracefully at run time
+    (no ColumnNotFoundError), matching the Select node's behaviour."""
+    graph = create_graph(execution_location=execution_location)
+    _build_join_flow(
+        graph,
+        left_data=[{'id': 1, 'name': 'alice'}, {'id': 2, 'name': 'bob'}],
+        right_data=[{'id': 1, 'city': 'NY'}, {'id': 2, 'city': 'LA'}],
+        join_input=transform_schema.JoinInput(
+            join_mapping=[transform_schema.JoinMap(left_col='id', right_col='id')],
+            left_select=[
+                transform_schema.SelectInput(old_name='id', new_name='id', keep=True, join_key=True),
+                transform_schema.SelectInput(old_name='name', new_name='name', keep=True),
+            ],
+            right_select=[
+                transform_schema.SelectInput(old_name='id', new_name='id', keep=False, join_key=True),
+                transform_schema.SelectInput(old_name='city', new_name='city', keep=True),
+            ],
+            how='inner',
+        ),
+    )
+
+    handle_run_info(graph.run_graph())
+    assert set(graph.get_node(4).get_resulting_data().columns) == {'id', 'name', 'city'}
+
+    # Drop `name` upstream; the join still references it in left_select but it no longer exists.
+    _reselect(graph, [transform_schema.SelectInput(old_name='id', new_name='id', keep=True)])
+    handle_run_info(graph.run_graph())  # must NOT raise (previously a ColumnNotFoundError)
+    assert set(graph.get_node(4).get_resulting_data().columns) == {'id', 'city'}
+
+
+def test_semi_join_passes_left_through_ignoring_left_select(execution_location):
+    """Semi joins push the full left input downstream unchanged: left_select renames/drops are
+    ignored, and a column removed upstream no longer errors."""
+    graph = create_graph(execution_location=execution_location)
+    _build_join_flow(
+        graph,
+        left_data=[{'id': 1, 'name': 'alice', 'extra': 9}, {'id': 2, 'name': 'bob', 'extra': 8}],
+        right_data=[{'id': 1}],
+        join_input=transform_schema.JoinInput(
+            join_mapping=[transform_schema.JoinMap(left_col='id', right_col='id')],
+            # A rename and a drop that must both be IGNORED for semi joins.
+            left_select=[
+                transform_schema.SelectInput(old_name='id', new_name='id', keep=True, join_key=True),
+                transform_schema.SelectInput(old_name='name', new_name='renamed_name', keep=True),
+                transform_schema.SelectInput(old_name='extra', new_name='extra', keep=False),
+            ],
+            right_select=[
+                transform_schema.SelectInput(old_name='id', new_name='id', keep=False, join_key=True),
+            ],
+            how='semi',
+        ),
+    )
+
+    join_node = graph.get_node(4)
+    predicted = [c.name for c in join_node.get_predicted_schema(force=True)]
+    assert set(predicted) == {'id', 'name', 'extra'}  # unchanged left names — rename/drop ignored
+
+    handle_run_info(graph.run_graph())
+    assert set(join_node.get_resulting_data().columns) == {'id', 'name', 'extra'}
+
+    # Remove `extra` upstream: semi still runs, output = the current left columns, unchanged.
+    _reselect(graph, [
+        transform_schema.SelectInput(old_name='id', new_name='id', keep=True),
+        transform_schema.SelectInput(old_name='name', new_name='name', keep=True),
+    ])
+    handle_run_info(graph.run_graph())
+    assert set(graph.get_node(4).get_resulting_data().columns) == {'id', 'name'}
+
+
+def test_join_missing_key_raises_named_error(execution_location):
+    """Removing a join-key column upstream fails the run with an error that names the column."""
+    graph = create_graph(execution_location=execution_location)
+    _build_join_flow(
+        graph,
+        left_data=[{'id': 1, 'name': 'alice'}, {'id': 2, 'name': 'bob'}],
+        right_data=[{'id': 1, 'city': 'NY'}],
+        join_input=transform_schema.JoinInput(
+            join_mapping=[transform_schema.JoinMap(left_col='id', right_col='id')],
+            left_select=[
+                transform_schema.SelectInput(old_name='id', new_name='id', keep=True, join_key=True),
+                transform_schema.SelectInput(old_name='name', new_name='name', keep=True),
+            ],
+            right_select=[
+                transform_schema.SelectInput(old_name='id', new_name='id', keep=False, join_key=True),
+                transform_schema.SelectInput(old_name='city', new_name='city', keep=True),
+            ],
+            how='inner',
+        ),
+    )
+
+    # Rename the left join key away so `id` no longer exists on the left input.
+    _reselect(graph, [
+        transform_schema.SelectInput(old_name='id', new_name='id2', keep=True),
+        transform_schema.SelectInput(old_name='name', new_name='name', keep=True),
+    ])
+
+    run_info = graph.run_graph()
+    assert not run_info.success
+    join_steps = [s for s in run_info.node_step_result if s.node_id == 4 and not s.success]
+    assert join_steps, 'Expected the join node to fail'
+    join_error = join_steps[0].error or ''
+    assert 'id' in join_error and 'not valid' in join_error.lower(), join_error
+
+
 def test_add_join(execution_location):
     graph = create_graph(execution_location=execution_location)
     # graph.flow_settings.execution_mode = 'Performance'

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/join/Join.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/join/Join.vue
@@ -19,6 +19,15 @@
           />
         </div>
         <div class="join-mapping-section">
+          <div v-if="invalidJoinKeys.length" class="join-warning-banner">
+            <unavailable-field
+              tooltip-text="Join keys reference columns that no longer exist upstream"
+            />
+            <span>
+              These join keys no longer exist upstream: {{ invalidJoinKeys.join(", ") }}. Re-map or
+              remove them.
+            </span>
+          </div>
           <div class="suggest-keys-row">
             <button class="suggest-keys-button" :disabled="aiSuggesting" @click="suggestJoinKeys">
               <span v-if="aiSuggesting">Asking AI…</span>
@@ -56,6 +65,15 @@
                     @update:value="(value: string) => handleChange(value, index, 'right')"
                   />
                 </div>
+                <unavailable-field
+                  v-if="
+                    !(
+                      containsVal(result?.main_input?.columns ?? [], selector.left_col) &&
+                      containsVal(result?.right_input?.columns ?? [], selector.right_col)
+                    )
+                  "
+                  tooltip-text="Join key is no longer valid — the column was removed upstream"
+                />
                 <div class="action-buttons">
                   <button class="action-button remove-button" @click="removeJoinCondition(index)">
                     -
@@ -97,6 +115,10 @@
           (updatedInputs: any) => updateSelectInputsHandler(updatedInputs, false)
         "
       />
+      <div v-if="!showColumnSelection" class="semi-anti-note">
+        Semi/anti joins pass all left-side columns through unchanged. Column selection and renaming
+        are not available for these join types.
+      </div>
     </generic-node-settings>
   </div>
   <code-loader v-else />
@@ -113,6 +135,7 @@ import { SelectInput } from "../../../baseNode/nodeInput";
 import { NodeJoin } from "./joinInterfaces";
 import DropDown from "../../../baseNode/page_objects/dropDown.vue";
 import selectDynamic from "../../../baseNode/selectComponents/selectDynamic.vue";
+import unavailableField from "../../../baseNode/selectComponents/UnavailableFields.vue";
 import GenericNodeSettings from "../../../baseNode/genericNodeSettings.vue";
 
 type JoinType = "inner" | "left" | "right" | "full" | "semi" | "anti" | "cross";
@@ -120,6 +143,8 @@ type JoinType = "inner" | "left" | "right" | "full" | "semi" | "anti" | "cross";
 const joinTypes: JoinType[] = ["inner", "left", "right", "full", "semi", "anti", "cross"];
 
 const JOIN_TYPES_WITHOUT_COLUMN_SELECTION: JoinType[] = ["anti", "semi"];
+
+const containsVal = (arr: string[], val: string) => arr.includes(val);
 
 const handleJoinTypeError = (error: string) => {
   console.error("Join type error:", error);
@@ -135,6 +160,13 @@ const aiSuggestNotice = ref<string>("");
 
 const { saveSettings, pushNodeData, handleGenericSettingsUpdate } = useNodeSettings({
   nodeRef: nodeJoin,
+  onAfterSave: () => {
+    if (!nodeJoin.value) return;
+    nodeStore.setNodeValidation(nodeJoin.value.node_id, {
+      isValid: !hasInvalidFields.value,
+      error: hasInvalidFields.value ? "Join keys reference columns that no longer exist" : "",
+    });
+  },
 });
 
 const updateSelectInputsHandler = (updatedInputs: SelectInput[], isLeft: boolean) => {
@@ -166,6 +198,21 @@ const showColumnSelection = computed(() => {
   const joinType = nodeJoin.value?.join_input.how;
   return joinType && !JOIN_TYPES_WITHOUT_COLUMN_SELECTION.includes(joinType);
 });
+
+const invalidJoinKeys = computed<string[]>(() => {
+  if (!nodeJoin.value?.join_input || !result.value) return [];
+  const leftCols = result.value.main_input?.columns ?? [];
+  const rightCols = result.value.right_input?.columns ?? [];
+  const msgs: string[] = [];
+  for (const m of nodeJoin.value.join_input.join_mapping) {
+    if (m.left_col && !containsVal(leftCols, m.left_col)) msgs.push(`left key "${m.left_col}"`);
+    if (m.right_col && !containsVal(rightCols, m.right_col))
+      msgs.push(`right key "${m.right_col}"`);
+  }
+  return msgs;
+});
+
+const hasInvalidFields = computed(() => invalidJoinKeys.value.length > 0);
 
 const removeJoinCondition = (index: number) => {
   if (nodeJoin.value && index >= 0) {
@@ -299,6 +346,28 @@ defineExpose({
 .suggest-keys-notice {
   font-size: 11px;
   color: var(--color-text-secondary);
+}
+
+/* Invalid-key warning banner */
+.join-warning-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 5px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-danger);
+  border-radius: 6px;
+  background-color: var(--color-danger-subtle, rgba(220, 38, 38, 0.08));
+  color: var(--color-danger);
+  font-size: 12px;
+}
+
+/* Semi/anti passthrough note */
+.semi-anti-note {
+  margin: 12px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  font-style: italic;
 }
 
 /* Join Mapping Section */

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/join/Join.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/join/Join.vue
@@ -67,10 +67,10 @@
                 </div>
                 <unavailable-field
                   v-if="
-                    !(
-                      containsVal(result?.main_input?.columns ?? [], selector.left_col) &&
-                      containsVal(result?.right_input?.columns ?? [], selector.right_col)
-                    )
+                    (selector.left_col &&
+                      !containsVal(result?.main_input?.columns ?? [], selector.left_col)) ||
+                    (selector.right_col &&
+                      !containsVal(result?.right_input?.columns ?? [], selector.right_col))
                   "
                   tooltip-text="Join key is no longer valid — the column was removed upstream"
                 />


### PR DESCRIPTION
## Summary
Improves join node robustness by gracefully handling upstream column removals and providing clear error messages when join keys become invalid. Semi/anti joins now correctly pass the full left input through unchanged, ignoring left-side column selection/rename operations.

## Key Changes

### Backend (flowfile_core)
- **Join integrity verification** (`verify_integrity.py`): Extracted `get_join_map_problems()` to collect human-readable error messages for missing or incompatible join keys, replacing silent boolean validation
- **Semi/anti join semantics** (`flow_data_engine.py`, `schema_callbacks.py`): Semi/anti joins now correctly pass the full left input downstream unchanged (all columns, original order, no rename/drop); left_select operations are ignored to match the documented behavior
- **Error messaging**: Join failures now report specific column names and types (e.g., "left join key 'id' no longer exists in the left input") instead of generic "not valid" messages
- **Code generation** (`join_handlers.py`): Simplified semi/anti join code generation to match runtime behavior—no longer applies left_select transforms
- **Schema handling** (`transform_schema.py`): `get_select_cols()` now respects `is_available` flag to skip stale column references

### Frontend (flowfile_frontend)
- **Join UI warnings** (`Join.vue`): 
  - Added warning banner showing which join keys no longer exist upstream
  - Added per-mapping indicator when a join key column is missing
  - Added explanatory note that semi/anti joins ignore column selection/renaming
- **Node validation**: Join nodes now report validation errors when keys reference missing columns, preventing silent failures

### Tests
- Added three new integration tests:
  - `test_join_drops_removed_non_key_column`: Non-key columns removed upstream are dropped gracefully
  - `test_semi_join_passes_left_through_ignoring_left_select`: Semi joins pass all left columns unchanged, ignoring left_select
  - `test_join_missing_key_raises_named_error`: Missing join keys fail with a clear error naming the column
- Updated existing semi/anti join tests to reflect the new "pass-through unchanged" semantics

## Implementation Details
- Join key validation now happens at runtime with detailed error collection rather than silent boolean checks
- Semi/anti joins bypass the entire left_select processing pipeline (no rename, no drop, no keep filtering)
- The right DataFrame is reduced to only the join key columns before the join operation
- Frontend validation mirrors backend behavior, showing users which keys are invalid before execution

https://claude.ai/code/session_01Jcjo4HEamgJ75hUD6uFQAv