### PR TITLE
ensure flowfile_ctx is parsed correctly in custom node

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/code_generator/code_generator.py
+++ b/flowfile_core/flowfile_core/flowfile/code_generator/code_generator.py
@@ -133,6 +133,39 @@ NODE_TYPE_VAR_LABEL: dict[str, str] = {
 _RESERVED_NAMES: frozenset[str] = frozenset(keyword.kwlist) | frozenset(dir(builtins))
 
 
+_FLAT_CTX_SHIM = '''# Minimal flowfile_ctx shim for standalone execution (logging/display only).
+# Export the flow as a project (code_to_project) for the full flowfile_ctx API.
+class _FlowfileCtx:
+    def log(self, message, level="INFO"):
+        print(f"[{level}] {message}")
+
+    def log_info(self, message):
+        self.log(message, "INFO")
+
+    def log_warning(self, message):
+        self.log(message, "WARNING")
+
+    def log_error(self, message):
+        self.log(message, "ERROR")
+
+    def display(self, obj, title=""):
+        if title:
+            print(f"=== {title} ===")
+        print(obj)
+
+    def explore(self, obj, title="", max_rows=10_000):
+        self.display(obj, title)
+
+    def __getattr__(self, name):
+        raise NotImplementedError(
+            f"flowfile_ctx.{name}() is not available in a single-file export; "
+            "export the flow as a project (code_to_project) for the full flowfile_ctx API."
+        )
+
+
+flowfile_ctx = _FlowfileCtx()'''
+
+
 class FlowGraphCodeConverter(
     JoinHandlersMixin,
     TransformHandlersMixin,
@@ -164,6 +197,9 @@ class FlowGraphCodeConverter(
         self.last_node_var: str | None = None
         self.unsupported_nodes: list[tuple[int, str, str]] = []
         self.custom_node_classes: dict[str, str] = {}
+        # True once a custom node's source references flowfile_ctx: the flat export
+        # then emits an inline shim; the project export ships flowfile_ctx.py.
+        self._needs_flowfile_ctx = False
         # (node, effective_var, start, end) per emitting node; (start, end) slices code_lines.
         self._node_spans: list[tuple[FlowNode, str, int, int]] = []
         # node_id -> upstream node_id for nodes that emit nothing (passthroughs).
@@ -884,6 +920,14 @@ class FlowGraphCodeConverter(
         lines.append("")
         lines.append("")
 
+        # Only the flat export inlines custom-node classes; the project export
+        # writes them to modules and ships flowfile_ctx.py instead, so this
+        # inline shim never lands in a project's pipeline.py.
+        if self.custom_node_classes and self._needs_flowfile_ctx:
+            lines.extend(_FLAT_CTX_SHIM.split("\n"))
+            lines.append("")
+            lines.append("")
+
         if self.custom_node_classes:
             lines.append("# Custom Node Class Definitions")
             lines.append("# These classes are user-defined nodes that were included in the flow")
@@ -1123,9 +1167,10 @@ class FlowGraphToFlowFrameConverter(FlowGraphCodeConverter):
     def _handle_manual_input(
         self, settings: input_schema.NodeManualInput, var_name: str, input_vars: dict[str, str]
     ) -> None:
-        self.imports.add("from flowfile_core.schemas.input_schema import RawData")
+        # ff.from_raw_data coerces the columnar dict into RawData via pydantic, so
+        # the exported script needs no flowfile_core import (public API only).
         raw_data = settings.raw_data_format
-        self._add_code(f"{var_name} = ff.from_raw_data(RawData(**{raw_data.model_dump()}))")
+        self._add_code(f"{var_name} = ff.from_raw_data({raw_data.model_dump()})")
         self._add_code("")
 
     def _handle_cloud_storage_reader(

--- a/flowfile_core/flowfile_core/flowfile/code_generator/custom_node_handlers.py
+++ b/flowfile_core/flowfile_core/flowfile/code_generator/custom_node_handlers.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import re
 import textwrap
 
 from flowfile_core.flowfile.code_generator.base import ConverterMixinBase
@@ -68,9 +69,14 @@ class CustomNodeHandlersMixin(ConverterMixinBase):
         """Carry a custom node's own import into the generated script.
 
         The node-designer import (any spelling) is skipped here because it is
-        re-added in a canonical form by the caller.
+        re-added in a canonical form by the caller. A ``flowfile_ctx`` import is
+        also skipped: the flat script ships no sibling module, so the inline shim
+        (project export ships flowfile_ctx.py) binds the name instead.
         """
         if any(marker in statement for marker in _SDK_IMPORT_MARKERS):
+            return
+        if re.match(r"\s*(import\s+flowfile_ctx\b|from\s+flowfile_ctx\b)", statement):
+            self._needs_flowfile_ctx = True
             return
         self.imports.add(statement.strip())
 
@@ -157,6 +163,8 @@ class CustomNodeHandlersMixin(ConverterMixinBase):
             self.imports.add("from flowfile import node_designer as nd")
             if self._body_uses_bare_sdk_symbols(self.custom_node_classes[class_name]):
                 self.imports.add(f"from flowfile.node_designer import ({_CANONICAL_SDK_SYMBOLS})")
+            if re.search(r"\bflowfile_ctx\b", self.custom_node_classes[class_name]):
+                self._needs_flowfile_ctx = True
         # The inlined node body references pl. (and the Polars converter's return
         # normalization uses isinstance(..., pl.DataFrame)), so polars is needed
         # in both converters.

--- a/flowfile_core/flowfile_core/flowfile/code_generator/project_exporter.py
+++ b/flowfile_core/flowfile_core/flowfile/code_generator/project_exporter.py
@@ -158,7 +158,8 @@ def _insert_flowfile_ctx_import(source: str) -> str:
         if is_docstring or is_future:
             insert_line = stmt.end_lineno + 1
             continue
-        insert_line = stmt.lineno
+        decorators = getattr(stmt, "decorator_list", None)
+        insert_line = decorators[0].lineno if decorators else stmt.lineno
         break
     lines = source.split("\n")
     lines.insert(max(0, insert_line - 1), "import flowfile_ctx")

--- a/flowfile_core/flowfile_core/flowfile/code_generator/project_exporter.py
+++ b/flowfile_core/flowfile_core/flowfile/code_generator/project_exporter.py
@@ -12,6 +12,7 @@ single script, emits a runnable project tree:
 - ``custom_nodes/<module>.py`` — verbatim source per user-defined node
 """
 
+import ast
 import importlib.metadata
 import inspect
 import io
@@ -129,6 +130,54 @@ def _read_shim_source() -> str:
         from flowfile_core.flowfile.code_generator import project_shim
 
         return inspect.getsource(project_shim)
+
+
+def _insert_flowfile_ctx_import(source: str) -> str:
+    """Insert ``import flowfile_ctx`` into a verbatim custom-node module.
+
+    Placed after a leading module docstring and any ``from __future__`` imports
+    (which must stay first) and before the first other statement, so the node's
+    ``flowfile_ctx.*`` calls resolve against the shipped shim. No-op if the module
+    already imports flowfile_ctx.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return _insert_flowfile_ctx_import_fallback(source)
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Import) and any(alias.name == "flowfile_ctx" for alias in stmt.names):
+            return source
+        if isinstance(stmt, ast.ImportFrom) and stmt.module == "flowfile_ctx":
+            return source
+    insert_line = 1
+    for stmt in tree.body:
+        is_docstring = (
+            isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, str)
+        )
+        is_future = isinstance(stmt, ast.ImportFrom) and stmt.module == "__future__"
+        if is_docstring or is_future:
+            insert_line = stmt.end_lineno + 1
+            continue
+        insert_line = stmt.lineno
+        break
+    lines = source.split("\n")
+    lines.insert(max(0, insert_line - 1), "import flowfile_ctx")
+    return "\n".join(lines)
+
+
+def _insert_flowfile_ctx_import_fallback(source: str) -> str:
+    """Line-scan fallback for unparseable source: keep leading ``from __future__``
+    lines first, then insert the import."""
+    lines = source.split("\n")
+    idx = 0
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("from __future__"):
+            idx = i + 1
+        elif stripped and not stripped.startswith("#"):
+            break
+    lines.insert(idx, "import flowfile_ctx")
+    return "\n".join(lines)
 
 
 class FlowGraphToProjectConverter(FlowGraphToFlowFrameConverter):
@@ -558,6 +607,7 @@ class FlowGraphToProjectConverter(FlowGraphToFlowFrameConverter):
             self._subflow_ancestry.discard(path_key)
 
         self.has_notebooks = self.has_notebooks or child.has_notebooks
+        self._needs_flowfile_ctx = self._needs_flowfile_ctx or child._needs_flowfile_ctx
         module_stem = self._unique_subflow_module_name(resolved.name)
         self.module_files[f"subflows/{module_stem}.py"] = (
             module_code if module_code.endswith("\n") else module_code + "\n"
@@ -602,6 +652,11 @@ class FlowGraphToProjectConverter(FlowGraphToFlowFrameConverter):
                     )
                     return False
             module_name = self._unique_custom_module_name(class_name)
+            if re.search(r"\bflowfile_ctx\b", source):
+                # Node code uses the kernel-injected flowfile_ctx global; bind it to
+                # the shipped shim so the exported module runs standalone.
+                self._needs_flowfile_ctx = True
+                source = _insert_flowfile_ctx_import(source)
             self.module_files[f"custom_nodes/{module_name}.py"] = source if source.endswith("\n") else source + "\n"
             self._custom_node_modules[class_key] = module_name
         self.imports.add(f"from custom_nodes.{module_name} import {class_name}")
@@ -630,8 +685,9 @@ class FlowGraphToProjectConverter(FlowGraphToFlowFrameConverter):
         project_name = _sanitize_identifier(self.flow_graph.__name__, "flowfile_project")
 
         files: dict[str, str] = {"pipeline.py": pipeline_code if pipeline_code.endswith("\n") else pipeline_code + "\n"}
-        if self.has_notebooks:
+        if self.has_notebooks or self._needs_flowfile_ctx:
             files["flowfile_ctx.py"] = _read_shim_source()
+        if self.has_notebooks:
             files["notebooks/__init__.py"] = ""
         if any(path.startswith("custom_nodes/") for path in self.module_files):
             files["custom_nodes/__init__.py"] = ""
@@ -719,6 +775,11 @@ class FlowGraphToProjectConverter(FlowGraphToFlowFrameConverter):
             ]
         if any(path.startswith("custom_nodes/") for path in self.module_files):
             lines += ["- `custom_nodes/` — user-defined node classes, source preserved verbatim."]
+            if self._needs_flowfile_ctx and not self.has_notebooks:
+                lines += [
+                    "- `flowfile_ctx.py` — local stand-in for the kernel `flowfile_ctx` API so "
+                    "custom-node code (e.g. `flowfile_ctx.log_info(...)`) runs without a Flowfile server."
+                ]
         if any(path.startswith("subflows/") for path in self.module_files):
             lines += [
                 "- `subflows/` — referenced flows exported as callable modules: "
@@ -773,7 +834,7 @@ class SubflowModuleConverter(FlowGraphToProjectConverter):
         self._flow_output_names: dict[int, str] = {}
         self._input_args: dict[str, str] = {}
         used = {p.name for p in codegen_parameters(flow_graph.flow_settings.parameters)}
-        used |= {"ff", "pl", "RawData"}
+        used |= {"ff", "pl"}
         for node in sorted(flow_graph.nodes, key=lambda n: n.node_id):
             if node.node_type != "flow_input" or not isinstance(node.setting_input, input_schema.NodeFlowInput):
                 continue
@@ -809,8 +870,8 @@ class SubflowModuleConverter(FlowGraphToProjectConverter):
 
     def _sample_expression(self, settings: input_schema.NodeFlowInput) -> str:
         if settings.raw_data_format is not None and settings.raw_data_format.columns:
-            self.imports.add("from flowfile_core.schemas.input_schema import RawData")
-            return f"ff.from_raw_data(RawData(**{settings.raw_data_format.model_dump()}))"
+            # Public API only: from_raw_data coerces the dict into RawData via pydantic.
+            return f"ff.from_raw_data({settings.raw_data_format.model_dump()})"
         return "ff.LazyFrame()"
 
     def _handle_flow_output(

--- a/flowfile_core/tests/flowfile/test_code_generator_custom_nodes.py
+++ b/flowfile_core/tests/flowfile/test_code_generator_custom_nodes.py
@@ -8,6 +8,7 @@ import pytest
 
 from flowfile_core.configs.node_store import add_to_custom_node_store
 from flowfile_core.flowfile.code_generator.code_generator import (
+    FlowGraphToFlowFrameConverter,
     export_flow_to_flowframe,
     export_flow_to_polars,
 )
@@ -603,6 +604,114 @@ class MathNode(CustomNodeBase):
         sys.modules.pop("math_custom_node_mod", None)
 
     assert "import math" in code
+
+
+class TestManualInputPublicApiOnly:
+    """Bug 1: manual-input codegen uses only the public flowfile API (no flowfile_core)."""
+
+    def test_no_flowfile_core_import_and_explicit_types_preserved(self):
+        graph = create_graph()
+        graph.add_node_promise(
+            input_schema.NodePromise(flow_id=graph.flow_id, node_id=1, node_type="manual_input")
+        )
+        graph.add_manual_input(
+            input_schema.NodeManualInput(
+                flow_id=graph.flow_id,
+                node_id=1,
+                raw_data_format=input_schema.RawData(
+                    columns=[
+                        input_schema.MinimalFieldInfo(name="amount", data_type="Float64"),
+                        input_schema.MinimalFieldInfo(name="label", data_type="String"),
+                    ],
+                    data=[[1, 2, 3], ["a", "b", "c"]],
+                ),
+            )
+        )
+
+        code = export_flow_to_flowframe(graph)
+        assert "flowfile_core" not in code
+        assert "ff.from_raw_data({" in code
+        assert "RawData(" not in code
+
+        ns: dict = {}
+        exec(compile(code, "<gen>", "exec"), ns)
+        result = ns["run_etl_pipeline"]()
+        df = result.collect() if hasattr(result, "collect") else result
+        # Explicit Float64 preserved (ff.from_dict would re-infer Int64 for [1, 2, 3]).
+        assert df.schema["amount"] == pl.Float64
+        assert df["amount"].to_list() == [1.0, 2.0, 3.0]
+        assert df["label"].to_list() == ["a", "b", "c"]
+
+
+_CTX_NODE_SOURCE = '''
+import polars as pl
+
+from flowfile import node_designer as nd
+
+
+class CtxLogger(nd.CustomNodeBase):
+    node_name: str = "Ctx Logger"
+    node_category: str = "Transform"
+    number_of_inputs: int = 1
+    number_of_outputs: int = 1
+
+    def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+        flowfile_ctx.log_info("ctx node ran")
+        return inputs[0].with_columns(pl.lit(1).alias("k"))
+'''
+
+
+class TestFlowfileCtxInlineShim:
+    """Bug 2: the flat export binds flowfile_ctx via a self-contained inline shim
+    (a single-file script ships no sibling flowfile_ctx.py)."""
+
+    def test_flat_export_binds_flowfile_ctx_and_runs(self, tmp_path):
+        import contextlib
+        import io
+        import sys
+
+        mod = _write_node_module(tmp_path, "ctx_logger_flat_mod", _CTX_NODE_SOURCE)
+        try:
+            add_to_custom_node_store(mod.CtxLogger)
+            graph = create_graph()
+            add_manual_input(graph, [{"x": 1}], node_id=1)
+            add_custom_node_to_graph(graph, mod.CtxLogger, node_id=2, settings={})
+            add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2))
+            code = export_flow_to_flowframe(graph)
+        finally:
+            sys.modules.pop("ctx_logger_flat_mod", None)
+
+        assert "class _FlowfileCtx" in code
+        assert "flowfile_ctx = _FlowfileCtx()" in code
+        assert "import flowfile_ctx" not in code
+
+        buf = io.StringIO()
+        ns: dict = {}
+        with contextlib.redirect_stdout(buf):
+            exec(compile(code, "<gen>", "exec"), ns)
+            result = ns["run_etl_pipeline"]()
+            if hasattr(result, "collect"):
+                result.collect()
+        assert "ctx node ran" in buf.getvalue()
+
+    def test_flat_export_omits_shim_when_ctx_unused(self, AddColumnNode):
+        add_to_custom_node_store(AddColumnNode)
+        graph = create_graph()
+        add_manual_input(graph, [{"Column 1": "test"}], node_id=1)
+        settings = {"config": {"column_name": "new_col", "fixed_value": "hello"}}
+        add_custom_node_to_graph(graph, AddColumnNode, node_id=2, settings=settings)
+        add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2))
+
+        code = export_flow_to_flowframe(graph)
+        assert "_FlowfileCtx" not in code
+
+    def test_register_node_import_suppresses_flowfile_ctx(self):
+        """A node's own `import flowfile_ctx` is dropped (the inline shim binds it)."""
+        conv = FlowGraphToFlowFrameConverter(create_graph())
+        conv._register_node_import("import flowfile_ctx")
+        conv._register_node_import("from flowfile_ctx import log_info")
+        assert not any("flowfile_ctx" in imp for imp in conv.imports)
+        assert conv._needs_flowfile_ctx is True
 
 
 if __name__ == "__main__":

