### PR TITLE
Add reactivity in the frontend components

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Deeper dive: [Architecting a Visual ETL Tool with Polars](https://dev.to/edwardv
 - [ ] Multi-user collaboration
 - [ ] Role-based access control
 
----
+-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,6 @@ Deeper dive: [Architecting a Visual ETL Tool with Polars](https://dev.to/edwardv
 - [ ] Multi-user collaboration
 - [ ] Role-based access control
 
--
-
 ## License
 
 [MIT](LICENSE)

--- a/flowfile_core/flowfile_core/flowfile/node_designer/__init__.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/__init__.py
@@ -34,6 +34,7 @@ from shared.node_designer import (
     TextInput,
     ToggleSwitch,
     Types,
+    VisibleWhen,
     create_node_settings,
     create_section,
     to_frontend_schema,
@@ -44,6 +45,7 @@ __all__ = [
     "CustomNodeBase",
     # UI Components & Layout
     "Section",
+    "VisibleWhen",
     "TextInput",
     "NumericInput",
     "SliderInput",

--- a/flowfile_core/flowfile_core/flowfile/node_designer/codegen.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/codegen.py
@@ -28,6 +28,7 @@ from flowfile_core.flowfile.node_designer.state import (
     SliderInputState,
     TextInputState,
     ToggleSwitchState,
+    VisibleWhenState,
 )
 
 
@@ -285,17 +286,32 @@ class _Renderer:
         if section.layout != "vertical":
             kwargs.append(("layout", _py_literal(section.layout)))
 
-        if not kwargs and not section.components:
+        inner = indent + _INDENT
+        visible_when_lines = self._visible_when_lines(section.visible_when, inner)
+
+        if not kwargs and not visible_when_lines and not section.components:
             # ruff collapses an empty call to one line — emit it that way directly.
             return [f"{indent}{section.name}: nd.Section = nd.Section()"]
 
-        inner = indent + _INDENT
         lines = [f"{indent}{section.name}: nd.Section = nd.Section("]
         for key, value in kwargs:
             lines.append(f"{inner}{key}={value},")
+        lines.extend(visible_when_lines)
         for comp in section.components:
             lines.extend(self._render_component(comp, inner))
         lines.append(f"{indent})")
+        return lines
+
+    def _visible_when_lines(self, spec: VisibleWhenState | None, inner: str) -> list[str]:
+        # Emitted after the scalar section kwargs as an nd.VisibleWhen(...) call;
+        # `equals` is omitted when True (the default) to keep the fixed point stable.
+        if spec is None:
+            return []
+        body = inner + _INDENT
+        lines = [f"{inner}visible_when=nd.VisibleWhen(", f"{body}field={_py_literal(spec.field)},"]
+        if spec.equals is not True:
+            lines.append(f"{body}equals={_py_literal(spec.equals)},")
+        lines.append(f"{inner}),")
         return lines
 
     # -- top-level rendering -------------------------------------------------

--- a/flowfile_core/flowfile_core/flowfile/node_designer/parsing.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/parsing.py
@@ -440,8 +440,11 @@ class _SourceParser:
                 raise _LiteralError(node, f"'{node.id}' must be used with an attribute, e.g. Types.String")
             raise _LiteralError(node, f"name '{node.id}' is not a designer literal")
         if isinstance(node, ast.Call):
-            if self.resolve_symbol(node.func) == "ActionOption":
+            func_symbol = self.resolve_symbol(node.func)
+            if func_symbol == "ActionOption":
                 return self._eval_action_option(node)
+            if func_symbol == "VisibleWhen":
+                return self._eval_visible_when(node)
             raise _LiteralError(node, f"call '{ast.unparse(node.func)}(...)' is not a designer literal")
         raise _LiteralError(node, f"'{ast.unparse(node)}' is not a designer literal")
 
@@ -460,6 +463,22 @@ class _SourceParser:
             raise _LiteralError(call, "ActionOption value and label must be strings")
         return SelectOption(value=values["value"], label=values["label"])
 
+    def _eval_visible_when(self, call: ast.Call) -> dict:
+        # Returns the {field, equals} dict; _lift_section validates + coerces to VisibleWhenState.
+        values: dict[str, Any] = {}
+        positional = ["field", "equals"]
+        if len(call.args) > 2:
+            raise _LiteralError(call, "VisibleWhen takes (field, equals)")
+        for i, arg in enumerate(call.args):
+            values[positional[i]] = self.eval_literal(arg)
+        for kw in call.keywords:
+            if kw.arg not in ("field", "equals"):
+                raise _LiteralError(call, "VisibleWhen takes (field, equals)")
+            values[kw.arg] = self.eval_literal(kw.value)
+        if not isinstance(values.get("field"), str):
+            raise _LiteralError(call, "VisibleWhen field must be a string")
+        return values
+
     # -- component lifting -----------------------------------------------------
 
     def _lift_section(self, name: str, call: ast.Call) -> SectionState | None:
@@ -473,6 +492,7 @@ class _SourceParser:
         title: str | None = None
         description: str | None = None
         hidden = False
+        visible_when: dict | None = None
         layout = "vertical"
         components = []
         ok = True
@@ -485,7 +505,7 @@ class _SourceParser:
                 )
                 ok = False
                 continue
-            if kw.arg in ("title", "description", "hidden", "layout"):
+            if kw.arg in ("title", "description", "hidden", "visible_when", "layout"):
                 try:
                     value = self.eval_literal(kw.value)
                 except _LiteralError as e:
@@ -500,6 +520,17 @@ class _SourceParser:
                     hidden = bool(value)
                 elif kw.arg == "title":
                     title = value
+                elif kw.arg == "visible_when":
+                    if not (isinstance(value, dict) and isinstance(value.get("field"), str)):
+                        self.error(
+                            ParseIssueCode.NON_LITERAL_COMPONENT_KWARG,
+                            f"'{name}.visible_when' must be nd.VisibleWhen(field='section.toggle') "
+                            "or a dict like {'field': 'section.toggle'}",
+                            kw.value,
+                        )
+                        ok = False
+                        continue
+                    visible_when = value
                 elif kw.arg == "layout":
                     if value not in ("vertical", "horizontal"):
                         self.error(
@@ -522,7 +553,13 @@ class _SourceParser:
             return None
         try:
             return SectionState(
-                name=name, title=title, description=description, hidden=hidden, layout=layout, components=components
+                name=name,
+                title=title,
+                description=description,
+                hidden=hidden,
+                visible_when=visible_when,
+                layout=layout,
+                components=components,
             )
         except ValidationError as e:
             self.error(ParseIssueCode.NON_LITERAL_COMPONENT_KWARG, f"Section '{name}' is invalid: {e}", call)

--- a/flowfile_core/flowfile_core/flowfile/node_designer/state.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/state.py
@@ -105,11 +105,17 @@ ComponentState = Annotated[
 ]
 
 
+class VisibleWhenState(BaseModel):
+    field: str  # dotted "<section>.<toggle>" reference
+    equals: bool = True
+
+
 class SectionState(BaseModel):
     name: PyIdentifier
     title: str | None = None
     description: str | None = None
     hidden: bool = False
+    visible_when: VisibleWhenState | None = None
     layout: Literal["vertical", "horizontal"] = "vertical"
     components: list[ComponentState] = []  # ordered
 

--- a/flowfile_core/tests/flowfile/node_designer/corpus/insubset_section_visible_when.py
+++ b/flowfile_core/tests/flowfile/node_designer/corpus/insubset_section_visible_when.py
@@ -1,0 +1,43 @@
+import polars as pl
+
+from flowfile import node_designer as nd
+
+
+class GreetingSettings(nd.NodeSettings):
+    main: nd.Section = nd.Section(
+        title="Greeting",
+        name_column=nd.ColumnSelector(
+            label="Name column",
+            required=True,
+        ),
+        show_advanced=nd.ToggleSwitch(
+            label="Customize greeting",
+        ),
+    )
+    advanced: nd.Section = nd.Section(
+        title="Advanced",
+        visible_when=nd.VisibleWhen(
+            field="main.show_advanced",
+        ),
+        word=nd.TextInput(
+            label="Greeting word",
+            default="Hello",
+        ),
+    )
+    inverted: nd.Section = nd.Section(
+        title="Basic",
+        visible_when=nd.VisibleWhen(
+            field="main.show_advanced",
+            equals=False,
+        ),
+        note=nd.TextInput(label="Note"),
+    )
+
+
+class GreetingNode(nd.CustomNodeBase):
+    node_name: str = "Greeting"
+
+    settings_schema: GreetingSettings = GreetingSettings()
+
+    def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+        return inputs[0]

--- a/flowfile_core/tests/flowfile/node_designer/test_node_designer.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_node_designer.py
@@ -5,7 +5,13 @@ import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
 
-from flowfile_core.flowfile.node_designer import ColumnSelector, CustomNodeBase, NodeSettings, Section
+from flowfile_core.flowfile.node_designer import (
+    ColumnSelector,
+    CustomNodeBase,
+    NodeSettings,
+    Section,
+    VisibleWhen,
+)
 from flowfile_core.flowfile.node_designer.custom_node import (
     to_frontend_schema,
 )
@@ -260,6 +266,29 @@ def test_to_frontend_schema_horizontal_layout():
     )
     schema = to_frontend_schema(settings)
     assert schema["config"]["layout"] == "horizontal"
+
+
+def test_to_frontend_schema_visible_when():
+    """VisibleWhen serializes to the {field, equals} wire dict; sections without it omit the key."""
+    settings = NodeSettings(
+        opts=Section(title="Opts", show_advanced=ToggleSwitch(label="Show advanced")),
+        advanced=Section(
+            title="Advanced",
+            visible_when=VisibleWhen(field="opts.show_advanced"),
+            note=TextInput(label="Note"),
+        ),
+    )
+    schema = to_frontend_schema(settings)
+    assert schema["advanced"]["visible_when"] == {"field": "opts.show_advanced", "equals": True}
+    assert "visible_when" not in schema["opts"]
+
+
+def test_section_visible_when_accepts_dict_and_coerces():
+    """A plain dict is coerced to VisibleWhen at the Section boundary (lenient authoring)."""
+    section = Section(title="Advanced", visible_when={"field": "opts.flag", "equals": False})
+    assert isinstance(section.visible_when, VisibleWhen)
+    assert section.visible_when.field == "opts.flag"
+    assert section.visible_when.equals is False
 
 
 def test_to_frontend_schema_incoming_columns(sample_node_settings: NodeSettings):

--- a/flowfile_core/tests/flowfile/node_designer/test_parsing.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_parsing.py
@@ -356,6 +356,51 @@ def test_section_invalid_layout_is_code_only():
     assert ParseIssueCode.NON_LITERAL_COMPONENT_KWARG.value in error_codes(result)
 
 
+def test_section_visible_when_lifts_and_round_trips():
+    result = parse("insubset_section_visible_when.py")
+    assert result.mode == "designer"
+    assert codes(result) == set()
+    sections = {s.name: s for s in result.designer_state.sections}
+    assert sections["main"].visible_when is None
+    assert sections["advanced"].visible_when.field == "main.show_advanced"
+    assert sections["advanced"].visible_when.equals is True
+    assert sections["inverted"].visible_when.field == "main.show_advanced"
+    assert sections["inverted"].visible_when.equals is False
+
+    from flowfile_core.flowfile.node_designer.codegen import generate_source
+
+    generated = generate_source(result.designer_state)
+    assert "visible_when=nd.VisibleWhen(" in generated
+    assert 'field="main.show_advanced"' in generated
+    # equals=True (advanced) is the default and omitted; only equals=False (inverted) is emitted.
+    assert generated.count("equals=") == 1
+    assert "equals=False" in generated
+    reparsed = parse_source(generated)
+    assert reparsed.designer_state == result.designer_state
+
+
+def test_section_visible_when_dict_form_lifts_and_normalizes():
+    """A hand-written dict is accepted and normalized to the canonical nd.VisibleWhen(...) on save."""
+    result = parse_source(_layout_source('visible_when={"field": "main.flag"},'))
+    assert result.mode == "designer"
+    assert error_codes(result) == set()
+    section = result.designer_state.sections[0]
+    assert section.visible_when.field == "main.flag"
+    assert section.visible_when.equals is True
+
+    from flowfile_core.flowfile.node_designer.codegen import generate_source
+
+    generated = generate_source(result.designer_state)
+    assert "visible_when=nd.VisibleWhen(" in generated
+    assert 'field="main.flag"' in generated
+
+
+def test_section_visible_when_non_dict_is_code_only():
+    result = parse_source(_layout_source('visible_when="main.flag",'))
+    assert result.mode == "code_only"
+    assert ParseIssueCode.NON_LITERAL_COMPONENT_KWARG.value in error_codes(result)
+
+
 def test_multi_input_node_without_settings():
     result = parse("insubset_multi_input.py")
     assert result.mode == "designer"

--- a/flowfile_core/tests/flowfile/node_designer/test_roundtrip_fixed_point.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_roundtrip_fixed_point.py
@@ -29,6 +29,7 @@ from flowfile_core.flowfile.node_designer.state import (
     SliderInputState,
     TextInputState,
     ToggleSwitchState,
+    VisibleWhenState,
 )
 
 # Leaf DataType values that normalize to themselves (see enumeration in the SDK).
@@ -185,12 +186,22 @@ def _component(rng: random.Random, taken: set[str]):
     )
 
 
+def _visible_when(rng: random.Random) -> VisibleWhenState | None:
+    if rng.random() < 0.5:
+        return None
+    return VisibleWhenState(
+        field=f"{rng.choice(_WORDS)}.{rng.choice(_WORDS)}",
+        equals=rng.random() < 0.5,
+    )
+
+
 def _section(rng: random.Random, taken: set[str]) -> SectionState:
     return SectionState(
         name=_ident(rng, taken, "s"),
         title=_maybe(rng, _text(rng)),
         description=_maybe(rng, _text(rng)),
         hidden=rng.random() < 0.3,
+        visible_when=_visible_when(rng),
         layout=rng.choice(["vertical", "horizontal"]),
         components=[_component(rng, taken) for _ in range(rng.randint(0, 4))],
     )

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/CustomNodeForm.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/CustomNodeForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-for="(section, sectionKey) in schema"
-    v-show="!section.hidden"
+    v-show="editMode || (!section.hidden && isSectionVisible(section, formData))"
     :key="sectionKey"
     class="listbox-wrapper"
     :class="{ 'section-selected': editMode && sectionKey.toString() === selectedSectionKey }"
@@ -119,6 +119,7 @@
 // Shared renderer for custom-node settings forms: used by the settings drawer
 // (CustomNode.vue) and, in editMode with chrome slots, by the Node Designer.
 import type { SettingsSchema } from "./interface";
+import { isSectionVisible } from "./visibility";
 import type { FileColumn } from "../../../baseNode/nodeInterfaces";
 import MultiSelect from "./components/MultiSelect.vue";
 import ToggleSwitch from "./components/ToggleSwitch.vue";

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/interface.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/interface.ts
@@ -88,11 +88,17 @@ export interface ColumnActionInputComponent extends BaseComponent {
 
 // --- Section Component Type ---
 
+export interface VisibleWhen {
+  field: string; // dotted "<section>.<toggle>" reference
+  equals?: boolean; // defaults to true
+}
+
 export interface SectionComponent {
   component_type: "Section";
   title?: string;
   description?: string;
   hidden?: boolean;
+  visible_when?: VisibleWhen;
   layout?: "vertical" | "horizontal";
   components: Record<string, UIComponent>;
 }

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/visibility.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/visibility.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isSectionVisible } from "./visibility";
+
+const data = {
+  main: { show_advanced: true, mode: false },
+};
+
+describe("isSectionVisible", () => {
+  it("shows a section with no visible_when rule", () => {
+    expect(isSectionVisible({ visible_when: undefined }, data)).toBe(true);
+  });
+
+  it("shows when the referenced toggle equals the default target (true)", () => {
+    expect(isSectionVisible({ visible_when: { field: "main.show_advanced" } }, data)).toBe(true);
+    expect(isSectionVisible({ visible_when: { field: "main.mode" } }, data)).toBe(false);
+  });
+
+  it("inverts with equals=false (show when the toggle is off)", () => {
+    expect(isSectionVisible({ visible_when: { field: "main.mode", equals: false } }, data)).toBe(
+      true,
+    );
+    expect(
+      isSectionVisible({ visible_when: { field: "main.show_advanced", equals: false } }, data),
+    ).toBe(false);
+  });
+
+  it("fails open on an unresolvable reference (missing section/field)", () => {
+    expect(isSectionVisible({ visible_when: { field: "nope.missing" } }, data)).toBe(true);
+    expect(isSectionVisible({ visible_when: { field: "main.absent" } }, data)).toBe(true);
+  });
+
+  it("fails open on a malformed reference (empty or no dot)", () => {
+    expect(isSectionVisible({ visible_when: { field: "" } }, data)).toBe(true);
+    expect(isSectionVisible({ visible_when: { field: "no_dot" } }, data)).toBe(true);
+  });
+});

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/visibility.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/visibility.ts
@@ -1,0 +1,17 @@
+import type { SectionComponent } from "./interface";
+
+// A section with `visible_when` shows only while its referenced toggle equals the
+// target value (default true). Fail-open: an unresolvable/undefined reference (typo,
+// missing toggle, no dot) leaves the section visible so it can never be lost.
+export function isSectionVisible(
+  section: Pick<SectionComponent, "visible_when">,
+  data: Record<string, Record<string, unknown>>,
+): boolean {
+  const vw = section.visible_when;
+  if (!vw?.field) return true;
+  const dot = vw.field.indexOf(".");
+  if (dot < 0) return true;
+  const actual = data[vw.field.slice(0, dot)]?.[vw.field.slice(dot + 1)];
+  if (actual === undefined) return true;
+  return actual === (vw.equals ?? true);
+}

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/__fixtures__/designer_state_roundtrip.json
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/__fixtures__/designer_state_roundtrip.json
@@ -60,6 +60,7 @@
       "title": "Advanced",
       "description": null,
       "hidden": false,
+      "visible_when": { "field": "main_config.include_totals", "equals": true },
       "layout": "vertical",
       "components": [
         {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/ControlInspector.vue
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/ControlInspector.vue
@@ -31,7 +31,9 @@
               type="text"
               class="ins-input"
               placeholder="field_name"
+              @focus="captureName"
               @input="updateName(($event.target as HTMLInputElement).value)"
+              @change="commitName"
             />
           </div>
           <div class="field-row">
@@ -390,10 +392,28 @@ function update(field: string, value: unknown) {
   (comp.value as unknown as Record<string, unknown>)[field] = value;
 }
 
+const nameBeforeEdit = ref("");
+
+function captureName() {
+  nameBeforeEdit.value = comp.value?.name ?? "";
+}
+
 function updateName(value: string) {
   if (!comp.value) return;
   comp.value.name = toSnakeCase(value);
   store.syncPreviewValues();
+}
+
+// On blur, retarget any visible_when rule that pointed at this control's old name
+// (no-op unless a section actually gates on it — only toggles are ever referenced).
+function commitName() {
+  const sectionIndex = store.selectedSectionIndex;
+  if (!comp.value || sectionIndex === null) return;
+  store.retargetVisibleWhenForComponent(
+    store.sections[sectionIndex].name,
+    nameBeforeEdit.value,
+    comp.value.name,
+  );
 }
 
 const optionsCsv = computed(() => {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/SectionInspector.vue
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/SectionInspector.vue
@@ -32,6 +32,7 @@
               class="ins-input ins-mono"
               title="Attribute used in self.settings_schema.<name>"
               placeholder="section_name"
+              @focus="captureName"
               @input="updateName(($event.target as HTMLInputElement).value)"
               @change="commitName"
             />
@@ -148,12 +149,15 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useNodeDesignerStore } from "@/stores/node-designer-store";
 import type { SectionLayout, SectionState } from "../designerState";
 import EmptyState from "../../../components/common/EmptyState/EmptyState.vue";
 
 const store = useNodeDesignerStore();
+
+// Captured before an edit so commitName can retarget visible_when refs to the new name.
+const nameBeforeEdit = ref("");
 
 const section = computed<SectionState | null>(() => {
   const idx = store.selectedSectionIndex;
@@ -185,9 +189,17 @@ function updateName(value: string) {
   store.sections[store.selectedSectionIndex].name = value;
 }
 
+function captureName() {
+  nameBeforeEdit.value = section.value?.name ?? "";
+}
+
 function commitName() {
   if (store.selectedSectionIndex === null) return;
   store.sanitizeSectionName(store.selectedSectionIndex);
+  store.retargetVisibleWhenForSection(
+    nameBeforeEdit.value,
+    store.sections[store.selectedSectionIndex].name,
+  );
 }
 
 function updateDescription(value: string) {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/SectionInspector.vue
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/SectionInspector.vue
@@ -79,6 +79,63 @@
             </span>
           </div>
         </div>
+
+        <div class="field-group">
+          <div class="field-group-title">Visibility</div>
+          <label class="vis-check">
+            <input
+              type="checkbox"
+              :checked="!!section.visible_when"
+              :disabled="!section.visible_when && toggleOptions.length === 0"
+              @change="toggleVisibility(($event.target as HTMLInputElement).checked)"
+            />
+            Only show this group when a toggle is set
+          </label>
+          <span v-if="!section.visible_when && toggleOptions.length === 0" class="field-hint">
+            Add a ToggleSwitch control to another group to gate this one.
+          </span>
+          <template v-if="section.visible_when">
+            <div class="field-row">
+              <label>Controlling toggle</label>
+              <select
+                class="ins-input"
+                :value="section.visible_when.field"
+                @change="setVisibleField(($event.target as HTMLSelectElement).value)"
+              >
+                <option
+                  v-if="!toggleOptions.includes(section.visible_when.field)"
+                  :value="section.visible_when.field"
+                >
+                  {{ section.visible_when.field || "— select a toggle —" }}
+                </option>
+                <option v-for="opt in toggleOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+            </div>
+            <div class="field-row">
+              <label>Show this group when the toggle is</label>
+              <div class="layout-switch" role="group" aria-label="Toggle state">
+                <button
+                  type="button"
+                  class="layout-btn"
+                  :class="{ active: section.visible_when.equals !== false }"
+                  @click="setVisibleEquals(true)"
+                >
+                  <i class="fa-solid fa-toggle-on"></i>
+                  On
+                </button>
+                <button
+                  type="button"
+                  class="layout-btn"
+                  :class="{ active: section.visible_when.equals === false }"
+                  @click="setVisibleEquals(false)"
+                >
+                  <i class="fa-solid fa-toggle-off"></i>
+                  Off
+                </button>
+              </div>
+            </div>
+          </template>
+        </div>
       </div>
 
       <EmptyState
@@ -104,6 +161,20 @@ const section = computed<SectionState | null>(() => {
   return store.sections[idx] ?? null;
 });
 
+// Eligible controlling toggles: ToggleSwitch controls in OTHER sections (a section
+// can't gate on a toggle it would itself hide). Rendered as "<section>.<toggle>".
+const toggleOptions = computed<string[]>(() => {
+  const current = section.value?.name;
+  const out: string[] = [];
+  for (const sec of store.sections) {
+    if (sec.name === current) continue;
+    for (const comp of sec.components) {
+      if (comp.component_type === "ToggleSwitch") out.push(`${sec.name}.${comp.name}`);
+    }
+  }
+  return out;
+});
+
 function updateTitle(value: string) {
   if (store.selectedSectionIndex === null) return;
   store.updateSectionTitle(store.selectedSectionIndex, value);
@@ -127,6 +198,26 @@ function updateDescription(value: string) {
 function setLayout(layout: SectionLayout) {
   if (store.selectedSectionIndex === null) return;
   store.setSectionLayout(store.selectedSectionIndex, layout);
+}
+
+function toggleVisibility(enabled: boolean) {
+  if (store.selectedSectionIndex === null) return;
+  store.setSectionVisibleWhen(
+    store.selectedSectionIndex,
+    enabled ? { field: toggleOptions.value[0] ?? "", equals: true } : null,
+  );
+}
+
+function setVisibleField(field: string) {
+  const vw = section.value?.visible_when;
+  if (store.selectedSectionIndex === null || !vw) return;
+  store.setSectionVisibleWhen(store.selectedSectionIndex, { ...vw, field });
+}
+
+function setVisibleEquals(equals: boolean) {
+  const vw = section.value?.visible_when;
+  if (store.selectedSectionIndex === null || !vw) return;
+  store.setSectionVisibleWhen(store.selectedSectionIndex, { ...vw, equals });
 }
 </script>
 
@@ -267,5 +358,18 @@ function setLayout(layout: SectionLayout) {
 .field-hint {
   font-size: 0.75rem;
   color: var(--color-text-secondary, #6b7280);
+}
+
+.vis-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+  cursor: pointer;
+}
+
+.vis-check input {
+  cursor: pointer;
 }
 </style>

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designerState.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designerState.ts
@@ -99,11 +99,18 @@ export type ComponentState =
 
 export type SectionLayout = "vertical" | "horizontal";
 
+/** Show the section only while the referenced toggle field equals `equals`. */
+export interface VisibleWhenState {
+  field: string; // dotted "<section>.<toggle>" reference
+  equals?: boolean; // defaults to true
+}
+
 export interface SectionState {
   name: string;
   title?: string | null;
   description?: string | null;
   hidden: boolean;
+  visible_when?: VisibleWhenState | null;
   layout: SectionLayout;
   components: ComponentState[]; // ordered
 }

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/mappers.test.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/mappers.test.ts
@@ -29,6 +29,14 @@ describe("designerStateToFrontendSchema", () => {
     expect(schema.advanced.layout).toBe("vertical");
   });
 
+  it("carries visible_when through, and omits it on sections without a rule", () => {
+    expect(schema.advanced.visible_when).toEqual({
+      field: "main_config.include_totals",
+      equals: true,
+    });
+    expect(schema.main_config.visible_when).toBeUndefined();
+  });
+
   it("keys components by name and carries component_type", () => {
     const comps = schema.main_config.components;
     expect(Object.keys(comps)).toEqual(["report_title", "include_totals", "mode", "group_cols"]);

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/mappers.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/mappers.ts
@@ -181,6 +181,7 @@ export function designerStateToFrontendSchema(state: DesignerState): SettingsSch
       title: section.title ?? undefined,
       description: section.description ?? undefined,
       hidden: section.hidden || undefined,
+      visible_when: section.visible_when ?? undefined,
       layout: section.layout ?? "vertical",
       components,
     };

--- a/flowfile_frontend/src/renderer/app/stores/node-designer-store.test.ts
+++ b/flowfile_frontend/src/renderer/app/stores/node-designer-store.test.ts
@@ -156,6 +156,33 @@ describe("state transitions", () => {
     expect(store.frontendSchema.settings.visible_when).toBeUndefined();
   });
 
+  it("retargets visible_when references when a section is renamed", () => {
+    const store = useNodeDesignerStore();
+    store.addComponent(0, "ToggleSwitch");
+    store.addSection();
+    store.setSectionVisibleWhen(1, { field: "settings.toggle_switch_1", equals: true });
+    store.retargetVisibleWhenForSection("settings", "main");
+    expect(store.sections[1].visible_when?.field).toBe("main.toggle_switch_1");
+  });
+
+  it("retargets visible_when references when a toggle is renamed", () => {
+    const store = useNodeDesignerStore();
+    store.addComponent(0, "ToggleSwitch");
+    store.addSection();
+    store.setSectionVisibleWhen(1, { field: "settings.toggle_switch_1", equals: false });
+    store.retargetVisibleWhenForComponent("settings", "toggle_switch_1", "flag");
+    expect(store.sections[1].visible_when).toEqual({ field: "settings.flag", equals: false });
+  });
+
+  it("leaves unrelated visible_when references untouched on rename", () => {
+    const store = useNodeDesignerStore();
+    store.addSection();
+    store.setSectionVisibleWhen(1, { field: "other.toggle", equals: true });
+    store.retargetVisibleWhenForSection("settings", "main");
+    store.retargetVisibleWhenForComponent("settings", "x", "y");
+    expect(store.sections[1].visible_when?.field).toBe("other.toggle");
+  });
+
   it("resetState restores the defaults", () => {
     const store = useNodeDesignerStore();
     store.nodeMetadata.node_name = "Something";

--- a/flowfile_frontend/src/renderer/app/stores/node-designer-store.test.ts
+++ b/flowfile_frontend/src/renderer/app/stores/node-designer-store.test.ts
@@ -142,6 +142,20 @@ describe("state transitions", () => {
     expect(store.frontendSchema.settings.layout).toBe("horizontal");
   });
 
+  it("sets and clears a section visible_when rule and reflects it in the schema", () => {
+    const store = useNodeDesignerStore();
+    expect(store.sections[0].visible_when).toBeUndefined();
+    store.setSectionVisibleWhen(0, { field: "opts.show_advanced", equals: true });
+    expect(store.sections[0].visible_when).toEqual({ field: "opts.show_advanced", equals: true });
+    expect(store.frontendSchema.settings.visible_when).toEqual({
+      field: "opts.show_advanced",
+      equals: true,
+    });
+    store.setSectionVisibleWhen(0, null);
+    expect(store.sections[0].visible_when).toBeNull();
+    expect(store.frontendSchema.settings.visible_when).toBeUndefined();
+  });
+
   it("resetState restores the defaults", () => {
     const store = useNodeDesignerStore();
     store.nodeMetadata.node_name = "Something";
@@ -267,7 +281,14 @@ describe("draft restore", () => {
     const state = newDesignerState();
     state.node_name = name;
     state.sections = [
-      { name: "opts", title: "Options", description: null, hidden: false, layout: "vertical", components: [] },
+      {
+        name: "opts",
+        title: "Options",
+        description: null,
+        hidden: false,
+        layout: "vertical",
+        components: [],
+      },
     ];
     state.process_code = "return inputs[0]";
     localStorageMock.setItem(NEW_DRAFT_KEY, v2Draft(state));

--- a/flowfile_frontend/src/renderer/app/stores/node-designer-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/node-designer-store.ts
@@ -633,6 +633,28 @@ export const useNodeDesignerStore = defineStore("node-designer", () => {
     sections.value[index].visible_when = visibleWhen;
   }
 
+  function retargetVisibleWhenForSection(oldName: string, newName: string) {
+    if (!oldName || oldName === newName) return;
+    const prefix = `${oldName}.`;
+    for (const s of sections.value) {
+      const vw = s.visible_when;
+      if (vw && vw.field.startsWith(prefix)) {
+        s.visible_when = { ...vw, field: `${newName}.${vw.field.slice(prefix.length)}` };
+      }
+    }
+  }
+
+  function retargetVisibleWhenForComponent(sectionName: string, oldName: string, newName: string) {
+    if (!oldName || oldName === newName) return;
+    const oldField = `${sectionName}.${oldName}`;
+    const newField = `${sectionName}.${newName}`;
+    for (const s of sections.value) {
+      if (s.visible_when?.field === oldField) {
+        s.visible_when = { ...s.visible_when, field: newField };
+      }
+    }
+  }
+
   function selectComponent(sectionIndex: number, compIndex: number) {
     selectedSectionIndex.value = sectionIndex;
     selectedComponentIndex.value = compIndex;
@@ -724,6 +746,8 @@ export const useNodeDesignerStore = defineStore("node-designer", () => {
     updateSectionDescription,
     setSectionLayout,
     setSectionVisibleWhen,
+    retargetVisibleWhenForSection,
+    retargetVisibleWhenForComponent,
     selectComponent,
     removeComponent,
     addComponentToSection,

--- a/flowfile_frontend/src/renderer/app/stores/node-designer-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/node-designer-store.ts
@@ -16,6 +16,7 @@ import type {
   ParseIssue,
   SectionLayout,
   SectionState,
+  VisibleWhenState,
 } from "../pages/nodeDesigner/designerState";
 import { newDesignerState } from "../pages/nodeDesigner/designerState";
 import {
@@ -628,6 +629,10 @@ export const useNodeDesignerStore = defineStore("node-designer", () => {
     sections.value[index].layout = layout;
   }
 
+  function setSectionVisibleWhen(index: number, visibleWhen: VisibleWhenState | null) {
+    sections.value[index].visible_when = visibleWhen;
+  }
+
   function selectComponent(sectionIndex: number, compIndex: number) {
     selectedSectionIndex.value = sectionIndex;
     selectedComponentIndex.value = compIndex;
@@ -718,6 +723,7 @@ export const useNodeDesignerStore = defineStore("node-designer", () => {
     updateSectionTitle,
     updateSectionDescription,
     setSectionLayout,
+    setSectionVisibleWhen,
     selectComponent,
     removeComponent,
     addComponentToSection,

--- a/shared/node_designer/__init__.py
+++ b/shared/node_designer/__init__.py
@@ -35,6 +35,7 @@ from shared.node_designer.ui_components import (
     SliderInput,
     TextInput,
     ToggleSwitch,
+    VisibleWhen,
 )
 
 __all__ = [
@@ -42,6 +43,7 @@ __all__ = [
     "CustomNodeBase",
     # UI Components & Layout
     "Section",
+    "VisibleWhen",
     "TextInput",
     "NumericInput",
     "SliderInput",

--- a/shared/node_designer/custom_node.py
+++ b/shared/node_designer/custom_node.py
@@ -15,6 +15,7 @@ from shared.node_designer.ui_components import (
     IncomingColumns,
     SecretSelector,
     Section,
+    VisibleWhen,
 )
 
 if TYPE_CHECKING:
@@ -88,7 +89,9 @@ def _convert_value(value: Any) -> Any:
     Helper function to convert any value to a frontend-ready format.
     """
     if isinstance(value, Section):
-        section_data = value.model_dump(include={"title", "description", "hidden", "layout"}, exclude_none=True)
+        section_data = value.model_dump(
+            include={"title", "description", "hidden", "visible_when", "layout"}, exclude_none=True
+        )
         section_data["component_type"] = "Section"
         section_data["components"] = {key: _convert_value(comp) for key, comp in value.get_components().items()}
         return section_data
@@ -341,8 +344,11 @@ class SectionBuilder:
         description: str | None = None,
         hidden: bool = False,
         layout: Literal["vertical", "horizontal"] = "vertical",
+        visible_when: VisibleWhen | dict | None = None,
     ):
-        self._section = Section(title=title, description=description, hidden=hidden, layout=layout)
+        self._section = Section(
+            title=title, description=description, hidden=hidden, layout=layout, visible_when=visible_when
+        )
 
     def add_component(self, name: str, component: FlowfileInComponent) -> "SectionBuilder":
         """Add a component to the section."""

--- a/shared/node_designer/ui_components.py
+++ b/shared/node_designer/ui_components.py
@@ -251,6 +251,22 @@ class MultiSelect(FlowfileInComponent):
             self.value = self.default if self.default else []
 
 
+class VisibleWhen(BaseModel):
+    """
+    Conditional-visibility rule for a `Section`.
+
+    `field` is a dotted ``"<section>.<toggle>"`` reference to a `ToggleSwitch`;
+    the owning section is shown only while that toggle's value equals `equals`.
+
+    Example:
+        VisibleWhen(field="main.show_advanced")            # show when the toggle is on
+        VisibleWhen(field="main.show_advanced", equals=False)  # show when it is off
+    """
+
+    field: str
+    equals: bool = True
+
+
 class Section(BaseModel):
     """
     A container for grouping related UI components in the node settings panel.
@@ -265,11 +281,19 @@ class Section(BaseModel):
             description="Configure the primary behavior of the node.",
             my_text_input=TextInput(label="Enter a value")
         )
+
+    Set `visible_when` to reveal the section only while a boolean toggle is set:
+        advanced = Section(
+            title="Advanced",
+            visible_when=VisibleWhen(field="main.enable_advanced"),  # equals defaults to True
+            timeout=NumericInput(label="Timeout (s)"),
+        )
     """
 
     title: str | None = None
     description: str | None = None
     hidden: bool = False
+    visible_when: VisibleWhen | None = None
     layout: Literal["vertical", "horizontal"] = "vertical"
 
     class Config:
@@ -309,7 +333,7 @@ class Section(BaseModel):
                 components[key] = value
 
         for field_name in self.model_fields:
-            if field_name not in {"title", "description", "hidden", "layout"}:
+            if field_name not in {"title", "description", "hidden", "visible_when", "layout"}:
                 value = getattr(self, field_name, None)
                 if isinstance(value, FlowfileInComponent):
                     components[field_name] = value


### PR DESCRIPTION
This pull request introduces a new `visible_when` feature for section components in the Node Designer, allowing sections to be conditionally shown or hidden based on the value of a referenced toggle field. This conditional visibility is supported end-to-end: in the Python backend (schema, parsing, codegen), the frontend schema, and the Vue renderer, with comprehensive tests for all behaviors.

**Conditional Section Visibility (visible_when):**

* Python backend:
  - Added the `VisibleWhenState` model and `visible_when` attribute to `SectionState`, supporting both direct and dict-based specification, with validation and normalization in parsing. [[1]](diffhunk://#diff-5b7edafc85db151ef8f328e1d905953ace45a9266dd63bee680baefbda663ea8R108-R118) [[2]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beR495) [[3]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beL488-R508) [[4]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beR523-R533) [[5]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beL525-R562)
  - Updated code generation to emit `visible_when=nd.VisibleWhen(...)` and parsing to support round-tripping and code normalization. [[1]](diffhunk://#diff-826ae291600f7e32c92928188c4179ef5857f24232aa9e55c3c78ab31203e5b3L288-R316) [[2]](diffhunk://#diff-826ae291600f7e32c92928188c4179ef5857f24232aa9e55c3c78ab31203e5b3R31) [[3]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beL443-R447) [[4]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beR466-R481)
  - Exposed `VisibleWhen` in the public API and added a corpus example node using conditional sections. [[1]](diffhunk://#diff-7dff95a644b34eae0f27de733fde94a096d5bffe3ab6ae3f6118b7e70e155873R37) [[2]](diffhunk://#diff-7dff95a644b34eae0f27de733fde94a096d5bffe3ab6ae3f6118b7e70e155873R48) [[3]](diffhunk://#diff-841cfaf13635e0dbba91e50c5459442b4109266b649220db00e431378579c132R1-R43)

* Frontend schema and rendering:
  - Extended the `SectionComponent` interface to include an optional `visible_when` property, and added the corresponding TypeScript type.
  - Updated the Vue form renderer to conditionally display sections using the new `isSectionVisible` utility, which implements fail-open logic for missing or malformed references. [[1]](diffhunk://#diff-6dcf9b5df5dc3ffb2650f7847a0e25dbbc0e931ac36b33d83e904908b98682daL4-R4) [[2]](diffhunk://#diff-6dcf9b5df5dc3ffb2650f7847a0e25dbbc0e931ac36b33d83e904908b98682daR122) [[3]](diffhunk://#diff-4f640e56dd7461f73ac2e826c6cf041a9af946ccefe030bdc5c6b40a68943c64R1-R17)
  - Added comprehensive unit tests for `isSectionVisible`.

* Testing:
  - Added backend and frontend tests for parsing, codegen round-trip, schema serialization, and UI behavior for the new feature, including edge cases and normalization. [[1]](diffhunk://#diff-6209e755b75ba1d0aaf7303b7c3566af0f12e643bb23da4c30b84cc72beb3347R271-R293) [[2]](diffhunk://#diff-47dab521b98afbc3fa6f4c78afe38a9f0a39640e81d56a216f086cc070939d76R359-R403) [[3]](diffhunk://#diff-1a9046ef23651ca3df2ecfe431bbcb69e1a142595f18e1ae6ef1eaf1dfc7fc9dR189-R204)

**Other:**

* Removed a stray separator in the `README.md`.

These changes enable authoring and rendering of sections that are only visible when a referenced toggle is set, improving the expressiveness and usability of custom node forms.