### PR TITLE
Add artifacts as selectable in custom nodes

### DIFF
--- a/docs/for-developers/kernel-architecture.md
+++ b/docs/for-developers/kernel-architecture.md
@@ -77,14 +77,14 @@ Flowfile does **not** define compatibility *ranges* between app and kernel versi
 | Version | Where | Role |
 |---------|-------|------|
 | App / root | root `pyproject.toml` `version` | The Flowfile release |
-| Kernel **image** tag | `flowfile_core/flowfile_core/kernel/manager.py` (`_KERNEL_IMAGE_{BASE,ML,LITE}_DEFAULT`, `0.4.0` as of 2026-07) | The image the app pulls / runs |
+| Kernel **image** tag | `flowfile_core/flowfile_core/kernel/manager.py` (`_KERNEL_IMAGE_{BASE,ML,LITE}_DEFAULT`, `0.5.0` as of 2026-07) | The image the app pulls / runs |
 | Kernel **runtime API** | `kernel_runtime/__init__.py` (`__version__`) | The kernel's HTTP API version, reported by `/health` |
 
 Read each value from its source rather than assuming a number — the three are decoupled. They evolve **independently**: bumping the app does not require bumping the kernel image, and vice versa.
 
 ### How the pin works
 
-- Each Flowfile version hardcodes **one exact kernel tag per flavour** (e.g. `edwardvaneechoud/flowfile-kernel-ml:0.4.0`) in `manager.py`. That single tag — not a `>=x,<y` range — is the version the app is built and tested against.
+- Each Flowfile version hardcodes **one exact kernel tag per flavour** (e.g. `edwardvaneechoud/flowfile-kernel-ml:0.5.0`) in `manager.py`. That single tag — not a `>=x,<y` range — is the version the app is built and tested against.
 - Core reads the running kernel's runtime version from `/health` into `KernelInfo.kernel_version` **for display only** (the "Kernel runtime" line in the Kernel Manager). There is no min/max gate and nothing that rejects or warns about an "out-of-range" kernel.
 - The only **hard** coupling is **polars**: `kernel_runtime` pins a polars (and the `polars-ds` plugin) compatible with the app's `polars >=1.8.2,<1.40`. These must be bumped together, but that compatibility is guaranteed at *image-build time* via the pinned tag — not by a runtime check.
 

--- a/flowfile_core/flowfile_core/flowfile/artifacts.py
+++ b/flowfile_core/flowfile_core/flowfile/artifacts.py
@@ -449,3 +449,44 @@ class ArtifactContext:
         if node_id not in self._node_states:
             self._node_states[node_id] = NodeArtifactState()
         return self._node_states[node_id]
+
+
+def merge_declared_artifacts(
+    observed: dict[str, ArtifactRef],
+    declared: list[tuple[int, str, str | None]],
+    kernel_id: str,
+) -> list[dict[str, Any]]:
+    """Merge run-observed artifact refs with manifest-declared publishes.
+
+    ``declared`` entries are ``(source_node_id, name, type)`` tuples where
+    ``type`` is a dotted qualname (``"sklearn.ensemble.RandomForest"``), a bare
+    name, or ``None``.  Observed refs win on name conflict; declared entries
+    only fill in names that were never published this run (``status`` field
+    distinguishes ``"published"`` from ``"declared"``).  Declared-vs-declared
+    duplicate names: first entry wins.  Pure — writes no ArtifactContext state.
+    """
+    result: list[dict[str, Any]] = []
+    seen: set[str] = set(observed)
+    for ref in observed.values():
+        result.append({**ref.to_dict(), "status": "published"})
+    for source_node_id, name, type_ in declared:
+        if name in seen:
+            continue
+        seen.add(name)
+        if type_:
+            module, _, type_name = type_.rpartition(".")
+        else:
+            module, type_name = "", ""
+        result.append(
+            {
+                "name": name,
+                "source_node_id": source_node_id,
+                "kernel_id": kernel_id,
+                "type_name": type_name,
+                "module": module,
+                "size_bytes": 0,
+                "created_at": None,
+                "status": "declared",
+            }
+        )
+    return result

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -2067,6 +2067,7 @@ class FlowGraph:
         code: str,
         output_names: list[str],
         flow_data_engine: tuple[FlowDataEngine, ...],
+        declared_publishes: list[str] | None = None,
     ) -> FlowDataEngine | None:
         """Execute code on a kernel container and return the primary output.
 
@@ -2080,7 +2081,7 @@ class FlowGraph:
 
         self.artifact_context.clear_nodes({node_id})
 
-        self.artifact_context.compute_available(
+        available = self.artifact_context.compute_available(
             node_id=node_id,
             kernel_id=kernel_id,
             upstream_node_ids=self._get_upstream_node_ids(node_id),
@@ -2108,6 +2109,7 @@ class FlowGraph:
             flow_id=flow_id,
             manager=manager,
             source_registration_id=self._flow_settings.source_registration_id,
+            available_artifacts={name: ref.source_node_id for name, ref in available.items()},
         )
 
         cancel_event = threading.Event()
@@ -2129,7 +2131,7 @@ class FlowGraph:
             self.artifact_context.record_published(
                 node_id=node_id,
                 kernel_id=kernel_id,
-                artifacts=[{"name": n} for n in result.artifacts_published],
+                artifacts=[a.model_dump() for a in result.artifacts_published],
             )
         if result.artifacts_deleted:
             self.artifact_context.record_deleted(
@@ -2137,6 +2139,12 @@ class FlowGraph:
                 kernel_id=kernel_id,
                 artifact_names=result.artifacts_deleted,
             )
+
+        if declared_publishes:
+            observed_names = {a.name for a in result.artifacts_published}
+            for name in declared_publishes:
+                if name not in observed_names:
+                    node_logger.warning(f"Declared artifact '{name}' (in publishes) was not published in this run.")
 
         primary_result = read_kernel_outputs(output_dir=output_dir, output_names=output_names, result=result, node=node)
 
@@ -2176,6 +2184,10 @@ class FlowGraph:
         else:
             code = custom_node.generate_kernel_code()
 
+        declared_publishes: list[str] | None = None
+        if registry_entry is not None and registry_entry.manifest is not None:
+            declared_publishes = [d.name for d in registry_entry.manifest.publishes]
+
         def _func(*flow_data_engine: FlowDataEngine) -> FlowDataEngine | None:
             return self._execute_on_kernel(
                 node_id=user_defined_node_settings.node_id,
@@ -2183,6 +2195,7 @@ class FlowGraph:
                 code=code,
                 output_names=output_names,
                 flow_data_engine=flow_data_engine,
+                declared_publishes=declared_publishes,
             )
 
         return _func

--- a/flowfile_core/flowfile_core/flowfile/node_designer/__init__.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/__init__.py
@@ -10,6 +10,7 @@ spellings expose the same public surface — keep it in lockstep.
 
 from shared.node_designer import (
     ActionOption,
+    Artifact,
     AvailableArtifacts,
     AvailableSecrets,
     ColumnActionInput,
@@ -43,6 +44,7 @@ from shared.node_designer import (
 __all__ = [
     # Core Node Class
     "CustomNodeBase",
+    "Artifact",
     # UI Components & Layout
     "Section",
     "VisibleWhen",

--- a/flowfile_core/flowfile_core/flowfile/node_designer/codegen.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/codegen.py
@@ -38,6 +38,15 @@ class CodegenError(ValueError):
 
 _INDENT = "    "
 
+
+class _CallValue:
+    """A kwarg value that renders as its own exploded call (e.g. options=nd.AvailableArtifacts(...))."""
+
+    def __init__(self, callee: str, kwargs: list):
+        self.callee = callee
+        self.kwargs = kwargs
+
+
 # Component kwargs in canonical emit order. Only kwargs that differ from the
 # component's designer default are emitted; ``label`` always leads when present.
 _MARKER_FOR_OPTIONS_SOURCE = {
@@ -124,6 +133,13 @@ def _options_literal(options: list[SelectOption]) -> list[str]:
     return parts
 
 
+def _artifact_literal(decl) -> str:
+    """Render an ArtifactDecl as ``nd.Artifact("name")`` / ``nd.Artifact("name", type="...")``."""
+    if decl.type is None:
+        return f"nd.Artifact({_py_literal(decl.name)})"
+    return f"nd.Artifact({_py_literal(decl.name)}, type={_py_literal(decl.type)})"
+
+
 def _data_types_kwarg(spec) -> list[str] | None:
     """Emit ``data_types`` only when narrowed; ``"ALL"`` is the default.
 
@@ -197,7 +213,9 @@ class _Renderer:
 
     def _select_kwargs(self, comp: SelectState) -> list[tuple[str, object]]:
         kwargs: list[tuple[str, object]] = []
-        if comp.options_source in _MARKER_FOR_OPTIONS_SOURCE:
+        if comp.options_source == "available_artifacts":
+            kwargs.append(("options", self._available_artifacts_value(comp)))
+        elif comp.options_source in _MARKER_FOR_OPTIONS_SOURCE:
             kwargs.append(("options", f"nd.{_MARKER_FOR_OPTIONS_SOURCE[comp.options_source]}"))
         else:
             kwargs.append(("options", _options_literal(comp.options)))
@@ -212,6 +230,18 @@ class _Renderer:
                 )
             )
         return kwargs
+
+    def _available_artifacts_value(self, comp: SelectState) -> object:
+        # Bare marker when both params are default; an exploded call otherwise
+        # (single-line would get rewrapped by ruff and break the fixed point).
+        if comp.artifact_scope == "upstream" and not comp.artifact_type_filter:
+            return "nd.AvailableArtifacts"
+        inner: list[tuple[str, object]] = []
+        if comp.artifact_scope != "upstream":
+            inner.append(("scope", _py_literal(comp.artifact_scope)))
+        if comp.artifact_type_filter:
+            inner.append(("type", [_py_literal(t) for t in comp.artifact_type_filter]))
+        return _CallValue("nd.AvailableArtifacts", inner)
 
     def _column_action_kwargs(self, comp: ColumnActionInputState) -> list[tuple[str, str]]:
         kwargs: list[tuple[str, str]] = []
@@ -250,7 +280,12 @@ class _Renderer:
         return lines
 
     def _render_kwarg(self, key: str, value, indent: str) -> list[str]:
-        """A single ``key=value,`` line, or a multiline list for list-valued kwargs."""
+        """A single ``key=value,`` line, or a multiline block for list-/call-valued kwargs."""
+        if isinstance(value, _CallValue):
+            call_lines = self._render_call(value.callee, value.kwargs, indent)
+            lines = [f"{indent}{key}={call_lines[0]}", *call_lines[1:]]
+            lines[-1] = f"{lines[-1]},"
+            return lines
         if isinstance(value, list):
             if not value:
                 return [f"{indent}{key}=[],"]
@@ -372,6 +407,20 @@ class _Renderer:
             value_lines = _render_data_literal(value, _INDENT)
             lines.append(f"{_INDENT}{name}: {annotation} = {value_lines[0]}")
             lines.extend(value_lines[1:])
+        lines.extend(self._render_publishes())
+        return lines
+
+    def _render_publishes(self) -> list[str]:
+        # Emitted after example_settings; a dedicated emitter because these are
+        # nd.Artifact(...) calls, not JSON handled by _render_data_literal.
+        publishes = self.state.publishes
+        if not publishes:
+            return []
+        inner = _INDENT + _INDENT
+        lines = [f"{_INDENT}publishes: list[nd.Artifact] = ["]
+        for decl in publishes:
+            lines.append(f"{inner}{_artifact_literal(decl)},")
+        lines.append(f"{_INDENT}]")
         return lines
 
     def _render_node_class(self) -> list[str]:

--- a/flowfile_core/flowfile_core/flowfile/node_designer/custom_node.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/custom_node.py
@@ -1,6 +1,7 @@
 """Re-export shim — implementation moved to shared/node_designer/custom_node.py."""
 
 from shared.node_designer.custom_node import (
+    Artifact,
     CustomNodeBase,
     NodeSettings,
     NodeSettingsBuilder,
@@ -13,6 +14,7 @@ from shared.node_designer.custom_node import (
 )
 
 __all__ = [
+    "Artifact",
     "CustomNodeBase",
     "NodeSettings",
     "NodeSettingsBuilder",

--- a/flowfile_core/flowfile_core/flowfile/node_designer/parsing.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/parsing.py
@@ -14,6 +14,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from flowfile_core.flowfile.node_designer.state import (
+    ArtifactDecl,
     ColumnActionInputState,
     ColumnSelectorState,
     DesignerState,
@@ -123,6 +124,7 @@ _RECOGNIZED_NODE_ATTRS = {
     "settings_schema",
     "example_inputs",
     "example_settings",
+    "publishes",
     "requires_kernel",
     "kernel_id",
 }
@@ -135,8 +137,10 @@ _SCALARS = (str, int, float, bool, type(None))
 
 
 class _Marker:
-    def __init__(self, name: str):
+    def __init__(self, name: str, scope: str = "upstream", type_filter: list[str] | None = None):
         self.name = name
+        self.scope = scope
+        self.type_filter = type_filter
 
 
 class _LiteralError(Exception):
@@ -445,6 +449,8 @@ class _SourceParser:
                 return self._eval_action_option(node)
             if func_symbol == "VisibleWhen":
                 return self._eval_visible_when(node)
+            if func_symbol == "AvailableArtifacts":
+                return self._eval_available_artifacts(node)
             raise _LiteralError(node, f"call '{ast.unparse(node.func)}(...)' is not a designer literal")
         raise _LiteralError(node, f"'{ast.unparse(node)}' is not a designer literal")
 
@@ -478,6 +484,37 @@ class _SourceParser:
         if not isinstance(values.get("field"), str):
             raise _LiteralError(call, "VisibleWhen field must be a string")
         return values
+
+    def _eval_available_artifacts(self, call: ast.Call) -> _Marker:
+        values: dict[str, Any] = {}
+        positional = ["scope", "type"]
+        if len(call.args) > 2:
+            raise _LiteralError(call, "AvailableArtifacts takes (scope, type)")
+        for i, arg in enumerate(call.args):
+            values[positional[i]] = self.eval_literal(arg)
+        for kw in call.keywords:
+            if kw.arg not in ("scope", "type"):
+                raise _LiteralError(call, "AvailableArtifacts only accepts scope and type")
+            values[kw.arg] = self.eval_literal(kw.value)
+        scope = values.get("scope", "upstream")
+        if scope not in ("upstream", "global", "all"):
+            raise _LiteralError(call, "AvailableArtifacts scope must be 'upstream', 'global' or 'all'")
+        type_filter = self._normalize_artifact_type_filter(values.get("type"), call)
+        return _Marker("AvailableArtifacts", scope=scope, type_filter=type_filter)
+
+    def _normalize_artifact_type_filter(self, value: Any, node: ast.expr) -> list[str] | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            items = [value]
+        elif isinstance(value, tuple | list):
+            items = list(value)
+        else:
+            raise _LiteralError(node, "AvailableArtifacts type must be a string or list of strings")
+        if not all(isinstance(v, str) for v in items):
+            raise _LiteralError(node, "AvailableArtifacts type must be strings")
+        result = sorted(set(items))
+        return result or None
 
     # -- component lifting -----------------------------------------------------
 
@@ -670,13 +707,22 @@ class _SourceParser:
                 **common, default=bool(kwargs.get("default", False)), description=kwargs.get("description")
             )
         if symbol in ("SingleSelect", "MultiSelect"):
-            options_source, options = self._normalize_options(kwargs.get("options"), expr)
+            default = kwargs.get("default")
+            if isinstance(default, _Marker) or (
+                isinstance(default, list | tuple) and any(isinstance(v, _Marker) for v in default)
+            ):
+                raise _LiteralError(expr, "IncomingColumns/AvailableArtifacts markers are only valid for options")
+            options_source, options, artifact_scope, artifact_type_filter = self._normalize_options(
+                kwargs.get("options"), expr
+            )
             return SelectState(
                 **common,
                 component_type=symbol,
                 options_source=options_source,
                 options=options,
-                default=self._jsonify(kwargs.get("default")),
+                default=self._jsonify(default),
+                artifact_scope=artifact_scope,
+                artifact_type_filter=artifact_type_filter,
             )
         if symbol == "ColumnSelector":
             return ColumnSelectorState(
@@ -708,16 +754,16 @@ class _SourceParser:
             **state,
         )
 
-    def _normalize_options(self, value: Any, expr: ast.expr) -> tuple[str, list[SelectOption]]:
+    def _normalize_options(self, value: Any, expr: ast.expr) -> tuple[str, list[SelectOption], str, list[str]]:
         if value is None:
-            return "static", []
+            return "static", [], "upstream", []
         if isinstance(value, _Marker):
             if value.name == "IncomingColumns":
-                return "incoming_columns", []
+                return "incoming_columns", [], "upstream", []
             if value.name == "AvailableArtifacts":
-                return "available_artifacts", []
+                return "available_artifacts", [], value.scope, list(value.type_filter or [])
             raise _LiteralError(expr, f"'{value.name}' is not valid for options")
-        return "static", self._normalize_select_items(value, expr, kind="options")
+        return "static", self._normalize_select_items(value, expr, kind="options"), "upstream", []
 
     def _normalize_select_items(self, value: Any, expr: ast.expr, *, kind: str) -> list[SelectOption]:
         if isinstance(value, tuple):
@@ -816,6 +862,8 @@ class _SourceParser:
             state_kwargs["example_inputs"] = lifted["example_inputs"]
         if "example_settings" in lifted:
             state_kwargs["example_settings"] = lifted["example_settings"]
+        if lifted.get("publishes"):
+            state_kwargs["publishes"] = lifted["publishes"]
 
         try:
             return DesignerState(**state_kwargs)
@@ -832,6 +880,9 @@ class _SourceParser:
                 continue
             if name == "example_inputs":
                 lifted[name] = self._lift_example_inputs(value)
+                continue
+            if name == "publishes":
+                lifted[name] = self._lift_publishes(value)
                 continue
             try:
                 evaluated = self.eval_literal(value)
@@ -940,6 +991,76 @@ class _SourceParser:
                 data[column] = values
             examples.append(ExampleInput(data=data))
         return examples
+
+    def _lift_publishes(self, node: ast.expr) -> Any:
+        if isinstance(node, ast.List | ast.Tuple):
+            elts = list(node.elts)
+        else:
+            self.error(
+                ParseIssueCode.NON_LITERAL_ATTR,
+                "'publishes' must be a list of nd.Artifact(...) calls or strings",
+                node,
+            )
+            return _INVALID
+        decls: list[ArtifactDecl] = []
+        for elt in elts:
+            decl = self._lift_publish_entry(elt)
+            if decl is None:
+                return _INVALID
+            decls.append(decl)
+        return decls
+
+    def _resolves_to_artifact(self, func: ast.expr) -> bool:
+        if self.resolve_symbol(func) == "Artifact":
+            return True
+        dotted = _dotted(func)
+        return dotted is not None and dotted.split(".")[-1] == "Artifact"
+
+    def _lift_publish_entry(self, node: ast.expr) -> ArtifactDecl | None:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return ArtifactDecl(name=node.value)
+        if isinstance(node, ast.Call) and self._resolves_to_artifact(node.func):
+            return self._lift_artifact_call(node)
+        self.error(
+            ParseIssueCode.NON_LITERAL_ATTR,
+            "'publishes' entries must be nd.Artifact(...) calls or string literals",
+            node,
+        )
+        return None
+
+    def _lift_artifact_call(self, call: ast.Call) -> ArtifactDecl | None:
+        name: str | None = None
+        type_value: str | None = None
+        if len(call.args) > 1:
+            self.error(ParseIssueCode.NON_LITERAL_ATTR, "Artifact takes (name, type=...)", call)
+            return None
+        if call.args:
+            arg0 = call.args[0]
+            if not (isinstance(arg0, ast.Constant) and isinstance(arg0.value, str)):
+                self.error(ParseIssueCode.NON_LITERAL_ATTR, "Artifact name must be a string literal", call)
+                return None
+            name = arg0.value
+        for kw in call.keywords:
+            if kw.arg == "name":
+                if not (isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str)):
+                    self.error(ParseIssueCode.NON_LITERAL_ATTR, "Artifact name must be a string literal", call)
+                    return None
+                name = kw.value.value
+            elif kw.arg == "type":
+                if isinstance(kw.value, ast.Constant) and kw.value.value is None:
+                    type_value = None
+                elif isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                    type_value = kw.value.value
+                else:
+                    self.error(ParseIssueCode.NON_LITERAL_ATTR, "Artifact type must be a string literal", call)
+                    return None
+            else:
+                self.error(ParseIssueCode.NON_LITERAL_ATTR, f"Artifact got unexpected argument '{kw.arg}'", call)
+                return None
+        if name is None:
+            self.error(ParseIssueCode.NON_LITERAL_ATTR, "Artifact requires a name", call)
+            return None
+        return ArtifactDecl(name=name, type=type_value)
 
     def _is_plain_json(self, value: Any) -> bool:
         if isinstance(value, _SCALARS):
@@ -1248,6 +1369,34 @@ def _node_classdefs(module: ast.Module) -> list[ast.ClassDef]:
     ]
 
 