--- a/flowfile_core/tests/flowfile/test_project_exporter.py
+++ b/flowfile_core/tests/flowfile/test_project_exporter.py
@@ -19,6 +19,7 @@ from flowfile_core.configs.node_store import add_to_custom_node_store
 from flowfile_core.flowfile.code_generator import project_shim
 from flowfile_core.flowfile.code_generator.project_exporter import (
     FlowGraphToProjectConverter,
+    _insert_flowfile_ctx_import,
     export_flow_to_project,
     project_to_zip_bytes,
 )
@@ -1160,6 +1161,28 @@ def test_custom_node_flowfile_ctx_executes_end_to_end(tmp_path):
     )
     assert result.returncode == 0, result.stderr
     assert "ctx node ran" in result.stdout
+
+
+def test_insert_flowfile_ctx_import_handles_decorated_first_statement():
+    """A decorated first top-level class/def has lineno at the keyword, not the
+    decorator; the import must go ABOVE the decorator or the module is a SyntaxError."""
+    # Decorated class as the first statement.
+    out = _insert_flowfile_ctx_import(
+        "@nd.register\nclass N(nd.CustomNodeBase):\n    def process(self, m):\n        return m\n"
+    )
+    ast.parse(out)  # would raise if spliced between @nd.register and `class`
+    lines = out.splitlines()
+    assert lines.index("import flowfile_ctx") < next(i for i, line in enumerate(lines) if line.startswith("@"))
+
+    # Stacked decorators after a docstring + __future__ import: stay after __future__,
+    # still above the first decorator.
+    out2 = _insert_flowfile_ctx_import(
+        '"""doc"""\nfrom __future__ import annotations\n\n@deco_a\n@deco_b\nclass N:\n    pass\n'
+    )
+    ast.parse(out2)
+    l2 = out2.splitlines()
+    assert l2.index("from __future__ import annotations") < l2.index("import flowfile_ctx")
+    assert l2.index("import flowfile_ctx") < next(i for i, line in enumerate(l2) if line.startswith("@"))
 
 
 def test_subflow_custom_node_ships_flowfile_ctx_shim(tmp_path):

