### PR TITLE
Fix kernel interrupt recovery so a cancelled cell can't wedge the kernel

### DIFF
--- a/kernel_runtime/kernel_runtime/main.py
+++ b/kernel_runtime/kernel_runtime/main.py
@@ -179,18 +179,17 @@ def _request_interrupt() -> bool:
 
 
 def _cancel_signal_handler(signum, frame):
-    """Handle SIGUSR1: re-assert the pending interrupt on its target cell.
+    """Handle SIGUSR1: re-assert the pending interrupt on the cell it was bound to.
 
-    Never re-sends SIGUSR1, so it cannot start a self-perpetuating signal storm.
+    Only the generation an interrupt was bound to (via ``_request_interrupt``) is
+    targeted, and only while that cell is still running. A stale, coalesced, or
+    external signal whose target has already finished is ignored rather than
+    misdirected onto a later cell. Never re-sends SIGUSR1, so no signal storm.
     """
-    global _interrupt_generation
     with _exec_lock:
         gen = _interrupt_generation
         if gen is None or gen not in _running_execs:
-            if not _running_execs:
-                return
-            gen = max(_running_execs)
-            _interrupt_generation = gen
+            return  # stale/external: bound target gone — don't misdirect onto a later cell
         tid = _running_execs[gen]
     _raise_in_thread(tid)
 
@@ -420,7 +419,7 @@ def _execute_sync(request: ExecuteRequest) -> ExecuteResponse:
     ``KeyboardInterrupt``) becomes a clean 200 response instead of an unhandled 500.
     Runs via ``asyncio.to_thread`` so the event loop stays free.
     """
-    global _exec_generation
+    global _exec_generation, _interrupt_generation
 
     start = time.perf_counter()
     stdout_buf = io.StringIO()
@@ -446,6 +445,8 @@ def _execute_sync(request: ExecuteRequest) -> ExecuteResponse:
     finally:
         with _exec_lock:
             _running_execs.pop(my_gen, None)