+def _best_effort_publishes(value: ast.expr) -> list[ArtifactDecl]:
+    """Lift a ``publishes`` list literal to ArtifactDecls, skipping anything malformed."""
+    decls: list[ArtifactDecl] = []
+    if not isinstance(value, ast.List | ast.Tuple):
+        return decls
+    for elt in value.elts:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            decls.append(ArtifactDecl(name=elt.value))
+            continue
+        if not isinstance(elt, ast.Call):
+            continue
+        dotted = _dotted(elt.func)
+        if dotted is None or dotted.split(".")[-1] != "Artifact":
+            continue
+        name: str | None = None
+        type_value: str | None = None
+        if elt.args and isinstance(elt.args[0], ast.Constant) and isinstance(elt.args[0].value, str):
+            name = elt.args[0].value
+        for kw in elt.keywords:
+            if kw.arg == "name" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                name = kw.value.value
+            elif kw.arg == "type" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                type_value = kw.value.value
+        if name is not None:
+            decls.append(ArtifactDecl(name=name, type=type_value))
+    return decls
+
+
 def extract_manifest(source: str) -> NodeManifest:
     """Best-effort exec-free listing metadata; never raises."""
     try:
@@ -1261,12 +1410,16 @@ def extract_manifest(source: str) -> NodeManifest:
         node_cls = classes[0]
 
         attrs: dict[str, Any] = {}
+        publishes: list[ArtifactDecl] = []
         for stmt in node_cls.body:
             if isinstance(stmt, ast.Assign) and len(stmt.targets) == 1 and isinstance(stmt.targets[0], ast.Name):
                 target, value = stmt.targets[0].id, stmt.value
             elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name) and stmt.value is not None:
                 target, value = stmt.target.id, stmt.value
             else:
+                continue
+            if target == "publishes":
+                publishes = _best_effort_publishes(value)
                 continue
             try:
                 attrs[target] = ast.literal_eval(value)
@@ -1308,6 +1461,8 @@ def extract_manifest(source: str) -> NodeManifest:
             manifest_kwargs["node_type"] = attrs["node_type"]
         if attrs.get("transform_type") in ("narrow", "wide", "other"):
             manifest_kwargs["transform_type"] = attrs["transform_type"]
+        if publishes:
+            manifest_kwargs["publishes"] = publishes
         return NodeManifest(**manifest_kwargs)
     except Exception:
         return NodeManifest()

--- a/flowfile_core/flowfile_core/flowfile/node_designer/state.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/state.py
@@ -8,7 +8,7 @@ flowfile_frontend/src/renderer/app/pages/nodeDesigner/designerState.ts).
 import keyword
 from typing import Annotated, Any, Literal
 
-from pydantic import AfterValidator, BaseModel, Field
+from pydantic import AfterValidator, BaseModel, Field, model_validator
 
 DESIGNER_STATE_VERSION = 1
 
@@ -67,6 +67,21 @@ class SelectState(_ComponentBase):
     options_source: Literal["static", "incoming_columns", "available_artifacts"] = "static"
     options: list[SelectOption] = []  # only when static
     default: Any | None = None  # list for MultiSelect
+    artifact_scope: Literal["upstream", "global", "all"] = "upstream"  # only when available_artifacts
+    artifact_type_filter: list[str] = []  # only when available_artifacts
+
+    @model_validator(mode="after")
+    def _clear_artifact_fields_off_source(self) -> "SelectState":
+        # Codegen only emits these for the available_artifacts source; reset them
+        # otherwise so parse can't lose them and the fixed point stays exact.
+        # On-source, canonicalize the filter (sorted-unique) so a frontend-authored
+        # state converges to the same byte-identical fixed point the parser produces.
+        if self.options_source != "available_artifacts":
+            self.artifact_scope = "upstream"
+            self.artifact_type_filter = []
+        else:
+            self.artifact_type_filter = sorted(set(self.artifact_type_filter))
+        return self
 
 
 class ColumnSelectorState(_ComponentBase):
@@ -130,6 +145,11 @@ class ExampleInput(BaseModel):
     data: dict[str, list[Any]]  # column -> JSON-scalar values
 
 
+class ArtifactDecl(BaseModel):
+    name: str
+    type: str | None = None
+
+
 class DesignerState(BaseModel):
     schema_version: Literal[1] = 1
     class_name: PyIdentifier
@@ -154,6 +174,7 @@ class DesignerState(BaseModel):
     extra_imports: list[str] = []  # verbatim statements, order preserved
     module_extra: list[str] = []  # verbatim module-level blocks, order preserved
     class_extra: list[str] = []  # verbatim class members, order preserved
+    publishes: list[ArtifactDecl] = []  # artifacts the node declares it publishes
 
 
 class ParseIssue(BaseModel):
@@ -188,3 +209,4 @@ class NodeManifest(BaseModel):
     environment: EnvironmentState = EnvironmentState()
     node_type: Literal["input", "output", "process"] = "process"
     transform_type: Literal["narrow", "wide", "other"] = "wide"
+    publishes: list[ArtifactDecl] = []