--- a/flowfile_core/tests/flowfile/test_project_exporter.py
+++ b/flowfile_core/tests/flowfile/test_project_exporter.py
@@ -28,6 +28,60 @@ from flowfile_core.schemas import input_schema, schemas, transform_schema
 from flowfile_core.schemas.output_model import ProjectExportManifest
 
 
+@pytest.fixture(autouse=True)
+def _restore_custom_node_registry():
+    """Snapshot/restore the global node registries so file-backed custom nodes
+    registered in a test never leak into sibling tests."""
+    from flowfile_core.configs import node_store as node_store_mod
+
+    saved_store = dict(node_store_mod.CUSTOM_NODE_STORE)
+    saved_dict = dict(node_store_mod.node_dict)
+    saved_list = list(node_store_mod.nodes_list)
+    try:
+        yield
+    finally:
+        node_store_mod.CUSTOM_NODE_STORE.clear()
+        node_store_mod.CUSTOM_NODE_STORE.update(saved_store)
+        node_store_mod.node_dict.clear()
+        node_store_mod.node_dict.update(saved_dict)
+        node_store_mod.nodes_list[:] = saved_list
+
+
+def _write_node_module(tmp_path: Path, stem: str, source: str):
+    """Write a custom-node module to a temp file and import it (file-backed so the
+    exporter can read the class source via ``inspect.getfile``)."""
+    import importlib
+    import sys
+
+    (tmp_path / f"{stem}.py").write_text(source)
+    sys.path.insert(0, str(tmp_path))
+    try:
+        return importlib.import_module(stem)
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
+# A custom node whose process() logs via the kernel-injected flowfile_ctx global.
+# The exported code must bind flowfile_ctx (ship the shim + insert the import) or
+# this raises NameError when run standalone.
+_CTX_NODE_SOURCE = '''
+import polars as pl
+
+from flowfile import node_designer as nd
+
+
+class CtxLogger(nd.CustomNodeBase):
+    node_name: str = "Ctx Logger"
+    node_category: str = "Transform"
+    number_of_inputs: int = 1
+    number_of_outputs: int = 1
+
+    def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+        flowfile_ctx.log_info("ctx node ran")
+        return inputs[0].with_columns(pl.lit(1).alias("k"))
+'''
+
+
 def create_flow_settings(flow_id: int = 1) -> schemas.FlowSettings:
     return schemas.FlowSettings(
         flow_id=flow_id,

--- a/flowfile_core/tests/flowfile/test_project_exporter.py
+++ b/flowfile_core/tests/flowfile/test_project_exporter.py
@@ -1073,3 +1073,112 @@ class TestRunFlowProjectExport:
         # head(1) + head(2) of the 3-row parent frame -> 3 rows with metadata columns
         assert "param_limit" in result.stdout
         assert "run_index" in result.stdout
+
+
+# ==================== flowfile_ctx binding in exported custom-node code ====================
+
+
+def _build_ctx_node_subflow(tmp_path: Path, node_cls) -> dict:
+    """flow_input 'customers' -> ctx custom node -> flow_output 'result'.
+
+    The custom node lives ONLY inside this subflow, so the parent project ships
+    flowfile_ctx.py only if _needs_flowfile_ctx propagates up from the child.
+    """
+    flow = create_basic_flow(flow_id=33, name="ctx_subflow")
+    flow.add_flow_input(
+        input_schema.NodeFlowInput(
+            flow_id=flow.flow_id,
+            node_id=1,
+            input_name="customers",
+            raw_data_format=input_schema.RawData.from_pylist([{"name": "a"}, {"name": "b"}]),
+        )
+    )
+    node_settings = input_schema.UserDefinedNode(flow_id=flow.flow_id, node_id=2, settings={}, is_user_defined=True)
+    flow.add_user_defined_node(
+        custom_node=node_cls.from_settings({}),
+        user_defined_node_settings=node_settings,
+    )
+    add_connection(flow, input_schema.NodeConnection.create_from_simple_input(1, 2))
+    flow.add_flow_output(
+        input_schema.NodeFlowOutput(flow_id=flow.flow_id, node_id=3, output_name="result", depending_on_id=2)
+    )
+    add_connection(flow, input_schema.NodeConnection.create_from_simple_input(2, 3))
+    path = tmp_path / "ctx_subflow.yaml"
+    flow.save_flow(str(path))
+    return {"path": path, "registration_id": _register_flow_file(path, "ctx_subflow")}
+
+
+def _ctx_custom_module(manifest: ProjectExportManifest) -> str:
+    """The shipped custom_nodes/<mod>.py content (exactly one in these tests)."""
+    path = next(
+        p
+        for p in file_paths(manifest)
+        if p.startswith("custom_nodes/") and p.endswith(".py") and not p.endswith("__init__.py")
+    )
+    return get_file(manifest, path)
+
+
+def test_flow_input_sample_expression_uses_public_api(tmp_path):
+    """Bug 1: the flow_input sample expression must not import flowfile_core."""
+    sub = _build_head_subflow(tmp_path)
+    flow = create_basic_flow(flow_id=51, name="sample_public_api_parent")
+    add_sample_input(flow, node_id=1)
+    flow.add_run_flow(_run_flow_settings(flow, sub["registration_id"]))
+    _keyed_connect(flow, 1, 9, "input-1")
+
+    manifest = export_flow_to_project(flow)
+    module = get_file(manifest, "subflows/head_subflow.py")
+    assert "flowfile_core" not in module
+    assert "ff.from_raw_data(" in module
+    assert "RawData(" not in module
+    ast.parse(module)
+
+
+def test_custom_node_flowfile_ctx_executes_end_to_end(tmp_path):
+    """Bug 2: an exported project with a flowfile_ctx-using custom node runs standalone."""
+    mod = _write_node_module(tmp_path, "ctx_e2e_node", _CTX_NODE_SOURCE)
+    try:
+        add_to_custom_node_store(mod.CtxLogger)
+        flow = create_basic_flow(name="ctx_e2e")
+        add_sample_input(flow, node_id=1)
+        node_settings = input_schema.UserDefinedNode(flow_id=1, node_id=2, settings={}, is_user_defined=True)
+        flow.add_user_defined_node(
+            custom_node=mod.CtxLogger.from_settings({}),
+            user_defined_node_settings=node_settings,
+        )
+        add_connection(flow, input_schema.NodeConnection.create_from_simple_input(1, 2))
+        manifest = export_flow_to_project(flow)
+    finally:
+        sys.modules.pop("ctx_e2e_node", None)
+
+    assert "flowfile_ctx.py" in file_paths(manifest)
+    assert "import flowfile_ctx" in _ctx_custom_module(manifest)
+
+    project_dir = write_project(manifest, tmp_path)
+    result = subprocess.run(
+        [sys.executable, "main.py"], cwd=project_dir, capture_output=True, text=True, timeout=300
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ctx node ran" in result.stdout
+
+
+def test_subflow_custom_node_ships_flowfile_ctx_shim(tmp_path):
+    """Bug 2 regression guard: _needs_flowfile_ctx must propagate up from a subflow so
+    a custom node living ONLY inside the subflow still ships flowfile_ctx.py."""
+    mod = _write_node_module(tmp_path, "ctx_subflow_node", _CTX_NODE_SOURCE)
+    try:
+        add_to_custom_node_store(mod.CtxLogger)
+        sub = _build_ctx_node_subflow(tmp_path, mod.CtxLogger)
+        flow = create_basic_flow(flow_id=52, name="ctx_subflow_parent")
+        add_sample_input(flow, node_id=1)
+        flow.add_run_flow(
+            _run_flow_settings(flow, sub["registration_id"], output_slots=["result"], parameter_specs=[])
+        )
+        _keyed_connect(flow, 1, 9, "input-1")
+        manifest = export_flow_to_project(flow)
+    finally:
+        sys.modules.pop("ctx_subflow_node", None)
+
+    assert "flowfile_ctx.py" in file_paths(manifest)
+    assert "import flowfile_ctx" in _ctx_custom_module(manifest)
+    ast.parse(get_file(manifest, "subflows/ctx_subflow.py"))


### PR DESCRIPTION
This pull request improves how custom nodes that use `flowfile_ctx` are handled in both single-file (flat) and multi-file (project) code exports, and ensures that only the public Flowfile API is used for manual input nodes. It introduces an inline shim for `flowfile_ctx` in flat exports, ensures the shim is included as a module in project exports when needed, and updates the handling of imports and code generation for clarity and correctness. Additionally, new and improved tests verify these behaviors.

**Custom Node Handling and `flowfile_ctx` Shim:**

* Added an inline `_FlowfileCtx` shim to flat (single-file) exports when a custom node references `flowfile_ctx`, so scripts run standalone without requiring a separate module. (`flowfile_core/flowfile_core/flowfile/code_generator/code_generator.py` [[1]](diffhunk://#diff-63ff66e1da59f117f03537cd0c27e97ff088ac8cebee6fe1f8b4778a4e553573R136-R168) [[2]](diffhunk://#diff-63ff66e1da59f117f03537cd0c27e97ff088ac8cebee6fe1f8b4778a4e553573R200-R202) [[3]](diffhunk://#diff-63ff66e1da59f117f03537cd0c27e97ff088ac8cebee6fe1f8b4778a4e553573R923-R930) `flowfile_core/flowfile_core/flowfile/code_generator/custom_node_handlers.py` [[4]](diffhunk://#diff-309b1258c15c26772f6b54450c57613775b30675cae514ec1084f6f3f9e7b393L71-R80) [[5]](diffhunk://#diff-309b1258c15c26772f6b54450c57613775b30675cae514ec1084f6f3f9e7b393R166-R167)
* In project (multi-file) exports, detects when any custom node references `flowfile_ctx`, injects an `import flowfile_ctx` statement into the custom node module, and ensures the shim file (`flowfile_ctx.py`) is included in the export. (`flowfile_core/flowfile_core/flowfile/code_generator/project_exporter.py` [[1]](diffhunk://#diff-58984f003709c9d797df76acda55676d6a423235e37280cbc7d7e21afcb057e6R135-R182) [[2]](diffhunk://#diff-58984f003709c9d797df76acda55676d6a423235e37280cbc7d7e21afcb057e6R610) [[3]](diffhunk://#diff-58984f003709c9d797df76acda55676d6a423235e37280cbc7d7e21afcb057e6R655-R659) [[4]](diffhunk://#diff-58984f003709c9d797df76acda55676d6a423235e37280cbc7d7e21afcb057e6L633-R690)
* README generation for exported projects now documents the presence and purpose of `flowfile_ctx.py` when included. (`flowfile_core/flowfile_core/flowfile/code_generator/project_exporter.py` [flowfile_core/flowfile_core/flowfile/code_generator/project_exporter.pyR778-R782](diffhunk://#diff-58984f003709c9d797df76acda55676d6a423235e37280cbc7d7e21afcb057e6R778-R782))

**Manual Input Node Improvements:**

* Manual input node code generation now uses only the public Flowfile API (`ff.from_raw_data({...})`), never referencing `flowfile_core` or internal types directly. (`flowfile_core/flowfile_core/flowfile/code_generator/code_generator.py` [[1]](diffhunk://#diff-63ff66e1da59f117f03537cd0c27e97ff088ac8cebee6fe1f8b4778a4e553573L1126-R1173) `flowfile_core/flowfile_core/flowfile/code_generator/project_exporter.py` [[2]](diffhunk://#diff-58984f003709c9d797df76acda55676d6a423235e37280cbc7d7e21afcb057e6L776-R837) [[3]](diffhunk://#diff-58984f003709c9d797df76acda55676d6a423235e37280cbc7d7e21afcb057e6L812-R874)

**Testing Enhancements:**

* Added comprehensive tests to ensure that:
  - Flat exports include the inline shim only when needed and never import `flowfile_ctx` as a module. (`flowfile_core/tests/flowfile/test_code_generator_custom_nodes.py` [flowfile_core/tests/flowfile/test_code_generator_custom_nodes.pyR609-R716](diffhunk://#diff-2ccdbb3efa23e5291a41231172f104febb700b6f4aaaf1e672cb030d35b1c0d2R609-R716))
  - Project exports ship `flowfile_ctx.py` and inject the import in custom node modules when required.
  - Manual input code never imports `flowfile_core` and preserves explicit types.
  - Node import registration correctly suppresses redundant `flowfile_ctx` imports and sets the shim flag. (`flowfile_core/tests/flowfile/test_code_generator_custom_nodes.py` [flowfile_core/tests/flowfile/test_code_generator_custom_nodes.pyR609-R716](diffhunk://#diff-2ccdbb3efa23e5291a41231172f104febb700b6f4aaaf1e672cb030d35b1c0d2R609-R716))
* Added test utilities for safely writing and importing custom node modules and for restoring the global custom node registry between tests. (`flowfile_core/tests/flowfile/test_project_exporter.py` [flowfile_core/tests/flowfile/test_project_exporter.pyR31-R84](diffhunk://#diff-3c7c91e5edf621fb583fbc0a9cbbd3ff32b648164159c0fcfd71cbd10702c9a1R31-R84))

These changes ensure robust, portable code generation for custom nodes using `flowfile_ctx`, clarify the public API surface, and improve test coverage for these scenarios.