+            if _interrupt_generation == my_gen:
+                _interrupt_generation = None
 
 
 def _run_user_code(

--- a/kernel_runtime/kernel_runtime/main.py
+++ b/kernel_runtime/kernel_runtime/main.py
@@ -136,34 +136,41 @@ def _peek_namespace(flow_id: int) -> dict:
 
 
 # Execution cancellation.
-# When user code runs via asyncio.to_thread(), we track its thread ident so
-# that /interrupt (or SIGUSR1) can inject a KeyboardInterrupt into it.
-_exec_thread_id: int | None = None
-_exec_lock = threading.Lock()
+# More than one cell can be in flight at once: a cell blocked in an
+# uninterruptible C call (e.g. time.sleep, which retries across EINTR per PEP 475)
+# keeps running after it is abandoned while the next cell starts. We track every
+# running execution by a monotonic generation and bind an interrupt to the exact
+# generation it targeted, so a stale interrupt can never land on a later cell.
+# RLock: the SIGUSR1 handler runs on the main thread and may re-enter a lock a
+# caller on that thread already holds.
+_exec_lock = threading.RLock()
+_exec_generation = 0
+_running_execs: dict[int, int] = {}  # generation -> thread ident
+_interrupt_generation: int | None = None  # generation the last interrupt targeted
 
 
-def _raise_in_exec_thread() -> bool:
-    """Inject ``KeyboardInterrupt`` into the executing thread (if any).
-
-    Uses ``PyThreadState_SetAsyncExc`` to set a pending async exception.
-    Also sends ``SIGUSR1`` to the thread to interrupt blocking C calls
-    (e.g. ``time.sleep``) so the exception is checked sooner.
-
-    Returns ``True`` if an exec thread was found and interrupted.
-    """
-    with _exec_lock:
-        tid = _exec_thread_id
-    if tid is None:
-        return False
-
+def _raise_in_thread(tid: int) -> None:
+    """Set a pending ``KeyboardInterrupt`` in thread *tid* (no signal sent)."""
     ctypes.pythonapi.PyThreadState_SetAsyncExc(
         ctypes.c_ulong(tid),
         ctypes.py_object(KeyboardInterrupt),
     )
-    # Send SIGUSR1 to the thread to kick it out of any blocking syscall.
-    # The signal itself is harmless (handler below ignores it when not
-    # targeting the main thread), but the EINTR it causes lets the
-    # thread re-enter the bytecode eval loop where the async exception fires.
+
+
+def _request_interrupt() -> bool:
+    """Interrupt the most recently started running cell, if any.
+
+    Injects ``KeyboardInterrupt`` and sends a single ``SIGUSR1`` to nudge the
+    thread out of a blocking syscall. The interrupt is bound to that cell's
+    generation, so a later cell can never receive it. One-shot: never re-arms.
+    """
+    global _interrupt_generation
+    with _exec_lock:
+        if not _running_execs:
+            return False
+        _interrupt_generation = max(_running_execs)
+        tid = _running_execs[_interrupt_generation]
+    _raise_in_thread(tid)
     try:
         signal.pthread_kill(tid, signal.SIGUSR1)
     except (OSError, ValueError):
@@ -172,11 +179,20 @@ def _raise_in_exec_thread() -> bool:
 
 
 def _cancel_signal_handler(signum, frame):
-    """Handle SIGUSR1: interrupt the exec thread if one is running."""
-    if _raise_in_exec_thread():
-        logger.warning("SIGUSR1 received – interrupting execution thread")
-    else:
-        logger.debug("SIGUSR1 received outside execution, ignoring")
+    """Handle SIGUSR1: re-assert the pending interrupt on its target cell.
+
+    Never re-sends SIGUSR1, so it cannot start a self-perpetuating signal storm.
+    """
+    global _interrupt_generation
+    with _exec_lock:
+        gen = _interrupt_generation
+        if gen is None or gen not in _running_execs:
+            if not _running_execs:
+                return
+            gen = max(_running_execs)
+            _interrupt_generation = gen
+        tid = _running_execs[gen]
+    _raise_in_thread(tid)
 
 
 # Persistence setup (driven by environment variables)
@@ -397,17 +413,48 @@ class CleanupRequest(BaseModel):
 
 
 def _execute_sync(request: ExecuteRequest) -> ExecuteResponse:
-    """Run user code synchronously (called via ``asyncio.to_thread``).
+    """Register this execution and guard its whole body.
 
-    Executing in a worker thread keeps the event loop free so that the
-    ``/interrupt`` endpoint can be served while user code is running.
+    Each cell gets a fresh generation so /interrupt targets exactly this cell and
+    never a later one; any escaping ``BaseException`` (e.g. a late async
+    ``KeyboardInterrupt``) becomes a clean 200 response instead of an unhandled 500.
+    Runs via ``asyncio.to_thread`` so the event loop stays free.
     """
-    global _exec_thread_id
+    global _exec_generation
 
     start = time.perf_counter()
     stdout_buf = io.StringIO()
     stderr_buf = io.StringIO()
 
+    with _exec_lock:
+        _exec_generation += 1
+        my_gen = _exec_generation
+        _running_execs[my_gen] = threading.get_ident()
+    try:
+        return _run_user_code(request, start, stdout_buf, stderr_buf)
+    except BaseException as exc:  # noqa: BLE001 - never surface a stray interrupt as a 500
+        elapsed = (time.perf_counter() - start) * 1000
+        return ExecuteResponse(
+            success=False,
+            stdout=stdout_buf.getvalue(),
+            stderr=stderr_buf.getvalue(),
+            error="Execution cancelled by user"
+            if isinstance(exc, KeyboardInterrupt)
+            else f"{type(exc).__name__}: {exc}",
+            execution_time_ms=elapsed,
+        )
+    finally:
+        with _exec_lock:
+            _running_execs.pop(my_gen, None)
+
+
+def _run_user_code(
+    request: ExecuteRequest,
+    start: float,
+    stdout_buf: io.StringIO,
+    stderr_buf: io.StringIO,
+) -> ExecuteResponse:
+    """Execute one cell's user code. Wrapped by ``_execute_sync``."""
     output_dir = request.output_dir
     if output_dir:
         os.makedirs(output_dir, exist_ok=True)
@@ -464,14 +511,7 @@ def _execute_sync(request: ExecuteRequest) -> ExecuteResponse:
             if request.interactive:
                 user_code = _maybe_wrap_last_expression(user_code)
 
-            # Execute user code — track the thread so /interrupt can target it
-            with _exec_lock:
-                _exec_thread_id = threading.get_ident()
-            try:
-                exec(user_code, exec_globals)  # noqa: S102
-            finally:
-                with _exec_lock:
-                    _exec_thread_id = None
+            exec(user_code, exec_globals)  # noqa: S102
 
         display_outputs = [DisplayOutput(**d) for d in flowfile_client._get_displays()]
 
@@ -497,8 +537,6 @@ def _execute_sync(request: ExecuteRequest) -> ExecuteResponse:
             execution_time_ms=elapsed,
         )
     except KeyboardInterrupt:
-        with _exec_lock:
-            _exec_thread_id = None
         display_outputs = [DisplayOutput(**d) for d in flowfile_client._get_displays()]
         elapsed = (time.perf_counter() - start) * 1000
         return ExecuteResponse(
@@ -522,8 +560,6 @@ def _execute_sync(request: ExecuteRequest) -> ExecuteResponse:
             execution_time_ms=elapsed,
         )
     finally:
-        with _exec_lock:
-            _exec_thread_id = None
         flowfile_client._clear_context()
 
 
@@ -535,7 +571,7 @@ async def execute(request: ExecuteRequest):
 @app.post("/interrupt")
 async def interrupt():
     """Interrupt running user code by injecting ``KeyboardInterrupt``."""
-    if _raise_in_exec_thread():
+    if _request_interrupt():
         return {"status": "interrupted"}
     return {"status": "no_execution_running"}
 

--- a/kernel_runtime/tests/conftest.py
+++ b/kernel_runtime/tests/conftest.py
@@ -31,7 +31,9 @@ def _clear_global_state():
     main._recovery_status = {"status": "pending", "recovered": [], "errors": []}
     main._kernel_id = "default"
     main._persistence_path = "/shared/artifacts"
-    main._is_executing = False
+    main._running_execs.clear()
+    main._exec_generation = 0
+    main._interrupt_generation = None
     artifact_store._persistence = None
     artifact_store._lazy_index.clear()
     artifact_store._loading_locks.clear()
@@ -46,7 +48,9 @@ def _clear_global_state():
     main._recovery_status = {"status": "pending", "recovered": [], "errors": []}
     main._kernel_id = "default"
     main._persistence_path = "/shared/artifacts"
-    main._is_executing = False
+    main._running_execs.clear()
+    main._exec_generation = 0
+    main._interrupt_generation = None
     artifact_store._persistence = None
     artifact_store._lazy_index.clear()
     artifact_store._loading_locks.clear()

--- a/kernel_runtime/tests/test_main.py
+++ b/kernel_runtime/tests/test_main.py
@@ -1317,6 +1317,40 @@ class TestExecutionCancellation:
                 main_module._running_execs.pop(gen, None)
                 main_module._interrupt_generation = None
 
+    def test_stale_interrupt_after_target_finished_spares_later_cell(self, monkeypatch):
+        """A SIGUSR1 handler firing after its bound cell finished must not hit a later cell."""
+        import kernel_runtime.main as main_module
+
+        injected: list = []
+        monkeypatch.setattr(main_module, "_raise_in_thread", lambda tid: injected.append(tid))
+        with main_module._exec_lock:
+            main_module._exec_generation += 1
+            gen_a = main_module._exec_generation  # bound interrupt target, already finished
+            main_module._interrupt_generation = gen_a
+            main_module._exec_generation += 1
+            gen_b = main_module._exec_generation  # a different cell running now
+            main_module._running_execs[gen_b] = 999999
+        try:
+            main_module._cancel_signal_handler(None, None)
+            assert injected == [], "handler injected into a later cell after its target finished"
+        finally:
+            with main_module._exec_lock:
+                main_module._running_execs.pop(gen_b, None)
+                main_module._interrupt_generation = None
+
+    def test_completing_bound_cell_clears_interrupt_generation(self, client: TestClient):
+        """When the interrupt's bound cell finishes, _interrupt_generation is reset to None."""
+        import kernel_runtime.main as main_module
+
+        with main_module._exec_lock:
+            main_module._interrupt_generation = main_module._exec_generation + 1  # the next cell's generation
+        resp = client.post(
+            "/execute",
+            json={"node_id": 1, "code": "x = 1", "flow_id": 1, "input_paths": {}, "output_dir": ""},
+        )
+        assert resp.json()["success"] is True
+        assert main_module._interrupt_generation is None
+
     def test_interrupt_endpoint_no_execution(self, client: TestClient):
         """POST /interrupt returns 'no_execution_running' when idle."""
         resp = client.post("/interrupt")