--- a/flowfile_core/flowfile_core/flowfile/user_defined/dry_run.py
+++ b/flowfile_core/flowfile_core/flowfile/user_defined/dry_run.py
@@ -471,6 +471,21 @@ def _read_kernel_output_previews(
     return outputs, None
 
 
+def _build_dry_run_execute_request(**kwargs):
+    """Build the kernel ExecuteRequest for a dry run with log streaming disabled.
+
+    Production runs stream ``flowfile_ctx.log()`` to core's ``/raw_logs`` flow
+    logger, but the Test tab only surfaces captured stdout/stderr. Blanking the
+    callback URL makes ``log()`` fall back to ``print()`` so its output lands in
+    stdout the tab already renders.
+    """
+    from flowfile_core.kernel.execution import build_execute_request
+
+    request = build_execute_request(**kwargs)
+    request.log_callback_url = ""
+    return request
+
+
 def _run_dry_run_on_kernel(
     request: DryRunRequest, source: str, output_names: list[str], samples: list[RawData]
 ) -> DryRunResponse:
@@ -483,7 +498,7 @@ def _run_dry_run_on_kernel(
     from flowfile_core.flowfile.flow_data_engine.flow_data_engine import FlowDataEngine
     from flowfile_core.flowfile.user_defined.kernel_codegen import KernelCodegenError, generate_kernel_script
     from flowfile_core.kernel import get_kernel_manager
-    from flowfile_core.kernel.execution import build_execute_request, clear_stale_parquets, write_inputs_to_parquet
+    from flowfile_core.kernel.execution import clear_stale_parquets, write_inputs_to_parquet
 
     if request.designer_state is not None:
         class_name = request.designer_state.class_name
@@ -523,7 +538,7 @@ def _run_dry_run_on_kernel(
     started = time.monotonic()
     try:
         input_paths = write_inputs_to_parquet(frames, manager, input_dir, _DRY_RUN_FLOW_ID, node_id)
-        execute_request = build_execute_request(
+        execute_request = _build_dry_run_execute_request(
             node_id=node_id,
             code=code,
             input_paths=input_paths,

--- a/flowfile_core/flowfile_core/flowfile/user_defined/templates.py
+++ b/flowfile_core/flowfile_core/flowfile/user_defined/templates.py
@@ -33,4 +33,5 @@ def manifest_to_template(manifest: NodeManifest, node_key: str) -> "NodeTemplate
         custom_node=True,
         execution_environment=manifest.environment.kind,
         dependencies=list(manifest.environment.dependencies) or None,
+        publishes=list(manifest.publishes) or None,
     )

--- a/flowfile_core/flowfile_core/kernel/execution.py
+++ b/flowfile_core/flowfile_core/kernel/execution.py
@@ -142,6 +142,7 @@ def build_execute_request(
     flow_id: int,
     manager: KernelManager,
     source_registration_id: int | None,
+    available_artifacts: dict[str, int] | None = None,
 ) -> ExecuteRequest:
     """Assemble the kernel ExecuteRequest with log callback URL and auth token."""
     if manager._kernel_volume:
@@ -166,6 +167,7 @@ def build_execute_request(
         source_registration_id=source_registration_id,
         log_callback_url=log_callback_url,
         internal_token=internal_token,
+        available_artifacts=available_artifacts,
     )
 
 

--- a/flowfile_core/flowfile_core/kernel/manager.py
+++ b/flowfile_core/flowfile_core/kernel/manager.py
@@ -35,9 +35,9 @@ from shared.storage_config import storage
 
 logger = logging.getLogger(__name__)
 
-_KERNEL_IMAGE_BASE_DEFAULT = "edwardvaneechoud/flowfile-kernel-base:0.4.0"
-_KERNEL_IMAGE_ML_DEFAULT = "edwardvaneechoud/flowfile-kernel-ml:0.4.0"
-_KERNEL_IMAGE_LITE_DEFAULT = "edwardvaneechoud/flowfile-kernel-lite:0.4.0"
+_KERNEL_IMAGE_BASE_DEFAULT = "edwardvaneechoud/flowfile-kernel-base:0.5.0"
+_KERNEL_IMAGE_ML_DEFAULT = "edwardvaneechoud/flowfile-kernel-ml:0.5.0"
+_KERNEL_IMAGE_LITE_DEFAULT = "edwardvaneechoud/flowfile-kernel-lite:0.5.0"
 
 _KERNEL_DOWN_MSG = (
     "Kernel is not running — its container was stopped or removed (often after a "

--- a/flowfile_core/flowfile_core/kernel/models.py
+++ b/flowfile_core/flowfile_core/kernel/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class KernelState(str, Enum):
@@ -128,6 +128,9 @@ class ExecuteRequest(BaseModel):
     log_callback_url: str = ""
     interactive: bool = False  # When True, auto-display last expression
     internal_token: str | None = None  # Core→kernel auth token for artifact API calls
+    # Artifact name → source node id lineage allowlist. None ⇒ no lineage context
+    # (no enforcement); {} ⇒ lineage known, nothing available.
+    available_artifacts: dict[str, int] | None = None
 
 
 class ClearNodeArtifactsRequest(BaseModel):
@@ -152,16 +155,34 @@ class DisplayOutput(BaseModel):
     title: str = ""
 
 
+class PublishedArtifact(BaseModel):
+    """Metadata for an artifact a kernel node published during a run."""
+
+    name: str
+    type_name: str = ""
+    module: str = ""
+    size_bytes: int = 0
+
+
 class ExecuteResult(BaseModel):
     success: bool
     output_paths: list[str] = Field(default_factory=list)
-    artifacts_published: list[str] = Field(default_factory=list)
+    artifacts_published: list[PublishedArtifact] = Field(default_factory=list)
     artifacts_deleted: list[str] = Field(default_factory=list)
     display_outputs: list[DisplayOutput] = Field(default_factory=list)
     stdout: str = ""
     stderr: str = ""
     error: str | None = None
     execution_time_ms: float = 0.0
+
+    @field_validator("artifacts_published", mode="before")
+    @classmethod
+    def _normalize_published(cls, value):
+        # Stale 0.4.0 kernel images emit plain name strings; map them to the rich
+        # shape so they degrade to names-only instead of a validation error.
+        if not isinstance(value, list):
+            return value
+        return [{"name": item} if isinstance(item, str) else item for item in value]
 
 
 # Artifact Persistence & Recovery models

--- a/flowfile_core/flowfile_core/routes/routes.py
+++ b/flowfile_core/flowfile_core/routes/routes.py
@@ -42,6 +42,7 @@ from flowfile_core.fileExplorer.funcs import (
     validate_path_under_cwd,
 )
 from flowfile_core.flowfile.analytics.analytics_processor import AnalyticsProcessor
+from flowfile_core.flowfile.artifacts import merge_declared_artifacts
 from flowfile_core.flowfile.catalog_helpers import (
     FlowNameNamespaceCollision,
     FlowPathNamespaceCollision,
@@ -86,6 +87,7 @@ from flowfile_core.flowfile.sources.external_sources.sql_source.sql_source impor
     create_engine_from_db_settings,
     create_sql_source_from_db_settings,
 )
+from flowfile_core.flowfile.user_defined.registry import registry as user_defined_registry
 from flowfile_core.routes._connection_sharing import (
     authorize_connection_mutation,
     changed_target_fields,
@@ -1049,9 +1051,7 @@ def create_flow(
                 status_code=409,
                 detail=f"Flow path {flow_path} is already registered in another namespace",
             )
-    flow_id = flow_file_handler.add_flow(
-        name=name, flow_path=flow_path, user_id=user_id, persist=register_in_catalog
-    )
+    flow_id = flow_file_handler.add_flow(name=name, flow_path=flow_path, user_id=user_id, persist=register_in_catalog)
     flow = flow_file_handler.get_flow(flow_id)
     if register_in_catalog and flow and flow.flow_settings:
         try:
@@ -1285,9 +1285,7 @@ def get_node_list() -> list[schemas.NodeTemplate]:
     if not overrides:
         return nodes_list
     return [
-        node.model_copy(update={"image": overrides[node.item]})
-        if node.custom_node and node.item in overrides
-        else node
+        node.model_copy(update={"image": overrides[node.item]}) if node.custom_node and node.item in overrides else node
         for node in nodes_list
     ]
 
@@ -1930,11 +1928,28 @@ def get_node_upstream_ids(flow_id: int, node_id: int):
     return {"upstream_node_ids": flow._get_upstream_node_ids(node_id)}
 
 
+def _resolve_node_kernel_id(node) -> str | None:
+    """Resolve a node's kernel binding via the setting/python_script/manifest ladder."""
+    kid = getattr(node.setting_input, "kernel_id", None)
+    if kid:
+        return kid
+    kid = getattr(getattr(node.setting_input, "python_script_input", None), "kernel_id", None)
+    if kid:
+        return kid
+    entry = user_defined_registry.get(node.node_type)
+    if entry is not None and entry.manifest is not None:
+        return entry.manifest.environment.default_kernel_id
+    return None
+
+
 @router.get("/flow/node_available_artifacts", tags=["editor"])
 def get_node_available_artifacts(flow_id: int, node_id: int, kernel_id: str | None = None):
     """Return available artifact metadata for a node.
 
-    Used by the frontend to populate artifact selector UI components.
+    Merges run-observed artifacts (published in a prior run) with artifacts
+    upstream kernel nodes *declare* they publish (from their manifests), so the
+    frontend's artifact pickers work before the flow has ever run. Observed
+    wins on name conflict.
     """
     flow = flow_file_handler.get_flow(flow_id)
     if flow is None:
@@ -1942,17 +1957,34 @@ def get_node_available_artifacts(flow_id: int, node_id: int, kernel_id: str | No
     node = flow.get_node(node_id)
     if node is None:
         raise HTTPException(404, "Could not find the node")
-    resolved_kernel_id = kernel_id or getattr(node.setting_input, "kernel_id", None)
+    resolved_kernel_id = kernel_id or _resolve_node_kernel_id(node)
     if not resolved_kernel_id:
         return {"artifacts": []}
 
     upstream_ids = flow._get_upstream_node_ids(node_id)
-    available = flow.artifact_context.compute_available(
+    observed = flow.artifact_context.compute_available(
         node_id=node_id,
         kernel_id=resolved_kernel_id,
         upstream_node_ids=upstream_ids,
     )
-    return {"artifacts": [ref.to_dict() for ref in available.values()]}
+
+    declared: list[tuple[int, str, str | None]] = []
+    for uid in upstream_ids:
+        up = flow.get_node(uid)
+        if up is None:
+            continue
+        entry = user_defined_registry.get(up.node_type)
+        if entry is None or entry.manifest is None:
+            continue
+        manifest = entry.manifest
+        if manifest.environment.kind != "kernel" or not manifest.publishes:
+            continue
+        if _resolve_node_kernel_id(up) != resolved_kernel_id:
+            continue
+        for decl in manifest.publishes:
+            declared.append((uid, decl.name, decl.type))
+
+    return {"artifacts": merge_declared_artifacts(observed, declared, resolved_kernel_id)}
 
 
 @router.get("/analysis_data/graphic_walker_input", tags=["analysis"], response_model=input_schema.NodeExploreData)

--- a/flowfile_core/flowfile_core/routes/user_defined_components.py
+++ b/flowfile_core/flowfile_core/routes/user_defined_components.py
@@ -17,8 +17,14 @@ from flowfile_core.flowfile.node_designer.codegen import CodegenError, generate_
 from flowfile_core.flowfile.node_designer.parsing import extract_manifest, parse_source
 from flowfile_core.flowfile.node_designer.state import DesignerState, ParseResult
 from flowfile_core.flowfile.user_defined.dry_run import DryRunRequest, DryRunResponse, run_dry_run
-from flowfile_core.flowfile.user_defined.registry import KernelRequiredError, LoadedNode, registry
+from flowfile_core.flowfile.user_defined.registry import (
+    KernelRequiredError,
+    LoadedNode,
+    compute_node_key,
+    registry,
+)
 from flowfile_core.schemas import input_schema
+from flowfile_core.schemas.schemas import NODE_TYPE_TO_SETTINGS_CLASS
 from flowfile_core.utils.utils import camel_case_to_snake_case
 from shared import storage
 
@@ -227,6 +233,32 @@ def _render_save_source(request: SaveCustomNodeRequest) -> str:
     return request.code
 
 
+def _reject_builtin_key_collision(source: str) -> None:
+    """Refuse a new save whose node key collides with a built-in node type.
+
+    Built-in types own the same keys in the type->schema mapping; a custom node
+    sharing one breaks flow deserialization. Only new saves/renames are guarded
+    here — existing colliding installs still load (parse-time resolution handles
+    them). Exec-free: the name comes from the AST manifest.
+    """
+    node_name = extract_manifest(source).node_name
+    if not node_name:
+        return
+    node_key = compute_node_key(node_name)
+    if node_key in NODE_TYPE_TO_SETTINGS_CLASS:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_code": "BUILTIN_NODE_KEY_COLLISION",
+                "error": (
+                    f"'{node_name}' resolves to node key '{node_key}', which is a built-in "
+                    "Flowfile node type. Rename the node so its key doesn't collide."
+                ),
+                "node_key": node_key,
+            },
+        )
+
+
 @router.post("/save-custom-node", summary="Save a custom node definition")
 def save_custom_node(request: SaveCustomNodeRequest, current_user=Depends(get_current_active_user)):
     """Write a custom node .py file and hot-register it (AST-only — no exec at save).
@@ -239,6 +271,7 @@ def save_custom_node(request: SaveCustomNodeRequest, current_user=Depends(get_cu
     """
     safe_name = _safe_file_name(request.file_name)
     source = _render_save_source(request)
+    _reject_builtin_key_collision(source)
 
     nodes_dir = storage.user_defined_nodes_directory
     file_path = nodes_dir / safe_name

--- a/flowfile_core/flowfile_core/schemas/schemas.py
+++ b/flowfile_core/flowfile_core/schemas/schemas.py
@@ -11,6 +11,7 @@ from pydantic import (
 )
 
 from flowfile_core.configs.settings import OFFLOAD_TO_WORKER
+from flowfile_core.flowfile.node_designer.state import ArtifactDecl
 from flowfile_core.flowfile.param_types import FlowParameter  # noqa: F401 - re-exported; historical home
 from flowfile_core.flowfile.utils import create_unique_id
 from flowfile_core.schemas import input_schema
@@ -104,12 +105,18 @@ def get_settings_class_for_node_type(node_type: str, setting_data: dict | None =
     referencing a custom node that is missing from the store still resolve to
     ``UserDefinedNode`` instead of failing as an unknown type.
     """
+    # A user-defined node whose key collides with a built-in type must still
+    # resolve to UserDefinedNode. Built-in schemas drop ``is_user_defined`` on
+    # serialization, so a truthy marker means a genuine custom node — it wins
+    # over the built-in type->schema mapping.
+    if isinstance(setting_data, dict) and setting_data.get("is_user_defined"):
+        return input_schema.UserDefinedNode
     model_class = NODE_TYPE_TO_SETTINGS_CLASS.get(node_type)
     if model_class is not None:
         return model_class
     if node_type in _get_custom_node_store():
         return input_schema.UserDefinedNode
-    if isinstance(setting_data, dict) and (setting_data.get("is_user_defined") or "settings" in setting_data):
+    if isinstance(setting_data, dict) and "settings" in setting_data:
         return input_schema.UserDefinedNode
     return None
 
@@ -623,6 +630,7 @@ class NodeTemplate(BaseModel):
     custom_node: bool | None = False
     execution_environment: str | None = None
     dependencies: list[str] | None = None
+    publishes: list[ArtifactDecl] | None = None
     laziness: LazinessLiteral = "eager"
     output_names: list[str] | None = None
     # Per-instance input handles (run_flow): connections are keyed by target

--- a/flowfile_core/tests/flowfile/node_designer/corpus/insubset_publishes.py
+++ b/flowfile_core/tests/flowfile/node_designer/corpus/insubset_publishes.py
@@ -1,0 +1,33 @@
+import polars as pl
+from flowfile import node_designer as nd
+
+
+class TrainerSettings(nd.NodeSettings):
+    main: nd.Section = nd.Section(
+        title="Model",
+        base_model=nd.SingleSelect(
+            label="Base Model",
+            options=nd.AvailableArtifacts(
+                scope="global",
+                type=[
+                    "sklearn.*",
+                ],
+            ),
+        ),
+    )
+
+
+class TrainerNode(nd.CustomNodeBase):
+    node_name: str = "Model Trainer"
+    environment: str = "kernel"
+    dependencies: list[str] = [
+        "scikit-learn>=1.4",
+    ]
+    publishes: list[nd.Artifact] = [
+        nd.Artifact("model"),
+        nd.Artifact("scaler", type="sklearn.preprocessing.StandardScaler"),
+    ]
+    settings_schema: TrainerSettings = TrainerSettings()
+
+    def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+        return inputs[0]

--- a/flowfile_core/tests/flowfile/node_designer/test_codegen.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_codegen.py
@@ -14,6 +14,7 @@ import pytest
 from flowfile_core.flowfile.node_designer.codegen import CodegenError, generate_source
 from flowfile_core.flowfile.node_designer.parsing import parse_source
 from flowfile_core.flowfile.node_designer.state import (
+    ArtifactDecl,
     ColumnSelectorState,
     DesignerState,
     EnvironmentState,
@@ -182,6 +183,121 @@ def test_incoming_columns_marker_emitted():
     src = generate_source(_minimal_state(sections=[section]))
     assert "options=nd.IncomingColumns" in src
     assert parse_source(src).designer_state.sections[0].components[0].options_source == "incoming_columns"
+
+
+def test_available_artifacts_default_emits_bare_marker():
+    section = SectionState(
+        name="main",
+        components=[SelectState(name="a", component_type="SingleSelect", options_source="available_artifacts")],
+    )
+    src = generate_source(_minimal_state(sections=[section]))
+    assert "options=nd.AvailableArtifacts," in src
+    assert "nd.AvailableArtifacts(" not in src
+    assert parse_source(src).designer_state.sections[0].components[0] == section.components[0]
+
+
+def test_available_artifacts_parametrized_emits_exploded_call():
+    section = SectionState(
+        name="main",
+        components=[
+            SelectState(
+                name="a",
+                component_type="SingleSelect",
+                options_source="available_artifacts",
+                artifact_scope="global",
+                artifact_type_filter=["sklearn.*"],
+            )
+        ],
+    )
+    src = generate_source(_minimal_state(sections=[section]))
+    assert "options=nd.AvailableArtifacts(" in src
+    assert 'scope="global",' in src
+    assert '"sklearn.*",' in src
+    # scope=="upstream" is the default and must be omitted
+    section2 = SectionState(
+        name="main",
+        components=[
+            SelectState(
+                name="a",
+                component_type="MultiSelect",
+                options_source="available_artifacts",
+                artifact_type_filter=["a.*", "b.*"],
+            )
+        ],
+    )
+    src2 = generate_source(_minimal_state(sections=[section2]))
+    assert "scope=" not in src2
+    assert parse_source(src2).designer_state.sections[0].components[0] == section2.components[0]
+
+
+def test_available_artifacts_scope_all_emits_call_form():
+    section = SectionState(
+        name="main",
+        components=[
+            SelectState(
+                name="a",
+                component_type="SingleSelect",
+                options_source="available_artifacts",
+                artifact_scope="all",
+            )
+        ],
+    )
+    src = generate_source(_minimal_state(sections=[section]))
+    assert "options=nd.AvailableArtifacts(" in src
+    assert 'scope="all",' in src
+    assert parse_source(src).designer_state.sections[0].components[0] == section.components[0]
+
+
+def test_artifact_type_filter_canonicalized_at_model_boundary():
+    # A frontend-authored state (comma-split, unsorted, duplicated) must
+    # canonicalize to sorted-unique at the pydantic boundary.
+    comp = SelectState(
+        name="a",
+        component_type="SingleSelect",
+        options_source="available_artifacts",
+        artifact_type_filter=["xgboost.*", "lightgbm.Booster", "xgboost.*"],
+    )
+    assert comp.artifact_type_filter == ["lightgbm.Booster", "xgboost.*"]
+
+
+def test_frontend_unsorted_type_filter_is_byte_identical_fixed_point():
+    # generate -> parse -> generate must be byte-stable even when the incoming
+    # state carried a raw (unsorted/duplicated) filter.
+    section = SectionState(
+        name="main",
+        components=[
+            SelectState(
+                name="a",
+                component_type="SingleSelect",
+                options_source="available_artifacts",
+                artifact_type_filter=["xgboost.*", "lightgbm.Booster", "xgboost.*"],
+            )
+        ],
+    )
+    state = _minimal_state(sections=[section])
+    src = generate_source(state)
+    reparsed = parse_source(src)
+    assert reparsed.mode == "designer", [i.message for i in reparsed.issues]
+    assert generate_source(reparsed.designer_state) == src
+
+
+def test_publishes_emitted_after_example_settings_and_round_trips():
+    state = _minimal_state(
+        example_settings={"main": {"k": 1}},
+        publishes=[ArtifactDecl(name="model"), ArtifactDecl(name="scaler", type="sklearn.X")],
+    )
+    src = generate_source(state)
+    assert "publishes: list[nd.Artifact] = [" in src
+    assert 'nd.Artifact("model"),' in src
+    assert 'nd.Artifact("scaler", type="sklearn.X"),' in src
+    assert src.index("example_settings") < src.index("publishes")
+    reparsed = parse_source(src).designer_state
+    assert reparsed.publishes == state.publishes
+
+
+def test_publishes_empty_emits_nothing():
+    src = generate_source(_minimal_state())
+    assert "publishes" not in src
 
 
 def test_section_layout_horizontal_emitted_and_round_trips():

--- a/flowfile_core/tests/flowfile/node_designer/test_dry_run.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_dry_run.py
@@ -394,6 +394,32 @@ def test_kernel_output_read_rejects_path_traversal(tmp_path):
     assert by_name[traversal].row_count == 0
 
 
+def test_dry_run_kernel_request_disables_log_callback():
+    """Dry runs blank the log callback so flowfile_ctx.log() prints to stdout the
+    Test tab renders, instead of streaming to core's /raw_logs flow logger."""
+    from flowfile_core.kernel.execution import build_execute_request
+
+    class _FakeManager:
+        _kernel_volume = None
+
+        def to_kernel_path(self, path):
+            return path
+
+    kwargs = dict(
+        node_id=7,
+        code="x = 1",
+        input_paths={"main": []},
+        output_dir="/tmp/out",
+        flow_id=dr._DRY_RUN_FLOW_ID,
+        manager=_FakeManager(),
+        source_registration_id=None,
+    )
+    # Baseline: a production request DOES point log() at core's /raw_logs.
+    assert build_execute_request(**kwargs).log_callback_url != ""
+    # Dry-run request blanks it.
+    assert dr._build_dry_run_execute_request(**kwargs).log_callback_url == ""
+
+
 @pytest.mark.kernel
 def test_dry_run_executes_on_kernel(monkeypatch):
     """A kernel-env dry-run runs process() inside the Docker kernel (Docker required).

--- a/flowfile_core/tests/flowfile/node_designer/test_node_designer.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_node_designer.py
@@ -6,6 +6,7 @@ import pytest
 from polars.testing import assert_frame_equal
 
 from flowfile_core.flowfile.node_designer import (
+    Artifact,
     ColumnSelector,
     CustomNodeBase,
     NodeSettings,
@@ -25,7 +26,7 @@ from flowfile_core.flowfile.node_designer.ui_components import (
     TextInput,
     ToggleSwitch,
 )
-from flowfile_core.types import DataType, Types
+from flowfile_core.types import Types
 
 
 @pytest.fixture
@@ -261,9 +262,7 @@ def test_to_frontend_schema_structure(sample_node_settings: NodeSettings):
 
 def test_to_frontend_schema_horizontal_layout():
     """A section built with layout='horizontal' carries that into the frontend schema."""
-    settings = NodeSettings(
-        config=Section(title="Row", layout="horizontal", note=TextInput(label="Note"))
-    )
+    settings = NodeSettings(config=Section(title="Row", layout="horizontal", note=TextInput(label="Note")))
     schema = to_frontend_schema(settings)
     assert schema["config"]["layout"] == "horizontal"
 
@@ -318,6 +317,157 @@ def test_to_frontend_schema_available_artifacts():
     assert multi_schema["options"] == {"__type__": "AvailableArtifacts"}
 
 
+def test_available_artifacts_default_instance_matches_bare_class():
+    """A default AvailableArtifacts() instance serializes byte-identically to the bare class."""
+
+    class BareSettings(NodeSettings):
+        config: Section = Section(sel=SingleSelect(label="A", options=AvailableArtifacts))
+
+    class InstanceSettings(NodeSettings):
+        config: Section = Section(sel=SingleSelect(label="A", options=AvailableArtifacts()))
+
+    bare = to_frontend_schema(BareSettings())["config"]["components"]["sel"]["options"]
+    instance = to_frontend_schema(InstanceSettings())["config"]["components"]["sel"]["options"]
+    assert bare == instance == {"__type__": "AvailableArtifacts"}
+
+
+def test_available_artifacts_scope_and_type_filter_serialized():
+    """scope=='global' and a type filter ride along on the wire marker."""
+
+    class ScopedSettings(NodeSettings):
+        config: Section = Section(
+            sel=SingleSelect(label="A", options=AvailableArtifacts(scope="global", type="xgboost.*"))
+        )
+
+    options = to_frontend_schema(ScopedSettings())["config"]["components"]["sel"]["options"]
+    assert options == {"__type__": "AvailableArtifacts", "scope": "global", "type_filter": ["xgboost.*"]}
+
+
+def test_available_artifacts_scope_all_serialized():
+    """scope=='all' (upstream ∪ global) rides along on the wire marker."""
+
+    class AllScopeSettings(NodeSettings):
+        config: Section = Section(sel=SingleSelect(label="A", options=AvailableArtifacts(scope="all")))
+
+    options = to_frontend_schema(AllScopeSettings())["config"]["components"]["sel"]["options"]
+    assert options == {"__type__": "AvailableArtifacts", "scope": "all"}
+
+
+def test_available_artifacts_type_list_normalizes_sorted_unique():
+    """A list type filter is de-duplicated and sorted (scope default omitted)."""
+    marker = AvailableArtifacts(type=["b.*", "a.*", "a.*"])
+    assert marker.type_filter == ["a.*", "b.*"]
+
+    class ListSettings(NodeSettings):
+        config: Section = Section(sel=MultiSelect(label="A", options=marker))
+
+    options = to_frontend_schema(ListSettings())["config"]["components"]["sel"]["options"]
+    assert options == {"__type__": "AvailableArtifacts", "type_filter": ["a.*", "b.*"]}
+
+
+def test_available_artifacts_rejects_bad_scope():
+    with pytest.raises(ValueError):
+        AvailableArtifacts(scope="sideways")
+    with pytest.raises(ValueError):
+        AvailableArtifacts(scope="everything")
+
+
+def test_custom_node_publishes_validates_and_templates():
+    """CustomNodeBase carries publishes; to_node_template surfaces them (None when empty)."""
+
+    class PublishingNode(CustomNodeBase):
+        node_name: str = "Publisher"
+        publishes: list[Artifact] = [Artifact("model"), Artifact("scaler", type="sklearn.X")]
+
+        def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+            return inputs[0]
+
+    node = PublishingNode()
+    assert [(a.name, a.type) for a in node.publishes] == [("model", None), ("scaler", "sklearn.X")]
+    template = node.to_node_template()
+    assert [p.model_dump() for p in template.publishes] == [
+        {"name": "model", "type": None},
+        {"name": "scaler", "type": "sklearn.X"},
+    ]
+
+    class NoPublishNode(CustomNodeBase):
+        node_name: str = "No Publish"
+
+        def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+            return inputs[0]
+
+    assert NoPublishNode().to_node_template().publishes is None
+
+
+def test_custom_node_publishes_coerces_dicts():
+    """Dicts passed to the publishes field coerce to the Artifact dataclass (pydantic v2)."""
+
+    class DictNode(CustomNodeBase):
+        node_name: str = "Dict Publisher"
+
+        def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+            return inputs[0]
+
+    node = DictNode(publishes=[{"name": "m"}, {"name": "s", "type": "t"}])
+    assert all(isinstance(a, Artifact) for a in node.publishes)
+    assert [(a.name, a.type) for a in node.publishes] == [("m", None), ("s", "t")]
+
+
+def test_custom_node_publishes_string_form_default_templates():
+    """A `publishes` class-attribute default may hold plain strings (pydantic v2
+    doesn't coerce defaults); to_node_template must not crash on them."""
+
+    class StrPublishingNode(CustomNodeBase):
+        node_name: str = "Str Publisher"
+        publishes: list[Artifact] = ["model", Artifact("m2", type="x.Y")]
+
+        def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+            return inputs[0]
+
+    node = StrPublishingNode()
+    # the string default is not coerced by pydantic v2 -> stays a plain str
+    assert node.publishes[0] == "model"
+    template = node.to_node_template()
+    assert [p.model_dump() for p in template.publishes] == [
+        {"name": "model", "type": None},
+        {"name": "m2", "type": "x.Y"},
+    ]
+
+
+def test_string_form_publishes_ast_template_matches_exec_template():
+    """AST (exec-free) and exec templates must agree for string-form publishes.
+
+    Codegen always canonicalizes string publishes to nd.Artifact(...), so this
+    case can't live in the parity corpus; assert parity directly instead.
+    """
+    from flowfile_core.flowfile.node_designer.parsing import scan_node_source
+    from flowfile_core.flowfile.user_defined.registry import compute_node_key
+    from flowfile_core.flowfile.user_defined.templates import manifest_to_template
+    from shared.node_designer.loading import find_custom_node_class, load_node_module
+
+    source = (
+        "import polars as pl\n"
+        "from flowfile import node_designer as nd\n\n\n"
+        "class StrPublisher(nd.CustomNodeBase):\n"
+        '    node_name: str = "Str Publisher"\n'
+        '    publishes: list[nd.Artifact] = ["model", nd.Artifact("m2", type="x.Y")]\n\n'
+        "    def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:\n"
+        "        return inputs[0]\n"
+    )
+    manifest = scan_node_source(source)
+    ast_template = manifest_to_template(manifest, compute_node_key(manifest.node_name))
+
+    module = load_node_module(source=source, module_name="parity_str_publisher")
+    node_class = find_custom_node_class(module, class_name=manifest.class_name)
+    exec_template = node_class().to_node_template()
+
+    assert ast_template.model_dump() == exec_template.model_dump()
+    assert [p.model_dump() for p in exec_template.publishes] == [
+        {"name": "model", "type": None},
+        {"name": "m2", "type": "x.Y"},
+    ]
+
+
 # --- Tests for CustomNodeBase ---
 
 
@@ -354,6 +504,7 @@ def test_generate_kernel_code_is_valid_python():
             if not inputs:
                 return pl.DataFrame()
             return inputs[0]
+
     node = KernelNode()
     code = node.generate_kernel_code()
     ast.parse(code)

--- a/flowfile_core/tests/flowfile/node_designer/test_parsing.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_parsing.py
@@ -192,7 +192,7 @@ def test_docs_example_designer_state():
     assert greeting.default == "casual"
 
     expected_process = textwrap.dedent(
-        '''\
+        """\
         def process(self, *inputs: pl.DataFrame) -> pl.DataFrame:
             df = inputs[0]
             name_col = self.settings_schema.main_config.name_column.value
@@ -200,7 +200,7 @@ def test_docs_example_designer_state():
             word = "Hello" if style == "formal" else "Hey"
             return df.with_columns(
                 pl.concat_str([pl.lit(f"{word}, "), pl.col(name_col)]).alias("greeting")
-            )'''
+            )"""
     )
     assert state.process_code == expected_process
 
@@ -711,3 +711,204 @@ def test_extract_manifest_environment_normalization():
     manifest = extract_manifest(load("codeonly_dynamic_kwargs.py"))
     assert manifest.class_name == "DynamicNode"
     assert manifest.node_name == "Dynamic Node"
+
+
+# -- AvailableArtifacts marker call parsing ------------------------------------
+
+
+def _select_source(options_expr: str) -> str:
+    return textwrap.dedent(
+        f"""
+        import polars as pl
+
+        from flowfile import node_designer as nd
+
+
+        class ArtifactSettings(nd.NodeSettings):
+            main: nd.Section = nd.Section(
+                title="Main",
+                artifact=nd.SingleSelect(label="Artifact", options={options_expr}),
+            )
+
+
+        class ArtifactNode(nd.CustomNodeBase):
+            node_name: str = "Artifact Node"
+            settings_schema: ArtifactSettings = ArtifactSettings()
+
+            def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+                return inputs[0]
+        """
+    )
+
+
+def _artifact_select(options_expr: str) -> SelectState:
+    result = parse_source(_select_source(options_expr))
+    assert result.mode == "designer", [i.message for i in result.issues]
+    (component,) = result.designer_state.sections[0].components
+    assert isinstance(component, SelectState)
+    return component
+
+
+def test_available_artifacts_bare_marker():
+    comp = _artifact_select("nd.AvailableArtifacts")
+    assert comp.options_source == "available_artifacts"
+    assert comp.artifact_scope == "upstream"
+    assert comp.artifact_type_filter == []
+
+
+def test_available_artifacts_kwarg_form():
+    comp = _artifact_select('nd.AvailableArtifacts(scope="global", type=["a.*", "b.*"])')
+    assert comp.options_source == "available_artifacts"
+    assert comp.artifact_scope == "global"
+    assert comp.artifact_type_filter == ["a.*", "b.*"]
+
+
+def test_available_artifacts_scope_all():
+    comp = _artifact_select('nd.AvailableArtifacts(scope="all")')
+    assert comp.options_source == "available_artifacts"
+    assert comp.artifact_scope == "all"
+    assert comp.artifact_type_filter == []
+
+
+def test_available_artifacts_positional_scope():
+    comp = _artifact_select('nd.AvailableArtifacts("global")')
+    assert comp.artifact_scope == "global"
+    assert comp.artifact_type_filter == []
+
+
+def test_available_artifacts_type_as_string():
+    comp = _artifact_select('nd.AvailableArtifacts(type="sklearn.*")')
+    assert comp.artifact_scope == "upstream"
+    assert comp.artifact_type_filter == ["sklearn.*"]
+
+
+def test_available_artifacts_type_list_normalizes_sorted_unique():
+    comp = _artifact_select('nd.AvailableArtifacts(type=["b.*", "a.*", "a.*"])')
+    assert comp.artifact_type_filter == ["a.*", "b.*"]
+
+
+def test_available_artifacts_bad_scope_is_code_only():
+    result = parse_source(_select_source('nd.AvailableArtifacts(scope="sideways")'))
+    assert result.mode == "code_only"
+    assert ParseIssueCode.NON_LITERAL_COMPONENT_KWARG.value in error_codes(result)
+
+
+def test_available_artifacts_bad_scope_everywhere_is_code_only():
+    result = parse_source(_select_source('nd.AvailableArtifacts(scope="everywhere")'))
+    assert result.mode == "code_only"
+    assert ParseIssueCode.NON_LITERAL_COMPONENT_KWARG.value in error_codes(result)
+
+
+def test_incoming_columns_call_is_still_rejected():
+    """IncomingColumns/AvailableSecrets stay bare-only — calling them is not a designer literal."""
+    result = parse_source(_select_source("nd.IncomingColumns()"))
+    assert result.mode == "code_only"
+    assert ParseIssueCode.NON_LITERAL_COMPONENT_KWARG.value in error_codes(result)
+
+
+def _select_default_source(default_expr: str) -> str:
+    return textwrap.dedent(
+        f"""
+        import polars as pl
+
+        from flowfile import node_designer as nd
+
+
+        class ArtifactSettings(nd.NodeSettings):
+            main: nd.Section = nd.Section(
+                title="Main",
+                artifact=nd.SingleSelect(label="Artifact", options=["a"], default={default_expr}),
+            )
+
+
+        class ArtifactNode(nd.CustomNodeBase):
+            node_name: str = "Artifact Node"
+            settings_schema: ArtifactSettings = ArtifactSettings()
+
+            def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+                return inputs[0]
+        """
+    )
+
+
+def test_artifact_marker_bare_in_default_degrades_not_500():
+    """A marker in default= (only valid for options) degrades to code_only, never raises."""
+    result = parse_source(_select_default_source("nd.AvailableArtifacts"))
+    assert result.mode == "code_only"
+    assert ParseIssueCode.NON_LITERAL_COMPONENT_KWARG.value in error_codes(result)
+
+
+def test_artifact_marker_call_in_default_degrades_not_500():
+    result = parse_source(_select_default_source('nd.AvailableArtifacts(scope="global")'))
+    assert result.mode == "code_only"
+    assert ParseIssueCode.NON_LITERAL_COMPONENT_KWARG.value in error_codes(result)
+
+
+# -- publishes lifting ---------------------------------------------------------
+
+
+def _publishes_source(publishes_expr: str) -> str:
+    return textwrap.dedent(
+        f"""
+        import polars as pl
+
+        from flowfile import node_designer as nd
+
+
+        class PublisherNode(nd.CustomNodeBase):
+            node_name: str = "Publisher"
+            publishes: list[nd.Artifact] = {publishes_expr}
+
+            def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+                return inputs[0]
+        """
+    )
+
+
+def test_publishes_artifact_calls_lift():
+    result = parse_source(_publishes_source('[nd.Artifact("model"), nd.Artifact("scaler", type="sklearn.X")]'))
+    assert result.mode == "designer"
+    assert error_codes(result) == set()
+    assert [(p.name, p.type) for p in result.designer_state.publishes] == [
+        ("model", None),
+        ("scaler", "sklearn.X"),
+    ]
+
+
+def test_publishes_plain_strings_canonicalize():
+    result = parse_source(_publishes_source('["model", "scaler"]'))
+    assert result.mode == "designer"
+    assert [(p.name, p.type) for p in result.designer_state.publishes] == [("model", None), ("scaler", None)]
+
+
+def test_publishes_mixed_entries_lift():
+    result = parse_source(_publishes_source('["model", nd.Artifact("scaler", type="T")]'))
+    assert result.mode == "designer"
+    assert [(p.name, p.type) for p in result.designer_state.publishes] == [("model", None), ("scaler", "T")]
+
+
+def test_publishes_empty_is_default():
+    result = parse_source(_publishes_source("[]"))
+    assert result.mode == "designer"
+    assert result.designer_state.publishes == []
+
+
+def test_publishes_non_literal_element_is_code_only():
+    result = parse_source(_publishes_source("[SOME_NAME]"))
+    assert result.mode == "code_only"
+    assert ParseIssueCode.NON_LITERAL_ATTR.value in error_codes(result)
+
+
+def test_publishes_non_list_is_code_only():
+    result = parse_source(_publishes_source('"model"'))
+    assert result.mode == "code_only"
+    assert ParseIssueCode.NON_LITERAL_ATTR.value in error_codes(result)
+
+
+def test_extract_manifest_publishes_best_effort():
+    manifest = extract_manifest(_publishes_source('[nd.Artifact("model"), "scaler", nd.Artifact("x", type="T")]'))
+    assert [(p.name, p.type) for p in manifest.publishes] == [("model", None), ("scaler", None), ("x", "T")]
+
+    # malformed entries are skipped, never fatal
+    manifest = extract_manifest(_publishes_source("[SOME_NAME, nd.Artifact(123)]"))
+    assert manifest.publishes == []

--- a/flowfile_core/tests/flowfile/node_designer/test_roundtrip_fixed_point.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_roundtrip_fixed_point.py
@@ -16,14 +16,15 @@ import pytest
 from flowfile_core.flowfile.node_designer.codegen import generate_source
 from flowfile_core.flowfile.node_designer.parsing import parse_source
 from flowfile_core.flowfile.node_designer.state import (
+    ArtifactDecl,
     ColumnActionInputState,
     ColumnSelectorState,
     DesignerState,
     EnvironmentState,
     ExampleInput,
     NumericInputState,
-    SectionState,
     SecretSelectorState,
+    SectionState,
     SelectOption,
     SelectState,
     SliderInputState,
@@ -31,6 +32,9 @@ from flowfile_core.flowfile.node_designer.state import (
     ToggleSwitchState,
     VisibleWhenState,
 )
+
+# Artifact type-filter patterns that are already sorted-unique-safe (round-trip exactly).
+_ARTIFACT_TYPE_PATTERNS = ["sklearn.*", "xgboost.*", "lightgbm.Booster", "numpy.ndarray", "pkg.Model"]
 
 # Leaf DataType values that normalize to themselves (see enumeration in the SDK).
 _LEAF_TYPES = [
@@ -153,6 +157,20 @@ def _component(rng: random.Random, taken: set[str]):
             return SelectState(
                 name=name, label=label, component_type=kind, options_source="static", options=opts, default=default
             )
+        if source == "available_artifacts":
+            scope = rng.choice(["upstream", "upstream", "global", "all"])
+            type_filter = (
+                sorted(set(rng.sample(_ARTIFACT_TYPE_PATTERNS, rng.randint(1, 3)))) if rng.random() < 0.5 else []
+            )
+            return SelectState(
+                name=name,
+                label=label,
+                component_type=kind,
+                options_source=source,
+                options=[],
+                artifact_scope=scope,
+                artifact_type_filter=type_filter,
+            )
         return SelectState(name=name, label=label, component_type=kind, options_source=source, options=[])
     if kind == "ColumnSelector":
         return ColumnSelectorState(
@@ -245,6 +263,17 @@ def _random_state(seed: int) -> DesignerState:
     if rng.random() < 0.3:
         example_settings = {f"sec_{rng.randint(0, 9)}": {f"comp_{rng.randint(0, 9)}": rng.randint(0, 100)}}
 
+    publishes: list[ArtifactDecl] = []
+    if rng.random() < 0.4:
+        seen: set[str] = set()
+        for _ in range(rng.randint(1, 3)):
+            pname = f"artifact_{rng.randint(0, 99)}"
+            if pname in seen:
+                continue
+            seen.add(pname)
+            ptype = rng.choice([None, None, f"pkg.Type{rng.randint(0, 9)}"])
+            publishes.append(ArtifactDecl(name=pname, type=ptype))
+
     class_name = f"Node{rng.choice(_WORDS).title()}{rng.randint(0, 9999)}"
     sections = [_section(rng, taken) for _ in range(rng.randint(0, 3))]
     # With no settings class emitted, the parser falls back to <class_name>Settings;
@@ -274,6 +303,7 @@ def _random_state(seed: int) -> DesignerState:
         process_code="def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:\n    return inputs[0]",
         example_inputs=_example_inputs(rng),
         example_settings=example_settings,
+        publishes=publishes,
     )
 
 

--- a/flowfile_core/tests/flowfile/test_artifact_context.py
+++ b/flowfile_core/tests/flowfile/test_artifact_context.py
@@ -4,7 +4,12 @@ from datetime import datetime
 
 import pytest
 
-from flowfile_core.flowfile.artifacts import ArtifactContext, ArtifactRef, NodeArtifactState
+from flowfile_core.flowfile.artifacts import (
+    ArtifactContext,
+    ArtifactRef,
+    NodeArtifactState,
+    merge_declared_artifacts,
+)
 
 
 # ArtifactRef
@@ -530,3 +535,110 @@ class TestArtifactContextChainIsolation:
 
         avail = ctx.compute_available(node_id=5, kernel_id="k", upstream_node_ids=[2, 3])
         assert set(avail.keys()) == {"b", "c"}
+
+
+# ArtifactContext — Allowlist map derivation (lineage sent to the kernel)
+
+
+class TestArtifactAllowlistMap:
+    """The {name: source_node_id} map core ships to the kernel is derived from
+    the same ``compute_available`` result used for availability."""
+
+    def test_allowlist_map_from_available(self):
+        ctx = ArtifactContext()
+        ctx.record_published(1, "k1", ["model"])
+        ctx.record_published(2, "k1", ["scaler"])
+        available = ctx.compute_available(node_id=3, kernel_id="k1", upstream_node_ids=[1, 2])
+        allowlist = {name: ref.source_node_id for name, ref in available.items()}
+        assert allowlist == {"model": 1, "scaler": 2}
+
+    def test_allowlist_map_empty_when_nothing_upstream(self):
+        ctx = ArtifactContext()
+        available = ctx.compute_available(node_id=1, kernel_id="k1", upstream_node_ids=[])
+        assert {name: ref.source_node_id for name, ref in available.items()} == {}
+
+
+# ArtifactContext — Rich publish metadata round-trip
+
+
+class TestArtifactRichMetadataRoundTrip:
+    def test_record_published_rich_dicts_surface_in_summaries(self):
+        """type_name/module from rich publish dicts flow into get_node_summaries."""
+        ctx = ArtifactContext()
+        ctx.record_published(
+            1,
+            "k1",
+            [{"name": "model", "type_name": "RandomForestClassifier", "module": "sklearn.ensemble"}],
+        )
+        summaries = ctx.get_node_summaries()
+        published = summaries["1"]["published"]
+        assert published == [
+            {"name": "model", "type_name": "RandomForestClassifier", "module": "sklearn.ensemble"}
+        ]
+
+
+# merge_declared_artifacts
+
+
+class TestMergeDeclaredArtifacts:
+    def test_observed_only(self):
+        observed = {"model": ArtifactRef(name="model", source_node_id=1, kernel_id="k1", type_name="dict")}
+        result = merge_declared_artifacts(observed, [], "k1")
+        assert len(result) == 1
+        assert result[0]["name"] == "model"
+        assert result[0]["status"] == "published"
+        assert result[0]["type_name"] == "dict"
+
+    def test_declared_only_entry_shape(self):
+        result = merge_declared_artifacts({}, [(2, "encoder", "sklearn.preprocessing.LabelEncoder")], "k1")
+        assert result == [
+            {
+                "name": "encoder",
+                "source_node_id": 2,
+                "kernel_id": "k1",
+                "type_name": "LabelEncoder",
+                "module": "sklearn.preprocessing",
+                "size_bytes": 0,
+                "created_at": None,
+                "status": "declared",
+            }
+        ]
+
+    def test_observed_wins_on_conflict(self):
+        observed = {"model": ArtifactRef(name="model", source_node_id=1, kernel_id="k1", type_name="RealType")}
+        declared = [(1, "model", "declared.Type")]
+        result = merge_declared_artifacts(observed, declared, "k1")
+        assert len(result) == 1
+        assert result[0]["status"] == "published"
+        assert result[0]["type_name"] == "RealType"
+
+    def test_type_rpartition_split(self):
+        result = merge_declared_artifacts({}, [(3, "a", "a.b.c.MyType")], "k1")
+        assert result[0]["module"] == "a.b.c"
+        assert result[0]["type_name"] == "MyType"
+
+    def test_no_dot_type(self):
+        result = merge_declared_artifacts({}, [(3, "a", "MyType")], "k1")
+        assert result[0]["module"] == ""
+        assert result[0]["type_name"] == "MyType"
+
+    def test_none_type(self):
+        result = merge_declared_artifacts({}, [(3, "a", None)], "k1")
+        assert result[0]["module"] == ""
+        assert result[0]["type_name"] == ""
+
+    def test_declared_duplicate_first_wins(self):
+        declared = [(1, "shared", "first.A"), (2, "shared", "second.B")]
+        result = merge_declared_artifacts({}, declared, "k1")
+        assert len(result) == 1
+        assert result[0]["source_node_id"] == 1
+        assert result[0]["type_name"] == "A"
+
+    def test_statuses_and_ordering(self):
+        observed = {"published_art": ArtifactRef(name="published_art", source_node_id=1, kernel_id="k1")}
+        declared = [(2, "declared_art", "mod.T"), (1, "published_art", "mod.Ignored")]
+        result = merge_declared_artifacts(observed, declared, "k1")
+        by_name = {r["name"]: r for r in result}
+        assert by_name["published_art"]["status"] == "published"
+        assert by_name["declared_art"]["status"] == "declared"
+        assert len(result) == 2

--- a/flowfile_core/tests/flowfile/test_artifact_lineage_kernel_integration.py
+++ b/flowfile_core/tests/flowfile/test_artifact_lineage_kernel_integration.py
@@ -1,0 +1,181 @@
+"""
+Kernel integration tests for artifact lineage enforcement.
+
+Core ships each kernel node an ``available_artifacts`` allowlist (artifact name →
+publishing node id) derived from the node's upstream lineage. When a node reads
+an artifact that was published *outside* its lineage, the kernel emits a
+deprecation warning ("not an upstream input"); reads from within the lineage
+stay silent.
+
+This exercises the end-to-end wire: a python_script node A publishes an
+artifact, an UNRELATED node B (no edge from A) reads it and must be warned, and
+a DOWNSTREAM node C (edge A→C) reads it and must NOT be warned. It also confirms
+the rich published-artifact shape round-trips (Gap 3): A's recorded refs carry a
+non-empty ``type_name``.
+
+Requires Docker (kernel container). Skips cleanly when Docker is unavailable via
+the ``kernel_manager_with_core`` fixture.
+"""
+
+import pytest
+
+from flowfile_core import flow_file_handler
+from flowfile_core.flowfile.flow_graph import FlowGraph, RunInformation, add_connection
+from flowfile_core.flowfile.handler import FlowfileHandler
+from flowfile_core.kernel.manager import KernelManager
+from flowfile_core.schemas import input_schema, schemas
+
+pytestmark = pytest.mark.kernel
+
+
+def _create_graph(flow_id: int = 1) -> FlowGraph:
+    handler = FlowfileHandler()
+    handler.register_flow(
+        schemas.FlowSettings(
+            flow_id=flow_id,
+            name="artifact_lineage_test_flow",
+            path=".",
+            execution_mode="Development",
+            execution_location="remote",
+            # Node 2 (publisher) and node 3 (out-of-lineage reader) are stage
+            # siblings; serialize execution so node 3 can't read before node 2
+            # publishes.
+            max_parallel_workers=1,
+        )
+    )
+    return handler.get_flow(flow_id)
+
+
+def _handle_run_info(run_info: RunInformation):
+    if not run_info.success:
+        errors = "errors:"
+        for step in run_info.node_step_result:
+            if not step.success:
+                errors += f"\n  node_id:{step.node_id}, error: {step.error}"
+        raise ValueError(f"Graph should run successfully:\n{errors}")
+
+
+class TestArtifactLineageWarning:
+    """A run where an out-of-lineage read is warned and an in-lineage read is not."""
+
+    def test_out_of_lineage_read_warns_in_lineage_does_not(
+        self, kernel_manager_with_core: tuple[KernelManager, str]
+    ):
+        manager, kernel_id = kernel_manager_with_core
+        import flowfile_core.kernel as _kernel_mod
+
+        _prev = _kernel_mod._manager
+        _kernel_mod._manager = manager
+
+        _prev_flow = flow_file_handler._flows.get(1)
+        try:
+            graph = _create_graph()
+            # /raw_logs resolves flows via the module-singleton handler; the
+            # kernel's log() callback lands there, so the graph must be
+            # registered like a production flow.
+            flow_file_handler._flows[1] = graph
+
+            # node 1: shared manual-input root so A (node 2) and B (node 3) are
+            # siblings — B is NOT downstream of A, so "model" is outside B's lineage.
+            graph.add_node_promise(
+                input_schema.NodePromise(flow_id=1, node_id=1, node_type="manual_input")
+            )
+            graph.add_manual_input(
+                input_schema.NodeManualInput(
+                    flow_id=1,
+                    node_id=1,
+                    raw_data_format=input_schema.RawData.from_pylist([{"x": 1}]),
+                )
+            )
+
+            # node 2 (A): publishes "model" (a dict → type_name "dict")
+            graph.add_node_promise(
+                input_schema.NodePromise(flow_id=1, node_id=2, node_type="python_script")
+            )
+            publish_code = """
+df = flowfile_ctx.read_input()
+flowfile_ctx.publish_artifact("model", {"weights": [1.0, 2.0, 3.0]})
+flowfile_ctx.publish_output(df)
+"""
+            graph.add_python_script(
+                input_schema.NodePythonScript(
+                    flow_id=1,
+                    node_id=2,
+                    depending_on_ids=[1],
+                    python_script_input=input_schema.PythonScriptInput(code=publish_code, kernel_id=kernel_id),
+                )
+            )
+
+            # node 3 (B): reads "model" from OUTSIDE its lineage (upstream = {1})
+            graph.add_node_promise(
+                input_schema.NodePromise(flow_id=1, node_id=3, node_type="python_script")
+            )
+            read_outside_code = """
+df = flowfile_ctx.read_input()
+model = flowfile_ctx.read_artifact("model")
+print(f"B read model outside lineage: {model}")
+flowfile_ctx.publish_output(df)
+"""
+            graph.add_python_script(
+                input_schema.NodePythonScript(
+                    flow_id=1,
+                    node_id=3,
+                    depending_on_ids=[1],
+                    python_script_input=input_schema.PythonScriptInput(
+                        code=read_outside_code, kernel_id=kernel_id
+                    ),
+                )
+            )
+
+            # node 4 (C): reads "model" from WITHIN its lineage (edge A→C)
+            graph.add_node_promise(
+                input_schema.NodePromise(flow_id=1, node_id=4, node_type="python_script")
+            )
+            read_inside_code = """
+df = flowfile_ctx.read_input()
+model = flowfile_ctx.read_artifact("model")
+print(f"C read model inside lineage: {model}")
+flowfile_ctx.publish_output(df)
+"""
+            graph.add_python_script(
+                input_schema.NodePythonScript(
+                    flow_id=1,
+                    node_id=4,
+                    depending_on_ids=[2],
+                    python_script_input=input_schema.PythonScriptInput(
+                        code=read_inside_code, kernel_id=kernel_id
+                    ),
+                )
+            )
+
+            add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2))
+            add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 3))
+            add_connection(graph, input_schema.NodeConnection.create_from_simple_input(2, 4))
+
+            run_info = graph.run_graph()
+            _handle_run_info(run_info)
+
+            # The flow log file captures both the node-logger stream and the
+            # forwarded kernel stdout/stderr — either carries the warning.
+            with open(graph.flow_logger.log_file_path) as fh:
+                log_text = fh.read()
+
+            warning_lines = [ln for ln in log_text.splitlines() if "not an upstream input" in ln]
+            assert warning_lines, "Expected a lineage deprecation warning for the out-of-lineage read"
+            assert any("model" in ln for ln in warning_lines)
+            # Warning is attributed to node B (id 3), not node C (id 4).
+            assert any(("node 3" in ln or "Node ID: 3" in ln) for ln in warning_lines)
+            assert not any(("node 4" in ln or "Node ID: 4" in ln) for ln in warning_lines)
+
+            # Gap 3 end-to-end: A's published refs carry the rich type metadata.
+            published = graph.artifact_context.get_published_by_node(2)
+            assert published, "Node A should have recorded a published artifact"
+            assert published[0].name == "model"
+            assert published[0].type_name, "Published ref should carry a non-empty type_name"
+
+        finally:
+            _kernel_mod._manager = _prev
+            if _prev_flow is not None:
+                flow_file_handler._flows[1] = _prev_flow
+            else:
+                flow_file_handler._flows.pop(1, None)

--- a/flowfile_core/tests/flowfile/test_custom_node_flow_roundtrip.py
+++ b/flowfile_core/tests/flowfile/test_custom_node_flow_roundtrip.py
@@ -48,6 +48,32 @@ NODE_TYPE = "roundtrip_fixed_column"
 SETTINGS = {"main_section": {"standard_input": "hello", "column_name": "custom_col"}}
 
 
+class CollidingTrainModel(CustomNodeBase):
+    """Custom node whose computed key collides with the built-in ``train_model`` type."""
+
+    node_name: str = "Train Model"
+    node_category: str = "Testing"
+    title: str = "Train Model"
+    intro: str = "Custom node whose key collides with a built-in type."
+
+    settings_schema: NodeSettings = NodeSettings(
+        main_section=Section(
+            title="Configuration",
+            standard_input=TextInput(label="Fixed Value"),
+            column_name=TextInput(label="New Column Name"),
+        ),
+    )
+
+    def process(self, *inputs):
+        input_df = inputs[0]
+        fixed_value = self.settings_schema.main_section.standard_input.value
+        new_col_name = self.settings_schema.main_section.column_name.value
+        return input_df.with_columns(pl.lit(fixed_value).alias(new_col_name))
+
+
+COLLIDING_TYPE = "train_model"
+
+
 @pytest.fixture
 def temp_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -123,6 +149,51 @@ def test_yaml_carries_user_defined_marker(temp_dir, store_snapshot):
     custom_node = next(n for n in data["nodes"] if n["id"] == 2)
     assert custom_node["setting_input"]["is_user_defined"] is True
     assert custom_node["setting_input"]["settings"] == SETTINGS
+
+
+class TestBuiltinKeyCollision:
+    """A user-defined node whose key collides with a built-in type must still load."""
+
+    def test_parse_resolves_user_defined_over_builtin_collision(self):
+        # is_user_defined marker wins over the built-in type->schema mapping.
+        raw = {"is_user_defined": True, "settings": SETTINGS, "output_names": ["main"]}
+        assert schemas.get_settings_class_for_node_type("train_model", raw) is input_schema.UserDefinedNode
+        # a genuine built-in train_model (no marker) still resolves to its own schema.
+        assert schemas.get_settings_class_for_node_type("train_model", {"train_input": {}}) is (
+            input_schema.NodeTrainModel
+        )
+
+    def test_colliding_node_opens_with_settings_preserved(self, temp_dir, store_snapshot):
+        store_snapshot.add_to_custom_node_store(CollidingTrainModel)
+        flow = create_graph(6100)
+        flow.add_node_promise(input_schema.NodePromise(flow_id=6100, node_id=1, node_type="manual_input"))
+        flow.add_manual_input(
+            input_schema.NodeManualInput(
+                flow_id=6100, node_id=1, raw_data_format=input_schema.RawData.from_pylist([{"a": 1}, {"a": 2}])
+            )
+        )
+        flow.add_node_promise(input_schema.NodePromise(flow_id=6100, node_id=2, node_type=COLLIDING_TYPE))
+        add_connection(flow, input_schema.NodeConnection.create_from_simple_input(1, 2))
+        node_settings = input_schema.UserDefinedNode(
+            flow_id=6100, node_id=2, settings=SETTINGS, is_user_defined=True
+        )
+        flow.add_user_defined_node(
+            custom_node=CollidingTrainModel.from_settings(node_settings.settings),
+            user_defined_node_settings=node_settings,
+        )
+
+        yaml_path = temp_dir / "collision.yaml"
+        flow.save_flow(str(yaml_path))
+
+        # Before the parse fix this raised AttributeError (NodeTrainModel has no .settings).
+        loaded = open_flow(yaml_path)
+        node = loaded.get_node(2)
+        assert node is not None
+        assert node.node_type == COLLIDING_TYPE
+        assert node.setting_input.is_user_defined is True
+        # settings survive verbatim: the node resolved to UserDefinedNode, not NodeTrainModel
+        assert node.setting_input.settings == SETTINGS
+        assert isinstance(node.setting_input, input_schema.UserDefinedNode)
 
 
 class TestMissingNodeGracefulDegradation:

--- a/flowfile_core/tests/flowfile/test_execute_result_validator.py
+++ b/flowfile_core/tests/flowfile/test_execute_result_validator.py
@@ -1,0 +1,50 @@
+"""Unit tests for the ExecuteResult.artifacts_published normalizing validator."""
+
+from flowfile_core.kernel.models import ExecuteResult, PublishedArtifact
+
+
+class TestExecuteResultPublishedNormalization:
+    def test_pure_string_list(self):
+        """Stale 0.4.0 kernels emit plain names; they normalize to names-only refs."""
+        result = ExecuteResult(success=True, artifacts_published=["model", "scaler"])
+        assert all(isinstance(a, PublishedArtifact) for a in result.artifacts_published)
+        assert [a.name for a in result.artifacts_published] == ["model", "scaler"]
+        assert result.artifacts_published[0].type_name == ""
+        assert result.artifacts_published[0].module == ""
+        assert result.artifacts_published[0].size_bytes == 0
+
+    def test_pure_rich_dicts(self):
+        result = ExecuteResult(
+            success=True,
+            artifacts_published=[
+                {"name": "model", "type_name": "RF", "module": "sklearn.ensemble", "size_bytes": 1024}
+            ],
+        )
+        art = result.artifacts_published[0]
+        assert isinstance(art, PublishedArtifact)
+        assert art.name == "model"
+        assert art.type_name == "RF"
+        assert art.module == "sklearn.ensemble"
+        assert art.size_bytes == 1024
+
+    def test_mixed_strings_and_dicts(self):
+        result = ExecuteResult(
+            success=True,
+            artifacts_published=["plain", {"name": "rich", "type_name": "dict"}],
+        )
+        assert all(isinstance(a, PublishedArtifact) for a in result.artifacts_published)
+        by_name = {a.name: a for a in result.artifacts_published}
+        assert by_name["plain"].type_name == ""
+        assert by_name["rich"].type_name == "dict"
+
+    def test_empty_default(self):
+        result = ExecuteResult(success=True)
+        assert result.artifacts_published == []
+
+    def test_published_artifact_instances_pass_through(self):
+        result = ExecuteResult(
+            success=True,
+            artifacts_published=[PublishedArtifact(name="x", type_name="T")],
+        )
+        assert result.artifacts_published[0].name == "x"
+        assert result.artifacts_published[0].type_name == "T"

--- a/flowfile_core/tests/flowfile/test_kernel_integration.py
+++ b/flowfile_core/tests/flowfile/test_kernel_integration.py
@@ -129,7 +129,7 @@ class TestKernelRuntime:
             )
         )
         assert result.success
-        assert "my_dict" in result.artifacts_published
+        assert "my_dict" in [a.name for a in result.artifacts_published]
 
     def test_read_and_write_parquet(self, kernel_manager: tuple[KernelManager, str]):
         """Kernel can read input parquet and write output parquet."""

--- a/flowfile_core/tests/flowfile/test_kernel_persistence_integration.py
+++ b/flowfile_core/tests/flowfile/test_kernel_persistence_integration.py
@@ -88,7 +88,7 @@ class TestArtifactPersistenceBasics:
             node_id=100,
         )
         assert result.success
-        assert "persist_test" in result.artifacts_published
+        assert "persist_test" in [a.name for a in result.artifacts_published]
 
         persistence = _get_json(kernel.port, "/persistence")
         assert persistence["enabled"] is True

--- a/flowfile_core/tests/flowfile/test_node_available_artifacts_route.py
+++ b/flowfile_core/tests/flowfile/test_node_available_artifacts_route.py
@@ -1,0 +1,285 @@
+"""Route-level tests for GET /flow/node_available_artifacts.
+
+Exercises ``get_node_available_artifacts`` (routes.py) end to end, in-process
+(no Docker / kernel): node lookup, the kernel-resolution ladder (query param →
+``setting_input.kernel_id`` → ``python_script_input.kernel_id`` → the
+registry manifest's ``default_kernel_id``) and the declared-publishes merge
+(upstream user-defined kernel nodes' manifest ``publishes`` unioned with
+run-observed artifacts). The pure merge helper is unit-tested separately in
+``test_artifact_context``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from flowfile_core import flow_file_handler
+from flowfile_core.configs import node_store
+from flowfile_core.flowfile.flow_graph import FlowGraph, add_connection
+from flowfile_core.flowfile.handler import FlowfileHandler
+from flowfile_core.flowfile.node_designer.state import (
+    ArtifactDecl,
+    EnvironmentState,
+    NodeManifest,
+)
+from flowfile_core.flowfile.user_defined.registry import LoadedNode
+from flowfile_core.flowfile.user_defined.registry import registry as user_defined_registry
+from flowfile_core.routes.routes import get_node_available_artifacts
+from flowfile_core.schemas import input_schema, schemas
+
+
+@pytest.fixture
+def flow_factory():
+    """Build flows and register them in the singleton handler the route reads."""
+    created: list[int] = []
+
+    def _make(flow_id: int) -> FlowGraph:
+        handler = FlowfileHandler()
+        handler.register_flow(
+            schemas.FlowSettings(
+                flow_id=flow_id,
+                name="artifacts_route_test",
+                path=".",
+                execution_mode="Development",
+            )
+        )
+        flow = handler.get_flow(flow_id)
+        flow_file_handler._flows[flow_id] = flow
+        created.append(flow_id)
+        return flow
+
+    yield _make
+    for fid in created:
+        flow_file_handler._flows.pop(fid, None)
+
+
+@pytest.fixture
+def register_manifest():
+    """Inject synthetic user-defined registry entries + node templates; restore on teardown."""
+    saved_entries = dict(user_defined_registry._entries)
+    saved_node_dict = dict(node_store.node_dict)
+
+    def _register(
+        node_key: str,
+        *,
+        kind: str = "kernel",
+        default_kernel_id: str | None = None,
+        publishes: list[tuple[str, str | None]] | None = None,
+    ) -> LoadedNode:
+        manifest = NodeManifest(
+            class_name=node_key.title().replace("_", ""),
+            node_name=node_key,
+            environment=EnvironmentState(kind=kind, default_kernel_id=default_kernel_id),
+            publishes=[ArtifactDecl(name=name, type=type_) for name, type_ in (publishes or [])],
+        )
+        entry = LoadedNode(
+            node_key=node_key,
+            file_path=Path(f"/virtual/{node_key}.py"),
+            file_name=f"{node_key}.py",
+            source_text="",
+            source_hash="deadbeef",
+            mtime=0.0,
+            manifest=manifest,
+        )
+        user_defined_registry._entries[str(entry.file_path)] = entry
+        # A template must exist in node_dict for the placeholder FlowNode to build.
+        node_store.register_missing_node_template(node_key)
+        return entry
+
+    yield _register
+    user_defined_registry._entries.clear()
+    user_defined_registry._entries.update(saved_entries)
+    node_store.node_dict.clear()
+    node_store.node_dict.update(saved_node_dict)
+
+
+# ------------------------------------------------------------------
+# graph-building helpers
+# ------------------------------------------------------------------
+
+
+def _add_manual_input(flow: FlowGraph, node_id: int) -> None:
+    flow.add_node_promise(input_schema.NodePromise(flow_id=flow.flow_id, node_id=node_id, node_type="manual_input"))
+    flow.add_manual_input(
+        input_schema.NodeManualInput(
+            flow_id=flow.flow_id,
+            node_id=node_id,
+            raw_data_format=input_schema.RawData.from_pylist([{"a": 1}, {"a": 2}]),
+        )
+    )
+
+
+def _add_python_script(
+    flow: FlowGraph, node_id: int, *, kernel_id: str | None = None, upstream_ids: tuple[int, ...] = ()
+) -> None:
+    flow.add_node_promise(input_schema.NodePromise(flow_id=flow.flow_id, node_id=node_id, node_type="python_script"))
+    flow.add_python_script(
+        input_schema.NodePythonScript(
+            flow_id=flow.flow_id,
+            node_id=node_id,
+            depending_on_ids=list(upstream_ids),
+            python_script_input=input_schema.PythonScriptInput(kernel_id=kernel_id),
+        )
+    )
+    for uid in upstream_ids:
+        add_connection(flow, input_schema.NodeConnection.create_from_simple_input(uid, node_id))
+
+
+def _add_custom_promise(flow: FlowGraph, node_id: int, node_type: str, *, upstream_ids: tuple[int, ...] = ()) -> None:
+    """A custom node placed as a bare placeholder (route reads node_type + setting_input only)."""
+    flow.add_node_promise(input_schema.NodePromise(flow_id=flow.flow_id, node_id=node_id, node_type=node_type))
+    for uid in upstream_ids:
+        add_connection(flow, input_schema.NodeConnection.create_from_simple_input(uid, node_id))
+
+
+# ------------------------------------------------------------------
+# 1. Ladder: python_script_input.kernel_id resolves, observed returned
+# ------------------------------------------------------------------
+
+
+def test_kernel_from_python_script_input_returns_observed(flow_factory):
+    flow = flow_factory(9101)
+    _add_manual_input(flow, 1)
+    _add_python_script(flow, 2, upstream_ids=(1,))  # publisher (no explicit kernel)
+    _add_python_script(flow, 3, kernel_id="k1", upstream_ids=(2,))  # target
+    flow.artifact_context.record_published(
+        2, "k1", [{"name": "scaler", "type_name": "StandardScaler", "module": "sklearn.preprocessing"}]
+    )
+
+    resp = get_node_available_artifacts(flow_id=9101, node_id=3, kernel_id=None)
+
+    assert len(resp["artifacts"]) == 1
+    art = resp["artifacts"][0]
+    assert art["name"] == "scaler"
+    assert art["status"] == "published"
+    assert art["type_name"] == "StandardScaler"
+    assert art["source_node_id"] == 2
+    assert art["kernel_id"] == "k1"
+
+
+# ------------------------------------------------------------------
+# 2. Ladder: manifest default_kernel_id fallback resolves the kernel
+# ------------------------------------------------------------------
+
+
+def test_kernel_from_manifest_default_fallback(flow_factory, register_manifest):
+    register_manifest("udf_target", kind="kernel", default_kernel_id="kdata")
+    flow = flow_factory(9102)
+    _add_manual_input(flow, 1)
+    _add_python_script(flow, 2, upstream_ids=(1,))  # publisher
+    _add_custom_promise(flow, 3, "udf_target", upstream_ids=(2,))  # target, no explicit binding
+    flow.artifact_context.record_published(2, "kdata", [{"name": "prep", "type_name": "dict"}])
+
+    resp = get_node_available_artifacts(flow_id=9102, node_id=3, kernel_id=None)
+
+    names = {a["name"]: a for a in resp["artifacts"]}
+    assert set(names) == {"prep"}
+    assert names["prep"]["status"] == "published"
+    assert names["prep"]["kernel_id"] == "kdata"
+
+
+# ------------------------------------------------------------------
+# 3. Declared merge: upstream manifest publishes, nothing observed
+# ------------------------------------------------------------------
+
+
+def test_declared_publishes_merged_when_no_run(flow_factory, register_manifest):
+    register_manifest(
+        "xgb_train",
+        kind="kernel",
+        default_kernel_id="k1",
+        publishes=[("model", "xgboost.core.Booster"), ("metrics", None)],
+    )
+    flow = flow_factory(9103)
+    _add_manual_input(flow, 1)
+    _add_custom_promise(flow, 2, "xgb_train", upstream_ids=(1,))
+    _add_python_script(flow, 3, upstream_ids=(2,))  # target, kernel via query param
+
+    resp = get_node_available_artifacts(flow_id=9103, node_id=3, kernel_id="k1")
+
+    by_name = {a["name"]: a for a in resp["artifacts"]}
+    assert set(by_name) == {"model", "metrics"}
+
+    model = by_name["model"]
+    assert model["status"] == "declared"
+    assert model["type_name"] == "Booster"
+    assert model["module"] == "xgboost.core"
+    assert model["created_at"] is None
+    assert model["size_bytes"] == 0
+    assert model["source_node_id"] == 2
+
+    metrics = by_name["metrics"]
+    assert metrics["status"] == "declared"
+    assert metrics["type_name"] == ""
+    assert metrics["module"] == ""
+    assert metrics["created_at"] is None
+
+
+# ------------------------------------------------------------------
+# 4. Observed wins on name conflict with a declared publish
+# ------------------------------------------------------------------
+
+
+def test_observed_wins_over_declared(flow_factory, register_manifest):
+    register_manifest(
+        "xgb_train",
+        kind="kernel",
+        default_kernel_id="k1",
+        publishes=[("model", "xgboost.core.Booster"), ("metrics", None)],
+    )
+    flow = flow_factory(9104)
+    _add_manual_input(flow, 1)
+    _add_custom_promise(flow, 2, "xgb_train", upstream_ids=(1,))
+    _add_python_script(flow, 3, upstream_ids=(2,))
+    flow.artifact_context.record_published(
+        2, "k1", [{"name": "model", "type_name": "ObservedBooster", "module": "xgboost.core"}]
+    )
+
+    resp = get_node_available_artifacts(flow_id=9104, node_id=3, kernel_id="k1")
+
+    models = [a for a in resp["artifacts"] if a["name"] == "model"]
+    assert len(models) == 1
+    assert models[0]["status"] == "published"
+    assert models[0]["type_name"] == "ObservedBooster"
+    assert models[0]["created_at"] is not None
+    # the un-observed declared publish still rides along
+    assert {a["name"] for a in resp["artifacts"]} == {"model", "metrics"}
+
+
+# ------------------------------------------------------------------
+# 5. Upstream bound to a different kernel: its declared publishes excluded
+# ------------------------------------------------------------------
+
+
+def test_upstream_on_different_kernel_excluded(flow_factory, register_manifest):
+    register_manifest(
+        "xgb_train_k2",
+        kind="kernel",
+        default_kernel_id="k2",
+        publishes=[("model", "xgboost.core.Booster")],
+    )
+    flow = flow_factory(9105)
+    _add_manual_input(flow, 1)
+    _add_custom_promise(flow, 2, "xgb_train_k2", upstream_ids=(1,))
+    _add_python_script(flow, 3, upstream_ids=(2,))
+
+    resp = get_node_available_artifacts(flow_id=9105, node_id=3, kernel_id="k1")
+
+    assert resp == {"artifacts": []}
+
+
+# ------------------------------------------------------------------
+# 6. Unresolvable kernel: no param, no bindings, no manifest → empty
+# ------------------------------------------------------------------
+
+
+def test_unresolvable_kernel_returns_empty(flow_factory):
+    flow = flow_factory(9106)
+    _add_manual_input(flow, 1)
+    _add_python_script(flow, 2, upstream_ids=(1,))  # no kernel binding
+
+    resp = get_node_available_artifacts(flow_id=9106, node_id=2, kernel_id=None)
+
+    assert resp == {"artifacts": []}

--- a/flowfile_core/tests/routes/test_user_defined_components_auth.py
+++ b/flowfile_core/tests/routes/test_user_defined_components_auth.py
@@ -143,6 +143,26 @@ class TestAuthedHappyPath:
         assert response.status_code == 400
         assert not (storage.user_defined_nodes_directory / f"{node_file}.py").exists()
 
+    def test_builtin_key_collision_rejected(self, node_file):
+        # "Train Model" -> key "train_model", a built-in node type: reject, never write.
+        colliding = VALID_NODE_CODE.format(node_name="Train Model")
+        resp = authed_client.post(
+            "/user_defined_components/save-custom-node", json={"file_name": node_file, "code": colliding}
+        )
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert detail["error_code"] == "BUILTIN_NODE_KEY_COLLISION"
+        assert detail["node_key"] == "train_model"
+        assert not (storage.user_defined_nodes_directory / f"{node_file}.py").exists()
+
+        # A non-colliding name on the same file still saves fine.
+        ok = VALID_NODE_CODE.format(node_name=f"Node {node_file[-8:]}")
+        resp2 = authed_client.post(
+            "/user_defined_components/save-custom-node", json={"file_name": node_file, "code": ok}
+        )
+        assert resp2.status_code == 200, resp2.text
+        assert resp2.json()["success"] is True
+
     def test_get_missing_node_404(self):
         response = authed_client.get("/user_defined_components/get-custom-node/never_saved_node_xyz")
         assert response.status_code == 404

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/CustomNode.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/CustomNode.vue
@@ -93,15 +93,17 @@
         :incoming-columns="availableColumns"
         :column-types="columnTypes"
         :artifact-options="artifactOptions"
+        :global-artifacts="globalArtifacts"
       />
     </generic-node-settings>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from "vue";
+import { ref, computed, watch } from "vue";
 import axios from "axios";
 import { CustomNodeSchema, SectionComponent } from "./interface";
+import type { ArtifactOption, GlobalArtifactOption } from "./interface";
 import { getCustomNodeSchema, CustomNodeSchemaError } from "./interface";
 import { useNodeStore } from "../../../../../stores/column-store";
 import { NodeUserDefined } from "../../../baseNode/nodeInput";
@@ -130,7 +132,8 @@ const availableColumns = ref<string[]>([]);
 const currentNodeId = ref<number | null>(null);
 const nodeUserDefined = ref<NodeUserDefined | null>(null);
 const columnTypes = ref<FileColumn[]>([]);
-const artifactOptions = ref<string[]>([]);
+const artifactOptions = ref<ArtifactOption[]>([]);
+const globalArtifacts = ref<GlobalArtifactOption[]>([]);
 
 // Kernel state
 const availableKernels = ref<KernelInfo[]>([]);
@@ -171,11 +174,56 @@ async function fetchAvailableArtifacts(nodeId: number, kernelId: string | null) 
       params: { flow_id: nodeStore.flow_id, node_id: nodeId, kernel_id: kernelId },
     });
     const artifacts = response.data?.artifacts ?? [];
-    artifactOptions.value = artifacts.map((artifact: any) => artifact.name);
+    artifactOptions.value = artifacts.map((a: any) => ({
+      name: a.name,
+      type_name: a.type_name,
+      module: a.module,
+      status: a.status,
+    }));
   } catch {
     artifactOptions.value = [];
   }
 }
+
+// Trailing slash: /artifacts/ is the router root; a missing slash 307-drops the body in Docker.
+async function fetchGlobalArtifacts() {
+  try {
+    const response = await axios.get("/artifacts/", { params: { limit: 500 } });
+    const raw = response.data;
+    const items: any[] = Array.isArray(raw) ? raw : (raw?.artifacts ?? raw?.items ?? []);
+    globalArtifacts.value = items.map((a) => ({
+      name: a.name,
+      python_type: a.python_type ?? null,
+      namespace_id: a.namespace_id ?? null,
+      version: a.version,
+    }));
+  } catch {
+    globalArtifacts.value = [];
+  }
+}
+
+// True when any select in the schema opts into the global (catalog) artifact source.
+function schemaWantsGlobalArtifacts(schemaData: CustomNodeSchema): boolean {
+  for (const sectionKey in schemaData.settings_schema) {
+    const section = schemaData.settings_schema[sectionKey];
+    for (const componentKey in section.components) {
+      const options = (section.components[componentKey] as any).options;
+      if (
+        options?.__type__ === "AvailableArtifacts" &&
+        (options.scope === "global" || options.scope === "all")
+      )
+        return true;
+    }
+  }
+  return false;
+}
+
+// Re-fetch upstream artifacts when the picked kernel changes; skip the initial
+// load's own assignment (fetched explicitly there).
+watch(selectedKernelId, (kernelId) => {
+  if (loading.value || currentNodeId.value === null) return;
+  void fetchAvailableArtifacts(currentNodeId.value, kernelId);
+});
 
 // --- Lifecycle Methods (exposed to parent) ---
 
@@ -216,6 +264,9 @@ const loadNodeData = async (nodeId: number) => {
     }
 
     await fetchAvailableArtifacts(nodeId, selectedKernelId.value ?? schemaData.kernel_id ?? null);
+    if (schemaWantsGlobalArtifacts(schemaData)) {
+      await fetchGlobalArtifacts();
+    }
 
     initializeFormData(schemaData, inputNodeData?.setting_input);
   } catch (err: any) {

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/CustomNodeForm.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/CustomNodeForm.vue
@@ -58,6 +58,7 @@
           :schema="component"
           :incoming-columns="incomingColumns"
           :available-artifacts="artifactOptions"
+          :global-artifacts="globalArtifacts"
           @update:model-value="setValue(sectionKey.toString(), componentKey.toString(), $event)"
         />
 
@@ -67,6 +68,7 @@
           :schema="component"
           :incoming-columns="incomingColumns"
           :available-artifacts="artifactOptions"
+          :global-artifacts="globalArtifacts"
           @update:model-value="setValue(sectionKey.toString(), componentKey.toString(), $event)"
         />
 
@@ -118,7 +120,7 @@
 <script setup lang="ts">
 // Shared renderer for custom-node settings forms: used by the settings drawer
 // (CustomNode.vue) and, in editMode with chrome slots, by the Node Designer.
-import type { SettingsSchema } from "./interface";
+import type { ArtifactOption, GlobalArtifactOption, SettingsSchema } from "./interface";
 import { isSectionVisible } from "./visibility";
 import type { FileColumn } from "../../../baseNode/nodeInterfaces";
 import MultiSelect from "./components/MultiSelect.vue";
@@ -142,7 +144,8 @@ const props = withDefaults(
     formData: CustomNodeFormData;
     incomingColumns?: string[];
     columnTypes?: FileColumn[];
-    artifactOptions?: string[];
+    artifactOptions?: ArtifactOption[];
+    globalArtifacts?: GlobalArtifactOption[];
     editMode?: boolean;
     selectedSectionKey?: string | null;
   }>(),
@@ -150,6 +153,7 @@ const props = withDefaults(
     incomingColumns: () => [],
     columnTypes: () => [],
     artifactOptions: () => [],
+    globalArtifacts: () => [],
     editMode: false,
     selectedSectionKey: null,
   },

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/MultiSelect.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/MultiSelect.vue
@@ -22,7 +22,8 @@
 
 <script setup lang="ts">
 import { computed, PropType } from "vue";
-import type { MultiSelectComponent } from "../interface";
+import type { ArtifactOption, GlobalArtifactOption, MultiSelectComponent } from "../interface";
+import { buildArtifactOptions } from "./artifactFilter";
 
 const props = defineProps({
   schema: {
@@ -38,22 +39,33 @@ const props = defineProps({
     default: () => [],
   },
   availableArtifacts: {
-    type: Array as PropType<string[]>,
+    type: Array as PropType<ArtifactOption[]>,
+    default: () => [],
+  },
+  globalArtifacts: {
+    type: Array as PropType<GlobalArtifactOption[]>,
     default: () => [],
   },
 });
 
 defineEmits(["update:modelValue"]);
 
+// Value is always the bare artifact name; scope decides source and label.
 const options = computed(() => {
-  if (Array.isArray(props.schema.options)) {
-    return props.schema.options;
+  const opts = props.schema.options;
+  if (Array.isArray(opts)) {
+    return opts;
   }
-  if (props.schema.options?.__type__ === "IncomingColumns") {
+  if (opts?.__type__ === "IncomingColumns") {
     return props.incomingColumns;
   }
-  if (props.schema.options?.__type__ === "AvailableArtifacts") {
-    return props.availableArtifacts;
+  if (opts?.__type__ === "AvailableArtifacts") {
+    return buildArtifactOptions(
+      opts.scope,
+      props.availableArtifacts,
+      props.globalArtifacts,
+      opts.type_filter,
+    );
   }
   return [];
 });

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/SingleSelect.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/SingleSelect.vue
@@ -21,7 +21,8 @@
 
 <script setup lang="ts">
 import { computed, PropType } from "vue";
-import type { SingleSelectComponent } from "../interface";
+import type { ArtifactOption, GlobalArtifactOption, SingleSelectComponent } from "../interface";
+import { buildArtifactOptions } from "./artifactFilter";
 
 const props = defineProps({
   schema: {
@@ -37,22 +38,33 @@ const props = defineProps({
     default: () => [],
   },
   availableArtifacts: {
-    type: Array as PropType<string[]>,
+    type: Array as PropType<ArtifactOption[]>,
+    default: () => [],
+  },
+  globalArtifacts: {
+    type: Array as PropType<GlobalArtifactOption[]>,
     default: () => [],
   },
 });
 
 defineEmits(["update:modelValue"]);
 
+// Value is always the bare artifact name; scope decides source and label.
 const options = computed(() => {
-  if (Array.isArray(props.schema.options)) {
-    return props.schema.options;
+  const opts = props.schema.options;
+  if (Array.isArray(opts)) {
+    return opts;
   }
-  if (props.schema.options?.__type__ === "IncomingColumns") {
+  if (opts?.__type__ === "IncomingColumns") {
     return props.incomingColumns;
   }
-  if (props.schema.options?.__type__ === "AvailableArtifacts") {
-    return props.availableArtifacts;
+  if (opts?.__type__ === "AvailableArtifacts") {
+    return buildArtifactOptions(
+      opts.scope,
+      props.availableArtifacts,
+      props.globalArtifacts,
+      opts.type_filter,
+    );
   }
   return [];
 });

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/artifactFilter.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/artifactFilter.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { buildArtifactOptions, formatTypeShort, matchesTypeFilter } from "./artifactFilter";
+import type { ArtifactOption, GlobalArtifactOption } from "../interface";
+
+describe("matchesTypeFilter", () => {
+  it("matches everything when the filter is empty or absent", () => {
+    expect(matchesTypeFilter("xgboost.Booster", [])).toBe(true);
+    expect(matchesTypeFilter("xgboost.Booster")).toBe(true);
+  });
+
+  it("matches an exact dotted type", () => {
+    expect(matchesTypeFilter("xgboost.Booster", ["xgboost.Booster"])).toBe(true);
+    expect(matchesTypeFilter("xgboost.Booster", ["xgboost.Model"])).toBe(false);
+  });
+
+  it("honours a prefix glob", () => {
+    expect(matchesTypeFilter("xgboost.Booster", ["xgboost.*"])).toBe(true);
+    expect(matchesTypeFilter("lightgbm.Booster", ["xgboost.*"])).toBe(false);
+  });
+
+  it("honours a suffix glob", () => {
+    expect(matchesTypeFilter("xgboost.Booster", ["*.Booster"])).toBe(true);
+    expect(matchesTypeFilter("xgboost.Model", ["*.Booster"])).toBe(false);
+  });
+
+  it("treats regex specials in the type as literal", () => {
+    expect(matchesTypeFilter("pkg.Foo[Bar]", ["pkg.Foo[Bar]"])).toBe(true);
+    expect(matchesTypeFilter("pkg.Foo[Bar]", ["pkg.*"])).toBe(true);
+    // A dot in the glob is literal, not a regex wildcard.
+    expect(matchesTypeFilter("pkgXFoo", ["pkg.Foo"])).toBe(false);
+  });
+
+  it("is case-sensitive", () => {
+    expect(matchesTypeFilter("xgboost.Booster", ["xgboost.booster"])).toBe(false);
+  });
+
+  it("ORs multiple globs", () => {
+    expect(matchesTypeFilter("xgboost.Booster", ["nope", "xgboost.*"])).toBe(true);
+    expect(matchesTypeFilter("xgboost.Booster", ["nope", "also.nope"])).toBe(false);
+  });
+});
+
+describe("formatTypeShort", () => {
+  it("returns the last dot segment", () => {
+    expect(formatTypeShort("xgboost.sklearn.XGBClassifier")).toBe("XGBClassifier");
+  });
+
+  it("returns the input unchanged when there is no dot", () => {
+    expect(formatTypeShort("Booster")).toBe("Booster");
+  });
+});
+
+describe("buildArtifactOptions", () => {
+  const upstream: ArtifactOption[] = [
+    { name: "model", type_name: "Booster", module: "xgboost" },
+    { name: "scaler", type_name: "StandardScaler", module: "sklearn" },
+  ];
+  const global: GlobalArtifactOption[] = [
+    { name: "model", python_type: "lightgbm.Booster", version: 3 },
+    { name: "encoder", python_type: "sklearn.OneHotEncoder", version: 1 },
+  ];
+
+  it("routes to the upstream list for scope 'upstream' (and undefined default)", () => {
+    const expected = [
+      ["model", "model (Booster)"],
+      ["scaler", "scaler (StandardScaler)"],
+    ];
+    expect(buildArtifactOptions("upstream", upstream, global)).toEqual(expected);
+    expect(buildArtifactOptions(undefined, upstream, global)).toEqual(expected);
+  });
+
+  it("routes to the global list for scope 'global'", () => {
+    expect(buildArtifactOptions("global", upstream, global)).toEqual([
+      ["model", "model (v3 · Booster)"],
+      ["encoder", "encoder (v1 · OneHotEncoder)"],
+    ]);
+  });
+
+  it("scope 'all' dedupes by name, upstream entry wins", () => {
+    // "model" exists on both sides; the upstream entry + label survives, the
+    // global one is dropped. Non-colliding "encoder" is appended.
+    expect(buildArtifactOptions("all", upstream, global)).toEqual([
+      ["model", "model (Booster)"],
+      ["scaler", "scaler (StandardScaler)"],
+      ["encoder", "encoder (v1 · OneHotEncoder)"],
+    ]);
+  });
+
+  it("scope 'all' applies the type filter to both sides", () => {
+    const up: ArtifactOption[] = [
+      { name: "a", type_name: "Booster", module: "xgboost" },
+      { name: "b", type_name: "Booster", module: "lightgbm" },
+    ];
+    const gl: GlobalArtifactOption[] = [
+      { name: "c", python_type: "xgboost.XGBModel", version: 1 },
+      { name: "d", python_type: "sklearn.Foo", version: 2 },
+    ];
+    const out = buildArtifactOptions("all", up, gl, ["xgboost.*"]);
+    expect(out.map(([name]) => name)).toEqual(["a", "c"]);
+  });
+
+  it("returns an empty list when both sources are empty", () => {
+    expect(buildArtifactOptions("all", [], [])).toEqual([]);
+    expect(buildArtifactOptions("upstream", [], [])).toEqual([]);
+    expect(buildArtifactOptions("global", [], [])).toEqual([]);
+  });
+});

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/artifactFilter.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/artifactFilter.ts
@@ -1,0 +1,66 @@
+// Glob-based type filtering for artifact selects. Mirrors the backend
+// AvailableArtifacts type_filter semantics: `*` matches any run of chars,
+// every other char is literal, and any glob matching wins.
+
+import type { ArtifactOption, GlobalArtifactOption } from "../interface";
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = escaped.replace(/\\\*/g, ".*");
+  return new RegExp(`^${pattern}$`);
+}
+
+export function matchesTypeFilter(fullType: string, globs?: string[]): boolean {
+  if (!globs || globs.length === 0) return true;
+  return globs.some((glob) => globToRegExp(glob).test(fullType));
+}
+
+export function formatTypeShort(fullType: string): string {
+  const idx = fullType.lastIndexOf(".");
+  return idx >= 0 ? fullType.slice(idx + 1) : fullType;
+}
+
+// [value, label] pair; value is always the bare artifact name.
+export type ArtifactSelectOption = [string, string];
+
+export function upstreamArtifactOptions(
+  artifacts: ArtifactOption[],
+  typeFilter?: string[],
+): ArtifactSelectOption[] {
+  return artifacts
+    .filter((a) => matchesTypeFilter([a.module, a.type_name].filter(Boolean).join("."), typeFilter))
+    .map((a): ArtifactSelectOption => [a.name, a.type_name ? `${a.name} (${a.type_name})` : a.name]);
+}
+
+export function globalArtifactOptions(
+  artifacts: GlobalArtifactOption[],
+  typeFilter?: string[],
+): ArtifactSelectOption[] {
+  return artifacts
+    .filter((a) => matchesTypeFilter(a.python_type ?? "", typeFilter))
+    .map((a): ArtifactSelectOption => [
+      a.name,
+      `${a.name} (v${a.version}${a.python_type ? " · " + formatTypeShort(a.python_type) : ""})`,
+    ]);
+}
+
+// scope "all": upstream options first, then global options whose bare name is not
+// already present (dedupe by name, upstream entry wins). Type filter applies to both.
+export function buildArtifactOptions(
+  scope: "upstream" | "global" | "all" | undefined,
+  upstream: ArtifactOption[],
+  global: GlobalArtifactOption[],
+  typeFilter?: string[],
+): ArtifactSelectOption[] {
+  const resolved = scope ?? "upstream";
+  if (resolved === "global") {
+    return globalArtifactOptions(global, typeFilter);
+  }
+  const upstreamOpts = upstreamArtifactOptions(upstream, typeFilter);
+  if (resolved === "upstream") {
+    return upstreamOpts;
+  }
+  const seen = new Set(upstreamOpts.map(([name]) => name));
+  const globalOpts = globalArtifactOptions(global, typeFilter).filter(([name]) => !seen.has(name));
+  return [...upstreamOpts, ...globalOpts];
+}

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/interface.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/interface.ts
@@ -17,9 +17,32 @@ export interface TextInputComponent extends BaseComponent {
   placeholder?: string;
 }
 
+// Marker for artifact-populated selects; scope/type_filter omitted at defaults.
+export interface AvailableArtifactsMarker {
+  __type__: "AvailableArtifacts";
+  scope?: "upstream" | "global" | "all";
+  type_filter?: string[];
+}
+
+// One upstream (lineage) artifact option surfaced by /flow/node_available_artifacts.
+export interface ArtifactOption {
+  name: string;
+  type_name?: string;
+  module?: string;
+  status?: "published" | "declared";
+}
+
+// One global (catalog) artifact option surfaced by /artifacts/.
+export interface GlobalArtifactOption {
+  name: string;
+  python_type?: string | null;
+  namespace_id?: number | null;
+  version: number;
+}
+
 export interface MultiSelectComponent extends BaseComponent {
   component_type: "MultiSelect";
-  options: { __type__: "IncomingColumns" } | { __type__: "AvailableArtifacts" } | string[];
+  options: { __type__: "IncomingColumns" } | AvailableArtifactsMarker | string[];
 }
 
 export interface ToggleSwitchComponent extends BaseComponent {
@@ -42,7 +65,7 @@ export interface SliderInputComponent extends BaseComponent {
 
 export interface SingleSelectComponent extends BaseComponent {
   component_type: "SingleSelect";
-  options: { __type__: "IncomingColumns" } | { __type__: "AvailableArtifacts" } | string[];
+  options: { __type__: "IncomingColumns" } | AvailableArtifactsMarker | string[];
 }
 
 export interface ColumnSelectorComponent extends BaseComponent {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/__fixtures__/designer_state_roundtrip.json
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/__fixtures__/designer_state_roundtrip.json
@@ -12,6 +12,7 @@
   "number_of_outputs": 1,
   "output_names": ["main"],
   "environment": { "kind": "local", "dependencies": [], "default_kernel_id": null },
+  "publishes": [],
   "sections": [
     {
       "name": "main_config",
@@ -69,7 +70,19 @@
           "label": "Extra columns",
           "options_source": "incoming_columns",
           "options": [],
+          "artifact_scope": "upstream",
+          "artifact_type_filter": [],
           "default": []
+        },
+        {
+          "component_type": "SingleSelect",
+          "name": "saved_model",
+          "label": "Saved model",
+          "options_source": "available_artifacts",
+          "options": [],
+          "artifact_scope": "global",
+          "artifact_type_filter": ["xgboost.*", "lightgbm.Booster", "xgboost.*"],
+          "default": null
         }
       ]
     }

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/ControlInspector.vue
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/ControlInspector.vue
@@ -175,8 +175,19 @@
             >
               <option value="static">Static Options</option>
               <option value="incoming_columns">Incoming Columns</option>
-              <option value="available_artifacts">Available Artifacts</option>
+              <option
+                v-if="isKernel || comp.options_source === 'available_artifacts'"
+                value="available_artifacts"
+              >
+                Available Artifacts
+              </option>
             </select>
+            <span
+              v-if="!isKernel && comp.options_source === 'available_artifacts'"
+              class="field-hint"
+            >
+              Artifact selectors only work for kernel nodes.
+            </span>
           </div>
           <div v-if="comp.options_source === 'static'" class="field-row">
             <label>Options (comma-separated)</label>
@@ -188,6 +199,30 @@
               @input="updateOptions(($event.target as HTMLInputElement).value)"
             />
           </div>
+          <template v-if="comp.options_source === 'available_artifacts'">
+            <div class="field-row">
+              <label>Scope</label>
+              <select
+                :value="comp.artifact_scope"
+                class="ins-input"
+                @change="update('artifact_scope', ($event.target as HTMLSelectElement).value)"
+              >
+                <option value="upstream">Upstream (lineage)</option>
+                <option value="global">Global (catalog)</option>
+                <option value="all">All (upstream + global)</option>
+              </select>
+            </div>
+            <div class="field-row">
+              <label>Type Filter (comma-separated)</label>
+              <input
+                :value="artifactTypeFilterCsv"
+                type="text"
+                class="ins-input"
+                placeholder="e.g. xgboost.*, *.Booster"
+                @input="updateArtifactTypeFilter(($event.target as HTMLInputElement).value)"
+              />
+            </div>
+          </template>
         </div>
 
         <!-- ColumnSelector -->
@@ -377,6 +412,8 @@ const store = useNodeDesignerStore();
 
 const comp = computed<ComponentState | null>(() => store.selectedComponent);
 
+const isKernel = computed(() => store.environment.kind === "kernel");
+
 const showHelp = ref(false);
 
 const typeIcon = computed(() => getComponentIcon(comp.value?.component_type ?? ""));
@@ -431,6 +468,22 @@ function updateOptions(raw: string) {
     .filter(Boolean)
     .map((v) => ({ value: v, label: v }));
   update("options", opts);
+}
+
+const artifactTypeFilterCsv = computed(() => {
+  const c = comp.value;
+  if (c && (c.component_type === "SingleSelect" || c.component_type === "MultiSelect")) {
+    return (c.artifact_type_filter ?? []).join(", ");
+  }
+  return "";
+});
+
+function updateArtifactTypeFilter(raw: string) {
+  const filters = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  update("artifact_type_filter", filters);
 }
 
 const actionsCsv = computed(() => {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designerState.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designerState.ts
@@ -60,6 +60,9 @@ export interface SelectState extends ComponentBase {
   component_type: "SingleSelect" | "MultiSelect";
   options_source: OptionsSource;
   options: SelectOption[];
+  // available_artifacts only: lineage vs catalog source + dotted-type globs.
+  artifact_scope: "upstream" | "global" | "all";
+  artifact_type_filter: string[];
   // list for MultiSelect, scalar for SingleSelect
   default?: unknown;
 }
@@ -128,6 +131,12 @@ export interface ExampleInput {
   data: Record<string, unknown[]>;
 }
 
+/** A declared published artifact (name + optional dotted type hint). */
+export interface PublishState {
+  name: string;
+  type: string | null;
+}
+
 export interface DesignerState {
   schema_version: 1;
   class_name: string;
@@ -145,6 +154,7 @@ export interface DesignerState {
   number_of_outputs: number;
   output_names: string[];
   environment: EnvironmentState;
+  publishes: PublishState[];
   sections: SectionState[];
   process_code: string; // full `def process(...)` source, dedented, verbatim
   example_inputs: ExampleInput[] | null;
@@ -194,6 +204,7 @@ export function newDesignerState(): DesignerState {
     number_of_outputs: 1,
     output_names: ["main"],
     environment: newEnvironmentState(),
+    publishes: [],
     sections: [
       {
         name: "settings",

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/mappers.test.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/mappers.test.ts
@@ -9,7 +9,7 @@ import {
   toPascalCase,
   toSnakeCase,
 } from "./mappers";
-import type { DesignerState } from "./designerState";
+import type { DesignerState, SelectState } from "./designerState";
 import fixture from "./__fixtures__/designer_state_roundtrip.json";
 
 const state = fixture as unknown as DesignerState;
@@ -59,6 +59,63 @@ describe("designerStateToFrontendSchema", () => {
   it("renders IncomingColumns options as the __type__ marker", () => {
     const multi = schema.advanced.components.extra_cols;
     expect((multi as { options: unknown }).options).toEqual({ __type__: "IncomingColumns" });
+  });
+
+  it("emits the AvailableArtifacts marker with global scope and sorted-unique type_filter", () => {
+    const select = schema.advanced.components.saved_model;
+    expect((select as { options: unknown }).options).toEqual({
+      __type__: "AvailableArtifacts",
+      scope: "global",
+      type_filter: ["lightgbm.Booster", "xgboost.*"],
+    });
+  });
+
+  it("emits a bare AvailableArtifacts marker when scope/type_filter are at defaults", () => {
+    const select = defaultComponentState("SingleSelect", "art") as SelectState;
+    select.options_source = "available_artifacts";
+    const s = {
+      ...state,
+      sections: [
+        {
+          name: "s",
+          title: null,
+          description: null,
+          hidden: false,
+          visible_when: null,
+          layout: "vertical",
+          components: [select],
+        },
+      ],
+    } as unknown as DesignerState;
+    const bare = designerStateToFrontendSchema(s);
+    expect((bare.s.components.art as { options: unknown }).options).toEqual({
+      __type__: "AvailableArtifacts",
+    });
+  });
+
+  it("emits the AvailableArtifacts marker with scope 'all'", () => {
+    const select = defaultComponentState("SingleSelect", "art") as SelectState;
+    select.options_source = "available_artifacts";
+    select.artifact_scope = "all";
+    const s = {
+      ...state,
+      sections: [
+        {
+          name: "s",
+          title: null,
+          description: null,
+          hidden: false,
+          visible_when: null,
+          layout: "vertical",
+          components: [select],
+        },
+      ],
+    } as unknown as DesignerState;
+    const out = designerStateToFrontendSchema(s);
+    expect((out.s.components.art as { options: unknown }).options).toEqual({
+      __type__: "AvailableArtifacts",
+      scope: "all",
+    });
   });
 
   it("renders ColumnSelector required/multiple/data_types", () => {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/mappers.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/mappers.ts
@@ -20,6 +20,7 @@ import type {
 } from "./designerState";
 import { newDesignerState, newEnvironmentState } from "./designerState";
 import type {
+  AvailableArtifactsMarker,
   ColumnActionInputComponent,
   ColumnSelectorComponent,
   MultiSelectComponent,
@@ -71,7 +72,14 @@ type SelectOptions = SingleSelectComponent["options"];
 
 function optionsFromSelect(comp: SelectState): SelectOptions {
   if (comp.options_source === "incoming_columns") return { __type__: "IncomingColumns" };
-  if (comp.options_source === "available_artifacts") return { __type__: "AvailableArtifacts" };
+  if (comp.options_source === "available_artifacts") {
+    // Omit-when-default: byte-identical to the backend serializer (wire contract).
+    const marker: AvailableArtifactsMarker = { __type__: "AvailableArtifacts" };
+    if (comp.artifact_scope && comp.artifact_scope !== "upstream") marker.scope = comp.artifact_scope;
+    const filters = [...new Set(comp.artifact_type_filter ?? [])].sort();
+    if (filters.length) marker.type_filter = filters;
+    return marker;
+  }
   return comp.options.map((o) => o.value);
 }
 
@@ -225,6 +233,8 @@ export function defaultComponentState(type: ComponentType, name: string): Compon
         label,
         options_source: "static",
         options: [],
+        artifact_scope: "upstream",
+        artifact_type_filter: [],
         default: null,
       };
     case "MultiSelect":
@@ -234,6 +244,8 @@ export function defaultComponentState(type: ComponentType, name: string): Compon
         label,
         options_source: "static",
         options: [],
+        artifact_scope: "upstream",
+        artifact_type_filter: [],
         default: [],
       };
     case "ColumnSelector":
@@ -340,6 +352,8 @@ function legacyComponentToState(comp: DesignerComponent): ComponentState {
         label,
         options_source: (comp.options_source as SelectState["options_source"]) ?? "static",
         options: parseCsvOptions(comp.options_string),
+        artifact_scope: "upstream",
+        artifact_type_filter: [],
         default: type === "MultiSelect" ? [] : null,
       } as SelectState;
     case "ColumnSelector":

--- a/flowfile_frontend/src/renderer/app/types/kernel.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/kernel.types.ts
@@ -115,7 +115,7 @@ export interface DisplayOutput {
 export interface ExecuteResult {
   success: boolean;
   output_paths: string[];
-  artifacts_published: string[];
+  artifacts_published: { name: string; type_name?: string; module?: string; size_bytes?: number }[];
   artifacts_deleted: string[];
   display_outputs: DisplayOutput[];
   stdout: string;

--- a/kernel_runtime/kernel_runtime/flowfile_client.py
+++ b/kernel_runtime/kernel_runtime/flowfile_client.py
@@ -83,6 +83,7 @@ def _set_context(
     log_callback_url: str = "",
     internal_token: str | None = None,
     interactive: bool = False,
+    available_artifacts: dict[str, int] | None = None,
 ) -> None:
     _context.set(
         {
@@ -95,6 +96,9 @@ def _set_context(
             "log_callback_url": log_callback_url,
             "internal_token": internal_token,
             "interactive": interactive,
+            "available_artifacts": available_artifacts,
+            # Warn-once tracking per /execute; _set_context runs once per request.
+            "_lineage_warned": set(),
         }
     )
     if log_callback_url:
@@ -193,12 +197,35 @@ def publish_artifact(name: str, obj: Any) -> None:
     node_id: int = _get_context_value("node_id")
     flow_id: int = _get_context_value("flow_id")
     store.publish(name, obj, node_id, flow_id=flow_id)
+    # A node reading back what it just published is always in-lineage; add it to
+    # the allowlist so read_artifact doesn't warn about the node's own artifact.
+    allow: dict[str, int] | None = _get_context_value("available_artifacts")
+    if allow is not None:
+        allow[name] = node_id
 
 
 def read_artifact(name: str) -> Any:
     store: ArtifactStore = _get_context_value("artifact_store")
     flow_id: int = _get_context_value("flow_id")
-    return store.get(name, flow_id=flow_id)
+    obj = store.get(name, flow_id=flow_id)  # missing artifact raises KeyError, as before
+
+    allow: dict[str, int] | None = _get_context_value("available_artifacts")
+    if allow is not None and name not in allow:
+        warned: set[str] = _get_context_value("_lineage_warned")
+        if name not in warned:
+            warned.add(name)
+            node_id: int = _get_context_value("node_id")
+            publisher_id = store.list_all(flow_id=flow_id).get(name, {}).get("node_id", -1)
+            publisher = f"node {publisher_id}" if publisher_id is not None and publisher_id >= 0 else "another node"
+            log(
+                f"Artifact '{name}' was published by {publisher}, which is not an upstream "
+                f"input of node {node_id}. Reading artifacts from outside a node's input "
+                f"lineage is deprecated and will raise an error in a future Flowfile version. "
+                f"Connect the publishing node upstream, or publish the artifact globally and "
+                f"use get_global().",
+                "WARNING",
+            )
+    return obj
 
 
 def delete_artifact(name: str) -> None:
@@ -635,10 +662,13 @@ def log(message: str, level: Literal["INFO", "WARNING", "ERROR"] = "INFO") -> No
         "log_type": level,
     }
     try:
-        client.post(callback_url, json=payload)
+        resp = client.post(callback_url, json=payload)
+        if resp.status_code >= 400:
+            print(f"[{level}] {message}")  # noqa: T201
     except Exception:
-        # Best-effort — don't let logging failures break user code.
-        pass
+        # Delivery is best-effort; surface via captured stdout instead so
+        # the message is never silently lost.
+        print(f"[{level}] {message}")  # noqa: T201
 
 
 def log_info(message: str) -> None:

--- a/kernel_runtime/kernel_runtime/main.py
+++ b/kernel_runtime/kernel_runtime/main.py
@@ -366,6 +366,9 @@ class ExecuteRequest(BaseModel):
     log_callback_url: str = ""
     interactive: bool = False  # When True, auto-display last expression
     internal_token: str | None = None  # Core→kernel auth token for artifact API calls
+    # artifact name -> source_node_id. None means no lineage context (no enforcement);
+    # {} means lineage is known but nothing is in this node's input lineage.
+    available_artifacts: dict[str, int] | None = None
 
 
 class ClearNodeArtifactsRequest(BaseModel):
@@ -381,10 +384,19 @@ class DisplayOutput(BaseModel):
     title: str = ""
 
 
+class PublishedArtifact(BaseModel):
+    """Metadata for an in-memory artifact published during a run."""
+
+    name: str
+    type_name: str = ""
+    module: str = ""
+    size_bytes: int = 0
+
+
 class ExecuteResponse(BaseModel):
     success: bool
     output_paths: list[str] = []
-    artifacts_published: list[str] = []
+    artifacts_published: list[PublishedArtifact] = []
     artifacts_deleted: list[str] = []
     display_outputs: list[DisplayOutput] = []
     stdout: str = ""
@@ -477,6 +489,7 @@ def _run_user_code(
             log_callback_url=request.log_callback_url,
             internal_token=request.internal_token,
             interactive=request.interactive,
+            available_artifacts=request.available_artifacts,
         )
 
         flowfile_client._reset_displays()
@@ -522,9 +535,18 @@ def _run_user_code(
         if output_dir and Path(output_dir).exists():
             output_paths = [str(p) for p in sorted(Path(output_dir).glob("*.parquet"))]
 
-        artifacts_after = set(artifact_store.list_all(flow_id=request.flow_id).keys())
-        new_artifacts = sorted(artifacts_after - artifacts_before)
-        deleted_artifacts = sorted(artifacts_before - artifacts_after)
+        artifacts_meta = artifact_store.list_all(flow_id=request.flow_id)
+        new_names = sorted(set(artifacts_meta) - artifacts_before)
+        new_artifacts = [
+            PublishedArtifact(
+                name=name,
+                type_name=artifacts_meta[name].get("type_name", ""),
+                module=artifacts_meta[name].get("module", ""),
+                size_bytes=artifacts_meta[name].get("size_bytes", 0),
+            )
+            for name in new_names
+        ]
+        deleted_artifacts = sorted(artifacts_before - set(artifacts_meta))
 
         elapsed = (time.perf_counter() - start) * 1000
         return ExecuteResponse(

--- a/kernel_runtime/pyproject.toml
+++ b/kernel_runtime/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kernel-runtime"
-version = "0.4.0"
+version = "0.5.0"
 description = "FlowFile kernel runtime - executes Python code in isolated Docker containers"
 authors = ["Edward van Eechoud <evaneechoud@gmail.com>"]
 readme = "README.md"

--- a/kernel_runtime/tests/test_artifact_store.py
+++ b/kernel_runtime/tests/test_artifact_store.py
@@ -62,6 +62,17 @@ class TestListAll:
         listing = store.list_all()
         assert set(listing.keys()) == {"a", "b"}
 
+    def test_list_all_flow_scoped_exposes_publish_diff_fields(self, store: ArtifactStore):
+        """The publish diff in main._run_user_code reads type_name/module/size_bytes/node_id
+        off list_all(flow_id=...) — pin that those fields are present."""
+        store.publish("model", {"a": 1}, node_id=7, flow_id=99)
+        meta = store.list_all(flow_id=99)["model"]
+        assert meta["type_name"] == "dict"
+        assert meta["module"] == "builtins"
+        assert meta["node_id"] == 7
+        assert isinstance(meta["size_bytes"], int)
+        assert meta["size_bytes"] > 0
+
 
 class TestClear:
     def test_clear_empties_store(self, store: ArtifactStore):

--- a/kernel_runtime/tests/test_main.py
+++ b/kernel_runtime/tests/test_main.py
@@ -331,7 +331,7 @@ class TestArtifactEndpoints:
         )
         data = resp.json()
         assert data["success"] is True
-        assert "my_dict" in data["artifacts_published"]
+        assert "my_dict" in [a["name"] for a in data["artifacts_published"]]
 
     def test_list_artifacts(self, client: TestClient):
         client.post(
@@ -457,7 +457,7 @@ class TestArtifactEndpoints:
             },
         )
         assert resp1.json()["success"] is True
-        assert "model" in resp1.json()["artifacts_published"]
+        assert "model" in [a["name"] for a in resp1.json()["artifacts_published"]]
 
         resp2 = client.post(
             "/execute",
@@ -470,7 +470,7 @@ class TestArtifactEndpoints:
             },
         )
         assert resp2.json()["success"] is True
-        assert "model" in resp2.json()["artifacts_published"]
+        assert "model" in [a["name"] for a in resp2.json()["artifacts_published"]]
 
         resp3 = client.post(
             "/execute",
@@ -1450,3 +1450,166 @@ class TestDisplayOutputStore:
 
         resp = client.get("/display_outputs", params={"flow_id": 4, "node_id": 50})
         assert resp.json() == []
+
+
+class TestArtifactLineage:
+    """Lineage enforcement: reading an artifact outside a node's input lineage
+    warns (deprecation) but still returns the value; in-lineage / no-lineage-context
+    reads stay silent. The warning falls back to stdout when no log_callback_url."""
+
+    def _publish_model(self, client: TestClient, node_id: int, flow_id: int):
+        resp = client.post(
+            "/execute",
+            json={
+                "node_id": node_id,
+                "code": 'flowfile_ctx.publish_artifact("model", {"weight": 5})',
+                "flow_id": flow_id,
+                "input_paths": {},
+                "output_dir": "",
+            },
+        )
+        assert resp.json()["success"] is True
+
+    def test_out_of_lineage_read_warns_but_returns_value(self, client: TestClient):
+        self._publish_model(client, node_id=300, flow_id=500)
+
+        resp = client.post(
+            "/execute",
+            json={
+                "node_id": 301,
+                "code": 'm = flowfile_ctx.read_artifact("model")\nprint("derived:", m["weight"] * 2)',
+                "flow_id": 500,
+                "input_paths": {},
+                "output_dir": "",
+                "available_artifacts": {},
+            },
+        )
+        data = resp.json()
+        assert data["success"] is True, f"Execution failed: {data['error']}"
+        assert "not an upstream input" in data["stdout"]
+        assert "node 300" in data["stdout"]
+        # The read actually returned the object (derived value proves it).
+        assert "derived: 10" in data["stdout"]
+
+    def test_log_falls_back_to_stdout_when_callback_unreachable(self, client: TestClient):
+        self._publish_model(client, node_id=300, flow_id=507)
+
+        resp = client.post(
+            "/execute",
+            json={
+                "node_id": 301,
+                "code": 'flowfile_ctx.read_artifact("model")',
+                "flow_id": 507,
+                "input_paths": {},
+                "output_dir": "",
+                "available_artifacts": {},
+                "log_callback_url": "http://127.0.0.1:1/raw_logs",
+            },
+        )
+        data = resp.json()
+        assert data["success"] is True, f"Execution failed: {data['error']}"
+        # POST to the dead callback fails -> the warning must surface via stdout.
+        assert "not an upstream input" in data["stdout"]
+
+    def test_in_lineage_read_is_silent(self, client: TestClient):
+        self._publish_model(client, node_id=300, flow_id=501)
+
+        resp = client.post(
+            "/execute",
+            json={
+                "node_id": 301,
+                "code": 'm = flowfile_ctx.read_artifact("model")\nprint("derived:", m["weight"] * 2)',
+                "flow_id": 501,
+                "input_paths": {},
+                "output_dir": "",
+                "available_artifacts": {"model": 300},
+            },
+        )
+        data = resp.json()
+        assert data["success"] is True, f"Execution failed: {data['error']}"
+        assert "not an upstream input" not in data["stdout"]
+        assert "derived: 10" in data["stdout"]
+
+    def test_no_lineage_context_is_silent(self, client: TestClient):
+        """available_artifacts omitted (None) => legacy/interactive path, no enforcement."""
+        self._publish_model(client, node_id=300, flow_id=502)
+
+        resp = client.post(
+            "/execute",
+            json={
+                "node_id": 301,
+                "code": 'm = flowfile_ctx.read_artifact("model")\nprint("derived:", m["weight"] * 2)',
+                "flow_id": 502,
+                "input_paths": {},
+                "output_dir": "",
+            },
+        )
+        data = resp.json()
+        assert data["success"] is True, f"Execution failed: {data['error']}"
+        assert "not an upstream input" not in data["stdout"]
+        assert "derived: 10" in data["stdout"]
+
+    def test_published_artifact_rich_metadata(self, client: TestClient):
+        resp = client.post(
+            "/execute",
+            json={
+                "node_id": 310,
+                "code": 'flowfile_ctx.publish_artifact("cfg", {"a": 1})',
+                "flow_id": 503,
+                "input_paths": {},
+                "output_dir": "",
+            },
+        )
+        data = resp.json()
+        assert data["success"] is True
+        entries = {a["name"]: a for a in data["artifacts_published"]}
+        assert "cfg" in entries
+        entry = entries["cfg"]
+        assert entry["type_name"] == "dict"
+        assert entry["module"] == "builtins"
+        assert entry["size_bytes"] > 0
+
+    def test_out_of_lineage_read_warns_once(self, client: TestClient):
+        self._publish_model(client, node_id=300, flow_id=504)
+
+        resp = client.post(
+            "/execute",
+            json={
+                "node_id": 301,
+                "code": (
+                    'flowfile_ctx.read_artifact("model")\n'
+                    'flowfile_ctx.read_artifact("model")\n'
+                    'print("done")'
+                ),
+                "flow_id": 504,
+                "input_paths": {},
+                "output_dir": "",
+                "available_artifacts": {},
+            },
+        )
+        data = resp.json()
+        assert data["success"] is True, f"Execution failed: {data['error']}"
+        assert "done" in data["stdout"]
+        assert data["stdout"].count("not an upstream input") == 1
+
+    def test_same_node_publish_then_read_is_silent(self, client: TestClient):
+        """A node reading back its own just-published artifact must not warn."""
+        resp = client.post(
+            "/execute",
+            json={
+                "node_id": 320,
+                "code": (
+                    'flowfile_ctx.publish_artifact("m", {"weight": 7})\n'
+                    'back = flowfile_ctx.read_artifact("m")\n'
+                    'print("read back:", back["weight"])'
+                ),
+                "flow_id": 505,
+                "input_paths": {},
+                "output_dir": "",
+                "available_artifacts": {},
+            },
+        )
+        data = resp.json()
+        assert data["success"] is True, f"Execution failed: {data['error']}"
+        assert "read back: 7" in data["stdout"]
+        assert "not an upstream input" not in data["stdout"]

--- a/shared/node_designer/__init__.py
+++ b/shared/node_designer/__init__.py
@@ -7,6 +7,7 @@ user-facing spelling is ``from flowfile import node_designer as nd``.
 """
 
 from shared.node_designer.custom_node import (
+    Artifact,
     CustomNodeBase,
     NodeSettings,
     NodeSettingsBuilder,
@@ -41,6 +42,7 @@ from shared.node_designer.ui_components import (
 __all__ = [
     # Core Node Class
     "CustomNodeBase",
+    "Artifact",
     # UI Components & Layout
     "Section",
     "VisibleWhen",

--- a/shared/node_designer/custom_node.py
+++ b/shared/node_designer/custom_node.py
@@ -30,6 +30,14 @@ logger = logging.getLogger(__name__)
 _legacy_kernel_warned: set[str] = set()
 
 
+@dataclass(frozen=True)
+class Artifact:
+    """A named artifact a node declares it publishes (optionally typed)."""
+
+    name: str
+    type: str | None = None
+
+
 def _warn_legacy_once(cls: type, message: str) -> None:
     key = f"{cls.__module__}.{cls.__qualname__}:{message}"
     if key not in _legacy_kernel_warned:
@@ -84,6 +92,16 @@ def to_frontend_schema(model_instance: BaseModel) -> dict:
     return result
 
 
+def _available_artifacts_marker(marker: AvailableArtifacts) -> dict:
+    """Serialize an AvailableArtifacts instance to its wire marker (omit-when-default)."""
+    data: dict[str, Any] = {"__type__": "AvailableArtifacts"}
+    if marker.scope != "upstream":
+        data["scope"] = marker.scope
+    if marker.type_filter:
+        data["type_filter"] = sorted(set(marker.type_filter))
+    return data
+
+
 def _convert_value(value: Any) -> Any:
     """
     Helper function to convert any value to a frontend-ready format.
@@ -99,15 +117,15 @@ def _convert_value(value: Any) -> Any:
     elif isinstance(value, FlowfileInComponent):
         component_dict = value.model_dump(exclude_none=True)
         if "options" in component_dict:
-            if component_dict["options"] is IncomingColumns or (
-                isinstance(component_dict["options"], type) and issubclass(component_dict["options"], IncomingColumns)
-            ):
+            options = component_dict["options"]
+            if options is IncomingColumns or (isinstance(options, type) and issubclass(options, IncomingColumns)):
                 component_dict["options"] = {"__type__": "IncomingColumns"}
-            if component_dict["options"] is AvailableArtifacts or (
-                isinstance(component_dict["options"], type)
-                and issubclass(component_dict["options"], AvailableArtifacts)
+            elif options is AvailableArtifacts or (
+                isinstance(options, type) and issubclass(options, AvailableArtifacts)
             ):
                 component_dict["options"] = {"__type__": "AvailableArtifacts"}
+            elif isinstance(options, AvailableArtifacts):
+                component_dict["options"] = _available_artifacts_marker(options)
         return component_dict
     elif isinstance(value, BaseModel):
         return to_frontend_schema(value)
@@ -440,6 +458,9 @@ class CustomNodeBase(BaseModel):
     author: str | None = None
     version: str | None = None
     tags: list[str] = Field(default_factory=list)
+
+    # Artifacts this node declares it publishes (optional; drives lineage-aware pickers)
+    publishes: list[Artifact] = Field(default_factory=list)
 
     # Behavior properties
     node_type: NodeTypeLiteral = "process"
@@ -782,4 +803,11 @@ if not inputs:
             custom_node=True,
             execution_environment=self.environment,
             dependencies=self.dependencies or None,
+            # pydantic v2 doesn't coerce class-attribute defaults, so a
+            # `publishes = ["model"]` default holds plain strings at exec time.
+            publishes=[
+                {"name": a, "type": None} if isinstance(a, str) else {"name": a.name, "type": a.type}
+                for a in self.publishes
+            ]
+            or None,
         )

--- a/shared/node_designer/ui_components.py
+++ b/shared/node_designer/ui_components.py
@@ -96,16 +96,36 @@ class IncomingColumns:
     pass
 
 
+def _normalize_artifact_type_filter(type_spec: str | list[str] | None) -> list[str] | None:
+    """sorted-unique string list, or None when unset/empty (matches the AST parser)."""
+    if type_spec is None:
+        return None
+    items = [type_spec] if isinstance(type_spec, str) else list(type_spec)
+    result = sorted(set(items))
+    return result or None
+
+
 class AvailableArtifacts:
     """
-    A marker class used in `SingleSelect` and `MultiSelect` components.
+    A marker used in `SingleSelect` and `MultiSelect` components.
 
-    When `options` is set to this class, the component will be dynamically
-    populated with available artifact names from upstream nodes. This is
-    useful for selecting models or other shared artifacts by name.
+    When `options` is set to this class (or an instance of it), the component
+    is dynamically populated with available artifact names. `scope` chooses
+    between upstream-only (default), global, and all (upstream ∪ global)
+    artifacts; `type` optionally filters by fully-qualified type name pattern(s).
+
+    Usage:
+        options=AvailableArtifacts                        # bare marker, upstream
+        options=AvailableArtifacts(scope="global")        # global artifacts
+        options=AvailableArtifacts(scope="all")           # upstream + global
+        options=AvailableArtifacts(type=["sklearn.*"])    # filtered by type
     """
 
-    pass
+    def __init__(self, scope: Literal["upstream", "global", "all"] = "upstream", type: str | list[str] | None = None):
+        if scope not in ("upstream", "global", "all"):
+            raise ValueError(f"AvailableArtifacts scope must be 'upstream', 'global' or 'all', got {scope!r}")
+        self.scope = scope
+        self.type_filter = _normalize_artifact_type_filter(type)
 
 
 class ColumnSelector(FlowfileInComponent):
@@ -222,9 +242,12 @@ class SingleSelect(FlowfileInComponent):
     """
 
     component_type: Literal["SingleSelect"] = "SingleSelect"
-    options: list[str | tuple[str, Any]] | type[IncomingColumns] | type[AvailableArtifacts]
+    options: list[str | tuple[str, Any]] | type[IncomingColumns] | type[AvailableArtifacts] | AvailableArtifacts
     default: Any | None = None
     input_type: InputType = "text"
+
+    class Config:
+        arbitrary_types_allowed = True
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -241,9 +264,12 @@ class MultiSelect(FlowfileInComponent):
     """
 
     component_type: Literal["MultiSelect"] = "MultiSelect"
-    options: list[str | tuple[str, Any]] | type[IncomingColumns] | type[AvailableArtifacts]
+    options: list[str | tuple[str, Any]] | type[IncomingColumns] | type[AvailableArtifacts] | AvailableArtifacts
     default: list[Any] = Field(default_factory=list)
     input_type: InputType = "array"
+
+    class Config:
+        arbitrary_types_allowed = True
 
     def __init__(self, **data):
         super().__init__(**data)


### PR DESCRIPTION
This pull request introduces several improvements and new features to artifact handling and node designer code generation/parsing, as well as minor updates to documentation and versioning. The main changes include enhanced artifact merging logic, improved code generation for artifact-related node designer components, expanded parsing support for artifact selection, and updated kernel image versioning.

**Artifact handling and merging:**

* Added a new `merge_declared_artifacts` function to merge runtime-observed artifact references with manifest-declared publishes, ensuring declared artifacts are included in outputs even if not published during a run.
* Updated flow execution (`_execute_on_kernel` in `flow_graph.py`) to receive and handle declared publishes, log warnings for missing declared artifacts, and pass available artifact information to the kernel. [[1]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R2070) [[2]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R2187-R2198) [[3]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R2112) [[4]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R2143-R2148)

**Node designer codegen improvements:**

* Enhanced code generation to support `Artifact` and `AvailableArtifacts` as proper code constructs, including rendering artifact publishes as `nd.Artifact(...)` calls and supporting parameterized `AvailableArtifacts` calls in select component options. [[1]](diffhunk://#diff-826ae291600f7e32c92928188c4179ef5857f24232aa9e55c3c78ab31203e5b3R41-R49) [[2]](diffhunk://#diff-826ae291600f7e32c92928188c4179ef5857f24232aa9e55c3c78ab31203e5b3R136-R142) [[3]](diffhunk://#diff-826ae291600f7e32c92928188c4179ef5857f24232aa9e55c3c78ab31203e5b3L200-R218) [[4]](diffhunk://#diff-826ae291600f7e32c92928188c4179ef5857f24232aa9e55c3c78ab31203e5b3R234-R245) [[5]](diffhunk://#diff-826ae291600f7e32c92928188c4179ef5857f24232aa9e55c3c78ab31203e5b3L253-R288) [[6]](diffhunk://#diff-826ae291600f7e32c92928188c4179ef5857f24232aa9e55c3c78ab31203e5b3R410-R423)
* Re-exported `Artifact` in `node_designer/__init__.py` and `custom_node.py` for easier access in custom node modules. [[1]](diffhunk://#diff-7dff95a644b34eae0f27de733fde94a096d5bffe3ab6ae3f6118b7e70e155873R13) [[2]](diffhunk://#diff-7dff95a644b34eae0f27de733fde94a096d5bffe3ab6ae3f6118b7e70e155873R47) [[3]](diffhunk://#diff-58decfc84f9b2cbca6c92711e08f0198b56795b523041f63191837c7d18e813dR4) [[4]](diffhunk://#diff-58decfc84f9b2cbca6c92711e08f0198b56795b523041f63191837c7d18e813dR17)

**Node designer parsing enhancements:**

* Extended the parser to support the `AvailableArtifacts` marker with `scope` and `type` parameters, including validation and normalization of type filters, and improved error handling for misuse of artifact markers in select components. [[1]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beL138-R143) [[2]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beR452-R453) [[3]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beR488-R518) [[4]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beL673-R725)
* Added support for parsing artifact publish declarations and error reporting (`publishes`) in designer code. [[1]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beR17) [[2]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beR127)

**Documentation and versioning:**

* Updated documentation to reflect the new default kernel image tag version (`0.5.0` as of 2026-07) and clarified version pinning in developer docs.

These changes collectively improve the robustness of artifact tracking, the expressiveness of node designer code, and the clarity of developer documentation.