--- a/kernel_runtime/tests/test_main.py
+++ b/kernel_runtime/tests/test_main.py
@@ -1,6 +1,7 @@
 """Tests for kernel_runtime.main (FastAPI endpoints)."""
 
 import os
+import signal
 import threading
 import time
 from pathlib import Path
@@ -1185,8 +1186,8 @@ class TestExecutionCancellation:
         os.getenv("GITHUB_ACTIONS") == "true" or os.getenv("CI") == "true",
         reason="Signal-based thread interrupt is unreliable in CI runners.",
     )
-    def test_signal_handler_interrupts_exec_thread(self):
-        """_raise_in_exec_thread injects KeyboardInterrupt into the tracked thread."""
+    def test_request_interrupt_hits_running_cell(self):
+        """_request_interrupt raises KeyboardInterrupt in the registered cell's thread."""
         import kernel_runtime.main as main_module
 
         caught: list[bool] = [False]
@@ -1195,35 +1196,46 @@ class TestExecutionCancellation:
         def _target():
             ready.set()
             try:
-                time.sleep(30)
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline:
+                    pass  # bytecode loop so the async KeyboardInterrupt fires promptly
             except KeyboardInterrupt:
                 caught[0] = True
 
+        # Register the handler ourselves (the lifespan normally does): sending SIGUSR1
+        # with the default disposition would kill the test process.
+        prev = signal.getsignal(signal.SIGUSR1)
+        signal.signal(signal.SIGUSR1, main_module._cancel_signal_handler)
         t = threading.Thread(target=_target, daemon=True)
         t.start()
         ready.wait()
 
         with main_module._exec_lock:
-            main_module._exec_thread_id = t.ident
+            main_module._exec_generation += 1
+            gen = main_module._exec_generation
+            main_module._running_execs[gen] = t.ident
         try:
-            assert main_module._raise_in_exec_thread() is True
+            assert main_module._request_interrupt() is True
             t.join(timeout=5)
             assert caught[0], "KeyboardInterrupt was not raised in the target thread"
         finally:
             with main_module._exec_lock:
-                main_module._exec_thread_id = None
+                main_module._running_execs.pop(gen, None)
+                main_module._interrupt_generation = None
+            signal.signal(signal.SIGUSR1, prev)
 
-    def test_signal_handler_ignores_when_not_executing(self):
-        """Outside of exec(), the handler is a no-op (no crash, no exception)."""
+    def test_request_interrupt_noop_when_not_executing(self):
+        """With no running cell the interrupt request is a no-op (no crash)."""
         import kernel_runtime.main as main_module
 
         with main_module._exec_lock:
-            main_module._exec_thread_id = None
-        assert main_module._raise_in_exec_thread() is False
+            main_module._running_execs.clear()
+            main_module._interrupt_generation = None
+        assert main_module._request_interrupt() is False
         main_module._cancel_signal_handler(None, None)  # should not raise
 
-    def test_exec_thread_id_cleared_after_success(self, client: TestClient):
-        """_exec_thread_id must be None after a successful execution."""
+    def test_running_execs_cleared_after_success(self, client: TestClient):
+        """No execution stays registered after a successful cell."""
         import kernel_runtime.main as main_module
 
         resp = client.post(
@@ -1231,10 +1243,10 @@ class TestExecutionCancellation:
             json={"node_id": 200, "code": "x = 1", "flow_id": 1, "input_paths": {}, "output_dir": ""},
         )
         assert resp.json()["success"] is True
-        assert main_module._exec_thread_id is None
+        assert main_module._running_execs == {}
 
-    def test_exec_thread_id_cleared_after_error(self, client: TestClient):
-        """_exec_thread_id must be None even when user code raises."""
+    def test_running_execs_cleared_after_error(self, client: TestClient):
+        """No execution stays registered even when user code raises."""
         import kernel_runtime.main as main_module
 
         resp = client.post(
@@ -1242,7 +1254,68 @@ class TestExecutionCancellation:
             json={"node_id": 201, "code": "1/0", "flow_id": 1, "input_paths": {}, "output_dir": ""},
         )
         assert resp.json()["success"] is False
-        assert main_module._exec_thread_id is None
+        assert main_module._running_execs == {}
+
+    def test_stale_interrupt_does_not_target_later_cell(self, client: TestClient):
+        """An interrupt bound to an earlier (still-registered) cell must never land on a new cell."""
+        import kernel_runtime.main as main_module
+
+        # A real, harmless "cell A" thread (pthread_kill needs a valid tid); interrupting it is safe.
+        stop = threading.Event()
+        a_ready = threading.Event()
+
+        def _cell_a():
+            a_ready.set()
+            try:
+                while not stop.wait(0.02):
+                    pass
+            except KeyboardInterrupt:
+                pass
+
+        prev = signal.getsignal(signal.SIGUSR1)
+        signal.signal(signal.SIGUSR1, main_module._cancel_signal_handler)
+        a = threading.Thread(target=_cell_a, daemon=True)
+        a.start()
+        a_ready.wait()
+        with main_module._exec_lock:
+            main_module._exec_generation += 1
+            gen_a = main_module._exec_generation
+            main_module._running_execs[gen_a] = a.ident
+        try:
+            assert main_module._request_interrupt() is True  # binds _interrupt_generation to A
+            # A fresh cell B must run cleanly: the stale interrupt is bound to A, never B.
+            resp = client.post(
+                "/execute",
+                json={"node_id": 100, "code": "x = 1 + 1", "flow_id": 999, "input_paths": {}, "output_dir": ""},
+            )
+            assert resp.status_code == 200
+            assert resp.json()["success"] is True
+        finally:
+            stop.set()
+            with main_module._exec_lock:
+                main_module._running_execs.pop(gen_a, None)
+                main_module._interrupt_generation = None
+            signal.signal(signal.SIGUSR1, prev)
+            a.join(timeout=5)
+
+    def test_signal_handler_does_not_resend_sigusr1(self, monkeypatch):
+        """The SIGUSR1 handler re-asserts the interrupt but never re-sends a signal (no storm)."""
+        import kernel_runtime.main as main_module
+
+        sent: list = []
+        monkeypatch.setattr(main_module.signal, "pthread_kill", lambda *a, **k: sent.append(a))
+        with main_module._exec_lock:
+            main_module._exec_generation += 1
+            gen = main_module._exec_generation
+            main_module._running_execs[gen] = 123456789
+            main_module._interrupt_generation = gen
+        try:
+            main_module._cancel_signal_handler(None, None)
+            assert sent == [], "signal handler must not re-send SIGUSR1"
+        finally:
+            with main_module._exec_lock:
+                main_module._running_execs.pop(gen, None)
+                main_module._interrupt_generation = None
 
     def test_interrupt_endpoint_no_execution(self, client: TestClient):
         """POST /interrupt returns 'no_execution_running' when idle."""


### PR DESCRIPTION
Cancelling a long-running kernel cell could leave the kernel returning HTTP
500 for every subsequent /execute, wedging the shared kernel until the
abandoned cell finished. The root cause was the interrupt machinery itself,
not any single cell:

- The SIGUSR1 handler re-sent SIGUSR1, creating a self-sustaining signal storm
  for as long as a cell stayed registered.
- A single process-global _exec_thread_id meant that storm re-targeted whatever
  cell ran next, injecting KeyboardInterrupt into an innocent follow-up cell.
- _execute_sync only guarded the middle of the body, so a KeyboardInterrupt
  landing in the pre-try setup or the finally escaped as an unhandled 500.

Replace the single global with a per-execution generation registry: an
interrupt binds to the exact generation it targeted and can never land on a
later cell. Make interrupt one-shot (the handler re-asserts the pending
interrupt but never re-sends SIGUSR1), switch the lock to RLock for the
main-thread signal handler, and wrap the whole execution body so any escaping
BaseException becomes a clean 200 success=False instead of a 500.

Rewrite TestExecutionCancellation to the new contract and add regression tests:
a stale interrupt bound to an earlier cell must not fail a fresh cell, and the
signal handler must not re-send SIGUSR1.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GPe63Ws14r7Thj3FDUtXma