### PR TITLE
Feature/add preview images

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/artifacts.py
+++ b/flowfile_core/flowfile_core/flowfile/artifacts.py
@@ -27,6 +27,8 @@ class ArtifactRef:
     type_name: str = ""
     module: str = ""
     size_bytes: int = 0
+    has_preview: bool = False
+    preview_mime: str = ""
     created_at: datetime = field(default_factory=datetime.now)
 
     def to_dict(self) -> dict[str, Any]:
@@ -37,6 +39,8 @@ class ArtifactRef:
             "type_name": self.type_name,
             "module": self.module,
             "size_bytes": self.size_bytes,
+            "has_preview": self.has_preview,
+            "preview_mime": self.preview_mime,
             "created_at": self.created_at.isoformat(),
         }
 
@@ -107,6 +111,8 @@ class ArtifactContext:
                 type_name=item.get("type_name", ""),
                 module=item.get("module", ""),
                 size_bytes=item.get("size_bytes", 0),
+                has_preview=item.get("has_preview", False),
+                preview_mime=item.get("preview_mime") or "",
                 created_at=datetime.now(timezone.utc),
             )
             refs.append(ref)
@@ -412,6 +418,8 @@ class ArtifactContext:
                         "name": r.name,
                         "type_name": r.type_name,
                         "module": r.module,
+                        "has_preview": r.has_preview,
+                        "preview_mime": r.preview_mime,
                     }
                     for r in state.published
                 ],

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -1377,18 +1377,7 @@ class FlowGraph:
                 if hasattr(node_info.setting_input, "is_user_defined") and node_info.setting_input.is_user_defined:
                     # .get() execs the node module lazily; on any failure the node
                     # lands in the missing/error path so the flow still opens.
-                    user_defined_node_class = CUSTOM_NODE_STORE.get(node_info.type)
-                    if user_defined_node_class is not None:
-                        self.add_user_defined_node(
-                            custom_node=user_defined_node_class.from_settings(node_info.setting_input.settings),
-                            user_defined_node_settings=node_info.setting_input,
-                        )
-                    else:
-                        self.add_missing_user_defined_node(
-                            user_defined_node_settings=node_info.setting_input,
-                            node_type=node_info.type,
-                            error=missing_custom_node_error(node_info.type),
-                        )
+                    self._place_user_defined_node(node_info.type, node_info.setting_input)
                 else:
                     add_method = getattr(self, "add_" + node_info.type, None)
                     if add_method:
@@ -1981,6 +1970,24 @@ class FlowGraph:
         )
         node = self.get_node(user_defined_node_settings.node_id)
         node.results.errors = error
+
+    def _place_user_defined_node(
+        self, node_type: str, user_defined_node_settings: input_schema.UserDefinedNode
+    ) -> None:
+        """Place a custom node from the store, degrading to a missing-node placeholder when
+        its type isn't installed. Shared by copy and both flow-restore paths."""
+        user_defined_node_class = CUSTOM_NODE_STORE.get(node_type)
+        if user_defined_node_class is not None:
+            self.add_user_defined_node(
+                custom_node=user_defined_node_class.from_settings(user_defined_node_settings.settings),
+                user_defined_node_settings=user_defined_node_settings,
+            )
+        else:
+            self.add_missing_user_defined_node(
+                user_defined_node_settings=user_defined_node_settings,
+                node_type=node_type,
+                error=missing_custom_node_error(node_type),
+            )
 
     def _make_local_user_defined_func(
         self,
@@ -5882,6 +5889,10 @@ class FlowGraph:
             existing_setting_input: The settings object from the node being copied.
             node_type: The type of the node being copied.
         """
+        # A custom node whose type isn't installed needs a placeholder template before
+        # the promise can be placed (mirrors the flow-restore path).
+        if getattr(existing_setting_input, "is_user_defined", False) and node_type not in CUSTOM_NODE_STORE:
+            register_missing_node_template(node_type)
         self.add_node_promise(new_node_settings)
 
         if isinstance(existing_setting_input, input_schema.NodePromise):
@@ -5898,7 +5909,10 @@ class FlowGraph:
                 combined_settings.input_name, node_type, combined_settings.node_id
             )
         try:
-            getattr(self, f"add_{node_type}")(combined_settings)
+            if getattr(existing_setting_input, "is_user_defined", False):
+                self._place_user_defined_node(node_type, combined_settings)
+            else:
+                getattr(self, f"add_{node_type}")(combined_settings)
         except Exception:
             # A failed copy must not leave the pre-added promise dangling in the graph.
             if self.get_node(new_node_settings.node_id) is not None:

--- a/flowfile_core/flowfile_core/flowfile/manage/io_flowfile.py
+++ b/flowfile_core/flowfile_core/flowfile/manage/io_flowfile.py
@@ -6,7 +6,6 @@ from flowfile_core.configs.settings import is_docker_mode
 from flowfile_core.flowfile.flow_graph import FlowGraph, restore_dynamic_input_connections
 from flowfile_core.flowfile.flow_node.multi_output import DEFAULT_OUTPUT_HANDLE
 from flowfile_core.flowfile.manage.compatibility_enhancements import ensure_compatibility, load_flowfile_pickle
-from flowfile_core.flowfile.user_defined.registry import missing_custom_node_error
 from flowfile_core.schemas import input_schema, schemas
 from flowfile_core.schemas.schemas import get_settings_class_for_node_type
 from shared.storage_config import storage
@@ -334,18 +333,7 @@ def open_flow(flow_path: Path, user_id: int | None = None) -> FlowGraph:
                 # .get() execs the node module lazily; missing or exec-broken nodes
                 # land in the error path so a flow always opens with settings
                 # preserved verbatim instead of being dropped.
-                user_defined_node_class = CUSTOM_NODE_STORE.get(node_info.type)
-                if user_defined_node_class is None:
-                    new_flow.add_missing_user_defined_node(
-                        user_defined_node_settings=node_info.setting_input,
-                        node_type=node_info.type,
-                        error=missing_custom_node_error(node_info.type),
-                    )
-                else:
-                    new_flow.add_user_defined_node(
-                        custom_node=user_defined_node_class.from_settings(node_info.setting_input.settings),
-                        user_defined_node_settings=node_info.setting_input,
-                    )
+                new_flow._place_user_defined_node(node_info.type, node_info.setting_input)
             else:
                 getattr(new_flow, "add_" + node_info.type)(node_info.setting_input)
 

--- a/flowfile_core/flowfile_core/flowfile/user_defined/kernel_codegen.py
+++ b/flowfile_core/flowfile_core/flowfile/user_defined/kernel_codegen.py
@@ -180,7 +180,8 @@ def generate_kernel_script(
     # process() runs; the kernel runtime captures stderr into the Test panel. The
     # handler is torn down in `finally` so the long-lived kernel never leaks handlers.
     # Root-DEBUG also unmutes chatty libraries — the log callback itself makes httpx
-    # calls — so pin the known-noisy ones to WARNING to keep the Test panel readable.
+    # calls, and matplotlib's font manager logs hundreds of findfont lines per figure
+    # — so pin the known-noisy ones to WARNING to keep the Test panel readable.
     exec_body = (
         "_inputs_by_name = flowfile_ctx.read_inputs()\n"
         "_inputs = [_lf for _lfs in _inputs_by_name.values() for _lf in _lfs]\n"
@@ -195,7 +196,9 @@ def generate_kernel_script(
         "_prev_log_level = _root_logger.level\n"
         "_root_logger.addHandler(_log_handler)\n"
         "_root_logger.setLevel(logging.DEBUG)\n"
-        'for _noisy in ("httpx", "httpcore", "urllib3", "asyncio"):\n'
+        '_noisy_libs = ("httpx", "httpcore", "urllib3", "asyncio",\n'
+        '               "matplotlib", "PIL", "fontTools", "kernel_runtime")\n'
+        "for _noisy in _noisy_libs:\n"
         "    logging.getLogger(_noisy).setLevel(logging.WARNING)\n"
         "try:\n"
         f"{_indent(exec_body)}\n"

--- a/flowfile_core/flowfile_core/kernel/manager.py
+++ b/flowfile_core/flowfile_core/kernel/manager.py
@@ -1860,6 +1860,18 @@ class KernelManager:
             response.raise_for_status()
             return response.json()
 
+    async def get_artifact_preview(self, kernel_id: str, flow_id: int, name: str) -> dict | None:
+        """Retrieve a rendered preview blob for a published artifact (session-only, kernel-held)."""
+        kernel = self._get_kernel_or_raise(kernel_id)
+        if kernel.state not in (KernelState.IDLE, KernelState.EXECUTING):
+            await self._ensure_running(kernel_id)
+
+        url = f"{self._kernel_url(kernel)}/artifact_preview"
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0)) as client:
+            response = await client.get(url, params={"flow_id": flow_id, "name": name})
+            response.raise_for_status()
+            return response.json()
+
     # Artifact Persistence & Recovery
 
     async def recover_artifacts(self, kernel_id: str) -> RecoveryStatus:

--- a/flowfile_core/flowfile_core/kernel/models.py
+++ b/flowfile_core/flowfile_core/kernel/models.py
@@ -162,6 +162,8 @@ class PublishedArtifact(BaseModel):
     type_name: str = ""
     module: str = ""
     size_bytes: int = 0
+    has_preview: bool = False
+    preview_mime: str | None = None
 
 
 class ExecuteResult(BaseModel):

--- a/flowfile_core/flowfile_core/kernel/routes.py
+++ b/flowfile_core/flowfile_core/kernel/routes.py
@@ -433,6 +433,28 @@ async def get_display_outputs(
         return []
 
 
+@router.get("/{kernel_id}/artifact_preview")
+async def get_artifact_preview(
+    kernel_id: str,
+    flow_id: int,
+    name: str,
+    current_user=Depends(get_current_active_user),
+):
+    """Proxy a session-only artifact preview blob from the kernel; core retains nothing."""
+    manager = _get_manager()
+    kernel = await manager.get_kernel(kernel_id)
+    if kernel is None:
+        raise HTTPException(status_code=404, detail=f"Kernel '{kernel_id}' not found")
+    if manager.get_kernel_owner(kernel_id) != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to access this kernel")
+    if kernel.state.value not in ("idle", "executing"):
+        return None
+    try:
+        return await manager.get_artifact_preview(kernel_id, flow_id, name)
+    except Exception:
+        return None
+
+
 # Artifact Persistence & Recovery endpoints
 
 

--- a/flowfile_core/tests/flowfile/test_artifact_context.py
+++ b/flowfile_core/tests/flowfile/test_artifact_context.py
@@ -10,6 +10,7 @@ from flowfile_core.flowfile.artifacts import (
     NodeArtifactState,
     merge_declared_artifacts,
 )
+from flowfile_core.kernel.models import ExecuteResult, PublishedArtifact
 
 
 # ArtifactRef
@@ -573,8 +574,88 @@ class TestArtifactRichMetadataRoundTrip:
         summaries = ctx.get_node_summaries()
         published = summaries["1"]["published"]
         assert published == [
-            {"name": "model", "type_name": "RandomForestClassifier", "module": "sklearn.ensemble"}
+            {
+                "name": "model",
+                "type_name": "RandomForestClassifier",
+                "module": "sklearn.ensemble",
+                "has_preview": False,
+                "preview_mime": "",
+            }
         ]
+
+
+# ArtifactContext — Preview metadata round-trip
+
+
+class TestArtifactPreviewMetadata:
+    def test_record_published_carries_preview_fields(self):
+        ctx = ArtifactContext()
+        refs = ctx.record_published(
+            1,
+            "k1",
+            [{"name": "chart", "has_preview": True, "preview_mime": "image/png"}],
+        )
+        assert refs[0].has_preview is True
+        assert refs[0].preview_mime == "image/png"
+
+    def test_to_dict_includes_preview_fields(self):
+        ref = ArtifactRef(name="chart", source_node_id=1, has_preview=True, preview_mime="image/png")
+        d = ref.to_dict()
+        assert d["has_preview"] is True
+        assert d["preview_mime"] == "image/png"
+
+    def test_node_summaries_surface_preview_fields(self):
+        ctx = ArtifactContext()
+        ctx.record_published(
+            1,
+            "k1",
+            [{"name": "chart", "has_preview": True, "preview_mime": "image/png"}],
+        )
+        published = ctx.get_node_summaries()["1"]["published"]
+        assert published == [
+            {
+                "name": "chart",
+                "type_name": "",
+                "module": "",
+                "has_preview": True,
+                "preview_mime": "image/png",
+            }
+        ]
+
+    def test_legacy_dict_without_keys_defaults(self):
+        """Old kernel payloads omit the preview keys → defaults False/''."""
+        ctx = ArtifactContext()
+        refs = ctx.record_published(1, "k1", [{"name": "model"}])
+        assert refs[0].has_preview is False
+        assert refs[0].preview_mime == ""
+
+    def test_none_preview_mime_normalizes_to_empty(self):
+        """model_dump yields None for an unset preview_mime; it must become ''."""
+        ctx = ArtifactContext()
+        refs = ctx.record_published(1, "k1", [{"name": "model", "has_preview": False, "preview_mime": None}])
+        assert refs[0].preview_mime == ""
+
+
+# PublishedArtifact / ExecuteResult (kernel wire model) forward/backward compat
+
+
+class TestPublishedArtifactCompat:
+    def test_new_fields_default_on_legacy_payload(self):
+        """A payload from an old kernel image lacks the preview keys → defaults."""
+        art = PublishedArtifact(name="model", type_name="RandomForest", size_bytes=10)
+        assert art.has_preview is False
+        assert art.preview_mime is None
+
+    def test_new_fields_parse_when_present(self):
+        art = PublishedArtifact(name="chart", has_preview=True, preview_mime="image/png")
+        assert art.has_preview is True
+        assert art.preview_mime == "image/png"
+
+    def test_normalize_published_maps_plain_strings(self):
+        """Stale 0.4.0 kernels emit bare name strings; they degrade to names-only."""
+        result = ExecuteResult(success=True, artifacts_published=["model", "scaler"])
+        assert [a.name for a in result.artifacts_published] == ["model", "scaler"]
+        assert result.artifacts_published[0].has_preview is False
 
 
 # merge_declared_artifacts

--- a/flowfile_core/tests/flowfile/test_custom_node_flow_roundtrip.py
+++ b/flowfile_core/tests/flowfile/test_custom_node_flow_roundtrip.py
@@ -300,3 +300,53 @@ class TestSchemaDrift:
         assert result.success
         expected = FlowDataEngine({"a": [1, 2], "kept_col": ["kept", "kept"]})
         expected.assert_equal(loaded.get_node(2).get_resulting_data())
+
+
+class TestCopyCustomNode:
+    """Copying a custom node must place it via the user-defined path, not the built-in
+    ``add_<type>`` dispatch (which raised AttributeError for custom node types)."""
+
+    def test_copy_configured_custom_node_runs(self, store_snapshot):
+        store_snapshot.add_to_custom_node_store(RoundtripFixedColumn)
+        flow = build_flow_with_custom_node(6200)
+        source = flow.get_node(2)
+
+        copied_promise = input_schema.NodePromise(flow_id=6200, node_id=3, node_type=NODE_TYPE)
+        flow.copy_node(
+            new_node_settings=copied_promise,
+            existing_setting_input=source.setting_input,
+            node_type=source.node_type,
+        )
+
+        copied = flow.get_node(3)
+        assert copied is not None, "copied custom node must be placed, not dropped"
+        assert copied.node_type == NODE_TYPE
+        assert isinstance(copied.setting_input, input_schema.UserDefinedNode)
+        assert copied.setting_input.is_user_defined is True
+        assert copied.setting_input.settings == SETTINGS
+
+        add_connection(flow, input_schema.NodeConnection.create_from_simple_input(1, 3))
+        result = flow.run_graph()
+        assert result.success, result
+        expected = FlowDataEngine({"a": [1, 2], "custom_col": ["hello", "hello"]})
+        expected.assert_equal(flow.get_node(3).get_resulting_data())
+
+    def test_copy_missing_custom_node_degrades(self, store_snapshot):
+        store_snapshot.add_to_custom_node_store(RoundtripFixedColumn)
+        flow = build_flow_with_custom_node(6201)
+        source = flow.get_node(2)
+        # simulate the node type being uninstalled after the source was placed
+        store_snapshot.remove_from_custom_node_store(NODE_TYPE)
+
+        copied_promise = input_schema.NodePromise(flow_id=6201, node_id=3, node_type=NODE_TYPE)
+        flow.copy_node(
+            new_node_settings=copied_promise,
+            existing_setting_input=source.setting_input,
+            node_type=source.node_type,
+        )
+
+        copied = flow.get_node(3)
+        assert copied is not None, "missing custom node must never be dropped on copy"
+        assert copied.node_type == NODE_TYPE
+        assert "not installed" in copied.results.errors
+        assert copied.setting_input.settings == SETTINGS

--- a/flowfile_core/tests/kernel/test_artifact_preview_route.py
+++ b/flowfile_core/tests/kernel/test_artifact_preview_route.py
@@ -1,0 +1,103 @@
+"""Hermetic tests for GET /kernels/{id}/artifact_preview.
+
+Core proxies a session-only preview blob from the kernel and retains nothing.
+No Docker required — the kernel manager is stubbed so the owner/state ladder and
+the verbatim passthrough are exercised in-process.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from flowfile_core import main
+from flowfile_core.kernel import routes as kernel_routes
+from flowfile_core.kernel.models import KernelState
+
+
+@pytest.fixture(scope="module")
+def token() -> str:
+    with TestClient(main.app) as auth_c:
+        return auth_c.post("/auth/token").json()["access_token"]
+
+
+@pytest.fixture(scope="module")
+def client(token: str) -> TestClient:
+    c = TestClient(main.app)
+    c.headers = {"Authorization": f"Bearer {token}"}
+    return c
+
+
+@pytest.fixture(scope="module")
+def owner_id(client: TestClient) -> int:
+    return client.get("/auth/users/me").json()["id"]
+
+
+class _StubKernel:
+    def __init__(self, state: KernelState):
+        self.state = state
+
+
+class _StubManager:
+    def __init__(self, *, kernel, owner_id, preview=None, raises=False):
+        self._kernel = kernel
+        self._owner_id = owner_id
+        self._preview = preview
+        self._raises = raises
+
+    async def get_kernel(self, kernel_id: str):
+        return self._kernel
+
+    def get_kernel_owner(self, kernel_id: str):
+        return self._owner_id
+
+    async def get_artifact_preview(self, kernel_id: str, flow_id: int, name: str):
+        if self._raises:
+            raise RuntimeError("kernel unreachable")
+        return self._preview
+
+
+def _install_manager(monkeypatch, manager: _StubManager) -> None:
+    monkeypatch.setattr(kernel_routes, "_get_manager", lambda: manager)
+
+
+def test_unknown_kernel_returns_404(client: TestClient, owner_id: int, monkeypatch):
+    _install_manager(monkeypatch, _StubManager(kernel=None, owner_id=owner_id))
+    resp = client.get("/kernels/no-such-kernel/artifact_preview", params={"flow_id": 1, "name": "x"})
+    assert resp.status_code == 404
+
+
+def test_non_owner_returns_403(client: TestClient, owner_id: int, monkeypatch):
+    kernel = _StubKernel(KernelState.IDLE)
+    _install_manager(monkeypatch, _StubManager(kernel=kernel, owner_id=owner_id + 999))
+    resp = client.get("/kernels/k1/artifact_preview", params={"flow_id": 1, "name": "x"})
+    assert resp.status_code == 403
+
+
+def test_not_running_returns_null(client: TestClient, owner_id: int, monkeypatch):
+    kernel = _StubKernel(KernelState.STOPPED)
+    _install_manager(monkeypatch, _StubManager(kernel=kernel, owner_id=owner_id, preview={"data": "abc"}))
+    resp = client.get("/kernels/k1/artifact_preview", params={"flow_id": 1, "name": "x"})
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+def test_running_kernel_passthrough_verbatim(client: TestClient, owner_id: int, monkeypatch):
+    preview = {"mime_type": "image/png", "data": "abc", "title": "chart"}
+    kernel = _StubKernel(KernelState.EXECUTING)
+    _install_manager(monkeypatch, _StubManager(kernel=kernel, owner_id=owner_id, preview=preview))
+    resp = client.get("/kernels/k1/artifact_preview", params={"flow_id": 1, "name": "chart"})
+    assert resp.status_code == 200
+    assert resp.json() == preview
+
+
+def test_kernel_error_degrades_to_null(client: TestClient, owner_id: int, monkeypatch):
+    kernel = _StubKernel(KernelState.IDLE)
+    _install_manager(monkeypatch, _StubManager(kernel=kernel, owner_id=owner_id, raises=True))
+    resp = client.get("/kernels/k1/artifact_preview", params={"flow_id": 1, "name": "x"})
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+def test_unauthenticated_is_rejected():
+    c = TestClient(main.app)
+    resp = c.get("/kernels/k1/artifact_preview", params={"flow_id": 1, "name": "x"})
+    assert resp.status_code in (401, 403)

--- a/flowfile_frontend/src/renderer/app/api/kernel.api.test.ts
+++ b/flowfile_frontend/src/renderer/app/api/kernel.api.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DisplayOutput } from "../types";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock("../services/axios.config", () => ({
+  default: { get: mocks.get },
+}));
+
+import { KernelApi } from "./kernel.api";
+
+const payload: DisplayOutput = {
+  mime_type: "image/png",
+  data: "base64data",
+  title: "Chart",
+};
+
+beforeEach(() => {
+  mocks.get.mockReset();
+});
+
+describe("KernelApi.getArtifactPreview", () => {
+  it("calls the exact URL (no trailing slash) with flow_id + name params", async () => {
+    mocks.get.mockResolvedValue({ data: payload });
+
+    await KernelApi.getArtifactPreview("k1", 5, "chart");
+
+    expect(mocks.get).toHaveBeenCalledWith("/kernels/k1/artifact_preview", {
+      params: { flow_id: 5, name: "chart" },
+    });
+  });
+
+  it("returns the payload verbatim", async () => {
+    mocks.get.mockResolvedValue({ data: payload });
+
+    const result = await KernelApi.getArtifactPreview("k1", 5, "chart");
+
+    expect(result).toEqual(payload);
+  });
+
+  it("returns null when axios rejects", async () => {
+    mocks.get.mockRejectedValue(new Error("boom"));
+
+    const result = await KernelApi.getArtifactPreview("k1", 5, "chart");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the response data is null", async () => {
+    mocks.get.mockResolvedValue({ data: null });
+
+    const result = await KernelApi.getArtifactPreview("k1", 5, "chart");
+
+    expect(result).toBeNull();
+  });
+});

--- a/flowfile_frontend/src/renderer/app/api/kernel.api.ts
+++ b/flowfile_frontend/src/renderer/app/api/kernel.api.ts
@@ -185,6 +185,22 @@ export class KernelApi {
     }
   }
 
+  static async getArtifactPreview(
+    kernelId: string,
+    flowId: number,
+    name: string,
+  ): Promise<DisplayOutput | null> {
+    try {
+      const response = await axios.get<DisplayOutput | null>(
+        `${API_BASE_URL}/${encodeURIComponent(kernelId)}/artifact_preview`,
+        { params: { flow_id: flowId, name } },
+      );
+      return response.data ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   static async getMemoryStats(kernelId: string): Promise<KernelMemoryInfo | null> {
     try {
       const response = await axios.get<KernelMemoryInfo>(

--- a/flowfile_frontend/src/renderer/app/features/designer/ArtifactPreviewModal.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/ArtifactPreviewModal.vue
@@ -1,0 +1,89 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    :title="dialogTitle"
+    width="70%"
+    top="6vh"
+    append-to-body
+    destroy-on-close
+  >
+    <div v-if="payload" class="artifact-preview-body">
+      <img
+        v-if="payload.mime_type === 'image/png'"
+        :src="'data:image/png;base64,' + payload.data"
+        class="artifact-preview-image"
+        alt="Artifact preview"
+      />
+
+      <!-- Sandboxed srcdoc has an opaque origin, so its height can't be measured
+           from outside — give it a viewport-based height instead. allow-downloads
+           lets plotly's "download as png" toolbar button work. -->
+      <iframe
+        v-else-if="payload.mime_type === 'text/html'"
+        :srcdoc="payload.data"
+        class="artifact-preview-iframe"
+        sandbox="allow-scripts allow-downloads"
+      ></iframe>
+
+      <pre v-else class="artifact-preview-text">{{ payload.data }}</pre>
+    </div>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import type { DisplayOutput } from "@/types";
+
+interface Props {
+  modelValue: boolean;
+  payload: DisplayOutput | null;
+  name?: string;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{ (e: "update:modelValue", value: boolean): void }>();
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit("update:modelValue", value),
+});
+
+const dialogTitle = computed(() => props.payload?.title || props.name || "Preview");
+</script>
+
+<style scoped>
+.artifact-preview-body {
+  overflow: auto;
+}
+
+.artifact-preview-image {
+  display: block;
+  max-width: 100%;
+  max-height: 72vh;
+  margin: 0 auto;
+  border-radius: 3px;
+  background: white;
+}
+
+.artifact-preview-iframe {
+  width: 100%;
+  height: 72vh;
+  border: none;
+  border-radius: 3px;
+  background: white;
+}
+
+.artifact-preview-text {
+  background: #1e1e2e;
+  color: #cdd6f4;
+  padding: 0.5rem 0.75rem;
+  border-radius: 3px;
+  font-size: 0.8rem;
+  font-family: "Fira Code", monospace;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  max-height: 72vh;
+  overflow-y: auto;
+  margin: 0;
+}
+</style>

--- a/flowfile_frontend/src/renderer/app/features/designer/ArtifactsPanel.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/ArtifactsPanel.vue
@@ -1,0 +1,241 @@
+<template>
+  <div class="dp-tab-content artifacts-panel">
+    <div v-if="summary.kernel_id" class="artifact-section-meta">
+      Kernel: <code>{{ summary.kernel_id }}</code>
+    </div>
+
+    <div v-if="summary.published.length > 0" class="artifact-section">
+      <div class="artifact-section-header">Published</div>
+      <table class="artifact-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Module</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="art in summary.published" :key="art.name">
+            <td class="artifact-name">{{ art.name }}</td>
+            <td>{{ art.type_name || "-" }}</td>
+            <td class="artifact-module">{{ art.module || "-" }}</td>
+            <td class="artifact-action">
+              <button
+                v-if="art.has_preview"
+                class="artifact-view-button"
+                :disabled="loadingName === art.name"
+                @click="viewPreview(art)"
+              >
+                {{ loadingName === art.name ? "Loading…" : "View" }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div v-if="summary.consumed.length > 0" class="artifact-section">
+      <div class="artifact-section-header">Consumed</div>
+      <table class="artifact-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Source Node</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="art in summary.consumed" :key="art.name">
+            <td class="artifact-name">{{ art.name }}</td>
+            <td>{{ art.type_name || "-" }}</td>
+            <td>{{ art.source_node_id != null ? `Node ${art.source_node_id}` : "-" }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div v-if="summary.deleted.length > 0" class="artifact-section">
+      <div class="artifact-section-header">Deleted</div>
+      <table class="artifact-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="name in summary.deleted" :key="name">
+            <td class="artifact-name artifact-deleted">{{ name }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div
+      v-if="
+        summary.published.length === 0 &&
+        summary.consumed.length === 0 &&
+        summary.deleted.length === 0
+      "
+      class="artifact-empty"
+    >
+      No artifacts recorded for this node.
+    </div>
+
+    <ArtifactPreviewModal v-model="modalOpen" :payload="previewPayload" :name="previewName" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { ElMessage } from "element-plus";
+import type { ArtifactPublished, DisplayOutput, NodeArtifactSummary } from "@/types";
+import { KernelApi } from "../../api/kernel.api";
+import ArtifactPreviewModal from "./ArtifactPreviewModal.vue";
+
+interface Props {
+  summary: NodeArtifactSummary;
+  flowId: number;
+}
+
+const props = defineProps<Props>();
+
+const loadingName = ref<string | null>(null);
+const modalOpen = ref(false);
+const previewPayload = ref<DisplayOutput | null>(null);
+const previewName = ref("");
+
+async function viewPreview(art: ArtifactPublished) {
+  if (loadingName.value) return;
+  loadingName.value = art.name;
+  try {
+    const payload = await KernelApi.getArtifactPreview(
+      props.summary.kernel_id,
+      props.flowId,
+      art.name,
+    );
+    if (!payload) {
+      ElMessage.warning(
+        "Kernel stopped — preview no longer available. Re-run the node to regenerate it.",
+      );
+      return;
+    }
+    previewPayload.value = payload;
+    previewName.value = art.name;
+    modalOpen.value = true;
+  } finally {
+    loadingName.value = null;
+  }
+}
+</script>
+
+<style scoped>
+.artifacts-panel {
+  padding: 12px 16px;
+  overflow-y: auto;
+}
+
+.artifact-section-meta {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  margin-bottom: 12px;
+}
+
+.artifact-section-meta code {
+  background: var(--color-background-tertiary, var(--color-background-secondary));
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.artifact-section {
+  margin-bottom: 16px;
+}
+
+.artifact-section-header {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+  margin-bottom: 6px;
+}
+
+.artifact-table {
+  width: 100%;
+  /* Keep rows readable on wide docks — otherwise the Actions column drifts
+     to the far right edge, hundreds of pixels from the row content. */
+  max-width: 880px;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.artifact-table th {
+  text-align: left;
+  padding: 4px 8px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-border-primary);
+  font-size: 11px;
+}
+
+.artifact-table td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--color-border-light, var(--color-border-primary));
+  color: var(--color-text-primary);
+}
+
+.artifact-table tbody tr:hover {
+  background: var(--color-background-hover);
+}
+
+.artifact-name {
+  font-weight: 500;
+}
+
+.artifact-module {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.artifact-deleted {
+  text-decoration: line-through;
+  color: var(--color-text-secondary);
+  opacity: 0.7;
+}
+
+.artifact-empty {
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  text-align: center;
+  padding: 24px;
+}
+
+.artifact-action {
+  text-align: right;
+  width: 1%;
+  white-space: nowrap;
+}
+
+.artifact-view-button {
+  padding: 2px 10px;
+  border: 1px solid var(--color-border-primary);
+  border-radius: 4px;
+  background: var(--color-background-primary);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.12s ease;
+}
+
+.artifact-view-button:hover:not(:disabled) {
+  background: var(--color-accent, #6366f1);
+  border-color: var(--color-accent, #6366f1);
+  color: var(--color-text-inverse, #fff);
+}
+
+.artifact-view-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+</style>

--- a/flowfile_frontend/src/renderer/app/features/designer/dataPreview.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/dataPreview.vue
@@ -88,87 +88,21 @@
       </div>
 
       <!-- Artifacts Tab Content -->
-      <div v-if="activeTab === 'artifacts' && nodeArtifacts" class="dp-tab-content artifacts-panel">
-        <div v-if="nodeArtifacts.kernel_id" class="artifact-section-meta">
-          Kernel: <code>{{ nodeArtifacts.kernel_id }}</code>
-        </div>
-
-        <div v-if="nodeArtifacts.published.length > 0" class="artifact-section">
-          <div class="artifact-section-header">Published</div>
-          <table class="artifact-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Module</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="art in nodeArtifacts.published" :key="art.name">
-                <td class="artifact-name">{{ art.name }}</td>
-                <td>{{ art.type_name || "-" }}</td>
-                <td class="artifact-module">{{ art.module || "-" }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div v-if="nodeArtifacts.consumed.length > 0" class="artifact-section">
-          <div class="artifact-section-header">Consumed</div>
-          <table class="artifact-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Source Node</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="art in nodeArtifacts.consumed" :key="art.name">
-                <td class="artifact-name">{{ art.name }}</td>
-                <td>{{ art.type_name || "-" }}</td>
-                <td>{{ art.source_node_id != null ? `Node ${art.source_node_id}` : "-" }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div v-if="nodeArtifacts.deleted.length > 0" class="artifact-section">
-          <div class="artifact-section-header">Deleted</div>
-          <table class="artifact-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="name in nodeArtifacts.deleted" :key="name">
-                <td class="artifact-name artifact-deleted">{{ name }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div
-          v-if="
-            nodeArtifacts.published.length === 0 &&
-            nodeArtifacts.consumed.length === 0 &&
-            nodeArtifacts.deleted.length === 0
-          "
-          class="artifact-empty"
-        >
-          No artifacts recorded for this node.
-        </div>
-      </div>
+      <ArtifactsPanel
+        v-if="activeTab === 'artifacts' && nodeArtifacts"
+        :summary="nodeArtifacts"
+        :flow-id="props.flowId || nodeStore.flow_id"
+      />
     </template>
   </div>
 </template>
 
 <script setup lang="ts">
 // TODO(refactor): large component. Plan to extract:
-//   - DataTabs.vue, OutputSelector.vue, ArtifactsPanel.vue
+//   - DataTabs.vue, OutputSelector.vue
 //   - useTableData composable: AG Grid setup + refresh
 import { ref, onMounted, onUnmounted, computed, watch } from "vue";
+import ArtifactsPanel from "./ArtifactsPanel.vue";
 import debounce from "lodash/debounce";
 import { TableExample } from "../../components/nodes/baseNode/nodeInterfaces";
 import { useNodeStore } from "../../stores/column-store";
@@ -653,7 +587,7 @@ onUnmounted(() => {
 }
 
 /* ============================================================
-   Tab Bar & Artifacts Panel
+   Tab Bar
    ============================================================ */
 
 .preview-tabs {
@@ -709,84 +643,6 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   position: relative;
-}
-
-.artifacts-panel {
-  padding: 12px 16px;
-  overflow-y: auto;
-}
-
-.artifact-section-meta {
-  font-size: 11px;
-  color: var(--color-text-secondary);
-  margin-bottom: 12px;
-}
-
-.artifact-section-meta code {
-  background: var(--color-background-tertiary, var(--color-background-secondary));
-  padding: 1px 5px;
-  border-radius: 3px;
-  font-size: 11px;
-}
-
-.artifact-section {
-  margin-bottom: 16px;
-}
-
-.artifact-section-header {
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--color-text-secondary);
-  margin-bottom: 6px;
-}
-
-.artifact-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 12px;
-}
-
-.artifact-table th {
-  text-align: left;
-  padding: 4px 8px;
-  font-weight: 500;
-  color: var(--color-text-secondary);
-  border-bottom: 1px solid var(--color-border-primary);
-  font-size: 11px;
-}
-
-.artifact-table td {
-  padding: 5px 8px;
-  border-bottom: 1px solid var(--color-border-light, var(--color-border-primary));
-  color: var(--color-text-primary);
-}
-
-.artifact-table tbody tr:hover {
-  background: var(--color-background-hover);
-}
-
-.artifact-name {
-  font-weight: 500;
-}
-
-.artifact-module {
-  font-size: 11px;
-  color: var(--color-text-secondary);
-}
-
-.artifact-deleted {
-  text-decoration: line-through;
-  color: var(--color-text-secondary);
-  opacity: 0.7;
-}
-
-.artifact-empty {
-  color: var(--color-text-secondary);
-  font-size: 13px;
-  text-align: center;
-  padding: 24px;
 }
 
 /* ============================================================

--- a/flowfile_frontend/src/renderer/app/types/flow.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/flow.types.ts
@@ -255,6 +255,8 @@ export interface ArtifactPublished {
   name: string;
   type_name: string;
   module: string;
+  has_preview?: boolean;
+  preview_mime?: string | null;
 }
 
 export interface ArtifactConsumed {

--- a/kernel_runtime/kernel_runtime/flowfile_client.py
+++ b/kernel_runtime/kernel_runtime/flowfile_client.py
@@ -72,6 +72,18 @@ _log_client: contextvars.ContextVar[httpx.Client | None] = contextvars.ContextVa
 # Display outputs collector (reset at start of each execution)
 _displays: contextvars.ContextVar[list[dict[str, str]]] = contextvars.ContextVar("flowfile_displays", default=None)
 
+# Artifact previews collected during execution (name -> {mime_type, data, title}).
+# Lives only in-process; only tiny flags ride inside ExecuteResponse.
+_artifact_previews: contextvars.ContextVar[dict[str, dict[str, str]] | None] = contextvars.ContextVar(
+    "flowfile_artifact_previews", default=None
+)
+
+# Names deleted via delete_artifact() during this execution. Per-execution so
+# deletion attribution is node-scoped rather than a racy store-wide diff.
+_deleted_artifacts: contextvars.ContextVar[list[str] | None] = contextvars.ContextVar(
+    "flowfile_deleted_artifacts", default=None
+)
+
 
 def _set_context(
     node_id: int,
@@ -117,6 +129,8 @@ def _clear_context() -> None:
         _log_client.set(None)
     _context.set({})
     _displays.set([])
+    _artifact_previews.set({})
+    _deleted_artifacts.set([])
 
 
 def _get_context_value(key: str) -> Any:
@@ -192,7 +206,14 @@ def publish_output(df: pl.LazyFrame | pl.DataFrame, name: str = "main") -> None:
         os.fsync(f.fileno())
 
 
-def publish_artifact(name: str, obj: Any) -> None:
+def publish_artifact(name: str, obj: Any, preview: bool = False) -> None:
+    """Publish an in-memory artifact for downstream nodes in the same flow.
+
+    When *preview* is true and *obj* is a matplotlib/plotly/PIL figure or an
+    HTML string, a viewable preview is rendered and kept only in the kernel
+    process; only a tiny flag rides in the execute response and Core fetches
+    the blob on demand.
+    """
     store: ArtifactStore = _get_context_value("artifact_store")
     node_id: int = _get_context_value("node_id")
     flow_id: int = _get_context_value("flow_id")
@@ -202,6 +223,20 @@ def publish_artifact(name: str, obj: Any) -> None:
     allow: dict[str, int] | None = _get_context_value("available_artifacts")
     if allow is not None:
         allow[name] = node_id
+    if not preview:
+        return
+    try:
+        payload = _render_display_payload(obj)
+        if payload is None and _is_html_string(obj):
+            payload = {"mime_type": "text/html", "data": obj}
+        if payload is not None and payload["mime_type"] in ("image/png", "text/html"):
+            previews = _artifact_previews.get({})
+            previews[name] = {**payload, "title": name}
+            _artifact_previews.set(previews)
+        else:
+            log(f"publish_artifact: no viewable preview for '{name}' (unsupported type)", "WARNING")
+    except Exception as exc:  # noqa: BLE001 - preview rendering is best-effort
+        log(f"publish_artifact: failed to render preview for '{name}': {exc}", "WARNING")
 
 
 def read_artifact(name: str) -> Any:
@@ -232,6 +267,9 @@ def delete_artifact(name: str) -> None:
     store: ArtifactStore = _get_context_value("artifact_store")
     flow_id: int = _get_context_value("flow_id")
     store.delete(name, flow_id=flow_id)
+    deleted = _deleted_artifacts.get([]) or []
+    deleted.append(name)
+    _deleted_artifacts.set(deleted)
 
 
 def list_artifacts() -> list[ArtifactInfo]:
@@ -870,6 +908,48 @@ def _get_displays() -> list[dict[str, str]]:
     return _displays.get([])
 
 
+def _reset_artifact_previews() -> None:
+    """Clear collected artifact previews. Called at start of each execution."""
+    _artifact_previews.set({})
+
+
+def _get_artifact_previews() -> dict[str, dict[str, str]]:
+    """Return the current mapping of artifact name -> preview payload."""
+    return _artifact_previews.get({})
+
+
+def _reset_deleted_artifacts() -> None:
+    """Clear the per-execution deleted-artifact tracker. Called at start of each execution."""
+    _deleted_artifacts.set([])
+
+
+def _get_deleted_artifacts() -> list[str]:
+    """Return names deleted via delete_artifact() during this execution."""
+    return _deleted_artifacts.get([]) or []
+
+
+def _render_display_payload(obj: Any) -> dict[str, str] | None:
+    """Render *obj* to a ``{mime_type, data}`` payload, or None if unsupported.
+
+    Handles matplotlib figures (PNG base64), plotly figures (text/html), and
+    PIL images (PNG base64). Polars frames, HTML strings, and plain text are
+    left to ``display`` so its fallbacks stay in one place.
+    """
+    if _is_matplotlib_figure(obj):
+        buf = io.BytesIO()
+        obj.savefig(buf, format="png", dpi=150, bbox_inches="tight")
+        buf.seek(0)
+        return {"mime_type": "image/png", "data": base64.b64encode(buf.read()).decode("ascii")}
+    if _is_plotly_figure(obj):
+        return {"mime_type": "text/html", "data": obj.to_html(include_plotlyjs="cdn", full_html=False)}
+    if _is_pil_image(obj):
+        buf = io.BytesIO()
+        obj.save(buf, format="PNG")
+        buf.seek(0)
+        return {"mime_type": "image/png", "data": base64.b64encode(buf.read()).decode("ascii")}
+    return None
+
+
 def display(obj: Any, title: str = "", max_rows: int = _GW_TABLE_MAX_ROWS) -> None:
     """Display a rich object in the output panel.
 
@@ -890,39 +970,9 @@ def display(obj: Any, title: str = "", max_rows: int = _GW_TABLE_MAX_ROWS) -> No
     """
     displays = _displays.get([])
 
-    if _is_matplotlib_figure(obj):
-        buf = io.BytesIO()
-        obj.savefig(buf, format="png", dpi=150, bbox_inches="tight")
-        buf.seek(0)
-        data = base64.b64encode(buf.read()).decode("ascii")
-        displays.append(
-            {
-                "mime_type": "image/png",
-                "data": data,
-                "title": title,
-            }
-        )
-    elif _is_plotly_figure(obj):
-        html = obj.to_html(include_plotlyjs="cdn", full_html=False)
-        displays.append(
-            {
-                "mime_type": "text/html",
-                "data": html,
-                "title": title,
-            }
-        )
-    elif _is_pil_image(obj):
-        buf = io.BytesIO()
-        obj.save(buf, format="PNG")
-        buf.seek(0)
-        data = base64.b64encode(buf.read()).decode("ascii")
-        displays.append(
-            {
-                "mime_type": "image/png",
-                "data": data,
-                "title": title,
-            }
-        )
+    payload = _render_display_payload(obj)
+    if payload is not None:
+        displays.append({**payload, "title": title})
     elif _is_polars_frame(obj):
         try:
             displays.append(

--- a/kernel_runtime/kernel_runtime/main.py
+++ b/kernel_runtime/kernel_runtime/main.py
@@ -97,6 +97,28 @@ def _purge_display_outputs(flow_id: int) -> None:
         del _display_output_store[key]
 
 
+# Rendered artifact previews (base64 PNG / HTML) from the most recent run,
+# fetched on demand by Core. Kept only in-kernel; only two tiny flags ride in
+# ExecuteResponse. Bounded (LRU) so blobs can't accumulate.
+_artifact_preview_store: OrderedDict[tuple[int, str], dict] = OrderedDict()
+_MAX_ARTIFACT_PREVIEWS = int(os.environ.get("MAX_ARTIFACT_PREVIEWS", "100"))
+
+
+def _store_artifact_preview(flow_id: int, name: str, payload: dict) -> None:
+    """Store an artifact preview, evicting the oldest entries past the cap."""
+    key = (flow_id, name)
+    _artifact_preview_store.pop(key, None)
+    _artifact_preview_store[key] = payload
+    while len(_artifact_preview_store) > _MAX_ARTIFACT_PREVIEWS:
+        _artifact_preview_store.popitem(last=False)
+
+
+def _purge_artifact_previews(flow_id: int) -> None:
+    """Drop all stored artifact previews belonging to a flow."""
+    for key in [k for k in _artifact_preview_store if k[0] == flow_id]:
+        del _artifact_preview_store[key]
+
+
 def _evict_oldest_namespace() -> None:
     """Evict the least recently used namespace if at capacity."""
     if len(_namespace_store) < _MAX_NAMESPACES:
@@ -391,6 +413,8 @@ class PublishedArtifact(BaseModel):
     type_name: str = ""
     module: str = ""
     size_bytes: int = 0
+    has_preview: bool = False
+    preview_mime: str | None = None
 
 
 class ExecuteResponse(BaseModel):
@@ -474,9 +498,9 @@ def _run_user_code(
 
     # Clear any artifacts this node previously published so re-execution
     # doesn't fail with "already exists".
-    artifact_store.clear_by_node_ids({request.node_id}, flow_id=request.flow_id)
-
-    artifacts_before = set(artifact_store.list_all(flow_id=request.flow_id).keys())
+    removed = artifact_store.clear_by_node_ids({request.node_id}, flow_id=request.flow_id)
+    for _name in removed:
+        _artifact_preview_store.pop((request.flow_id, _name), None)
 
     try:
         flowfile_client._set_context(
@@ -493,6 +517,8 @@ def _run_user_code(
         )
 
         flowfile_client._reset_displays()
+        flowfile_client._reset_artifact_previews()
+        flowfile_client._reset_deleted_artifacts()
 
         exec_globals = _get_namespace(request.flow_id)
 
@@ -535,18 +561,27 @@ def _run_user_code(
         if output_dir and Path(output_dir).exists():
             output_paths = [str(p) for p in sorted(Path(output_dir).glob("*.parquet"))]
 
-        artifacts_meta = artifact_store.list_all(flow_id=request.flow_id)
-        new_names = sorted(set(artifacts_meta) - artifacts_before)
+        # Attribute artifacts by the owning node_id (stamped in store metadata),
+        # never by a store-wide name diff — the store is shared across nodes on
+        # the same kernel and concurrent flow execution would otherwise misattribute.
+        owned = artifact_store.list_by_node_id(request.node_id, flow_id=request.flow_id)
+        previews = flowfile_client._get_artifact_previews()
+        for name, payload in previews.items():
+            if name in owned:
+                _store_artifact_preview(request.flow_id, name, payload)
         new_artifacts = [
             PublishedArtifact(
                 name=name,
-                type_name=artifacts_meta[name].get("type_name", ""),
-                module=artifacts_meta[name].get("module", ""),
-                size_bytes=artifacts_meta[name].get("size_bytes", 0),
+                type_name=meta.get("type_name", ""),
+                module=meta.get("module", ""),
+                size_bytes=meta.get("size_bytes", 0),
+                has_preview=name in previews,
+                preview_mime=previews[name]["mime_type"] if name in previews else None,
             )
-            for name in new_names
+            for name, meta in sorted(owned.items())
         ]
-        deleted_artifacts = sorted(artifacts_before - set(artifacts_meta))
+        deleted_names = flowfile_client._get_deleted_artifacts()
+        deleted_artifacts = sorted(set(deleted_names) - set(owned))
 
         elapsed = (time.perf_counter() - start) * 1000
         return ExecuteResponse(
@@ -662,10 +697,12 @@ async def clear_artifacts(flow_id: int | None = Query(default=None)):
     artifact_store.clear(flow_id=flow_id)
     if flow_id is not None:
         _clear_namespace(flow_id)
+        _purge_artifact_previews(flow_id)
     else:
         _namespace_store.clear()
         _namespace_access.clear()
         _display_output_store.clear()
+        _artifact_preview_store.clear()
     return {"status": "cleared"}
 
 
@@ -684,6 +721,13 @@ async def get_display_outputs(flow_id: int = Query(...), node_id: int = Query(..
     return [DisplayOutput(**d) for d in stored]
 
 
+@app.get("/artifact_preview", response_model=DisplayOutput | None)
+async def get_artifact_preview(flow_id: int = Query(...), name: str = Query(...)):
+    """Retrieve a stored artifact preview (base64 PNG / HTML), if any."""
+    stored = _artifact_preview_store.get((flow_id, name))
+    return DisplayOutput(**stored) if stored else None
+
+
 @app.post("/clear_node_artifacts")
 async def clear_node_artifacts(request: ClearNodeArtifactsRequest):
     """Clear only artifacts published by the specified node IDs."""
@@ -691,6 +735,12 @@ async def clear_node_artifacts(request: ClearNodeArtifactsRequest):
         set(request.node_ids),
         flow_id=request.flow_id,
     )
+    for name in removed:
+        if request.flow_id is not None:
+            _artifact_preview_store.pop((request.flow_id, name), None)
+        else:
+            for key in [k for k in _artifact_preview_store if k[1] == name]:
+                del _artifact_preview_store[key]
     return {"status": "cleared", "removed": removed}
 
 

--- a/kernel_runtime/poetry.lock
+++ b/kernel_runtime/poetry.lock
@@ -170,6 +170,97 @@ files = [
 ]
 
 [[package]]
+name = "contourpy"
+version = "1.3.2"
+description = "Python library for calculating contours of 2D quadrilateral grids"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "contourpy-1.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ba38e3f9f330af820c4b27ceb4b9c7feee5fe0493ea53a8720f4792667465934"},
+    {file = "contourpy-1.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc41ba0714aa2968d1f8674ec97504a8f7e334f48eeacebcaa6256213acb0989"},
+    {file = "contourpy-1.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9be002b31c558d1ddf1b9b415b162c603405414bacd6932d031c5b5a8b757f0d"},
+    {file = "contourpy-1.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2e74acbcba3bfdb6d9d8384cdc4f9260cae86ed9beee8bd5f54fee49a430b9"},
+    {file = "contourpy-1.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e259bced5549ac64410162adc973c5e2fb77f04df4a439d00b478e57a0e65512"},
+    {file = "contourpy-1.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad687a04bc802cbe8b9c399c07162a3c35e227e2daccf1668eb1f278cb698631"},
+    {file = "contourpy-1.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cdd22595308f53ef2f891040ab2b93d79192513ffccbd7fe19be7aa773a5e09f"},
+    {file = "contourpy-1.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b4f54d6a2defe9f257327b0f243612dd051cc43825587520b1bf74a31e2f6ef2"},
+    {file = "contourpy-1.3.2-cp310-cp310-win32.whl", hash = "sha256:f939a054192ddc596e031e50bb13b657ce318cf13d264f095ce9db7dc6ae81c0"},
+    {file = "contourpy-1.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:c440093bbc8fc21c637c03bafcbef95ccd963bc6e0514ad887932c18ca2a759a"},
+    {file = "contourpy-1.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6a37a2fb93d4df3fc4c0e363ea4d16f83195fc09c891bc8ce072b9d084853445"},
+    {file = "contourpy-1.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b7cd50c38f500bbcc9b6a46643a40e0913673f869315d8e70de0438817cb7773"},
+    {file = "contourpy-1.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d6658ccc7251a4433eebd89ed2672c2ed96fba367fd25ca9512aa92a4b46c4f1"},
+    {file = "contourpy-1.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:70771a461aaeb335df14deb6c97439973d253ae70660ca085eec25241137ef43"},
+    {file = "contourpy-1.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65a887a6e8c4cd0897507d814b14c54a8c2e2aa4ac9f7686292f9769fcf9a6ab"},
+    {file = "contourpy-1.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3859783aefa2b8355697f16642695a5b9792e7a46ab86da1118a4a23a51a33d7"},
+    {file = "contourpy-1.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eab0f6db315fa4d70f1d8ab514e527f0366ec021ff853d7ed6a2d33605cf4b83"},
+    {file = "contourpy-1.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d91a3ccc7fea94ca0acab82ceb77f396d50a1f67412efe4c526f5d20264e6ecd"},
+    {file = "contourpy-1.3.2-cp311-cp311-win32.whl", hash = "sha256:1c48188778d4d2f3d48e4643fb15d8608b1d01e4b4d6b0548d9b336c28fc9b6f"},
+    {file = "contourpy-1.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:5ebac872ba09cb8f2131c46b8739a7ff71de28a24c869bcad554477eb089a878"},
+    {file = "contourpy-1.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4caf2bcd2969402bf77edc4cb6034c7dd7c0803213b3523f111eb7460a51b8d2"},
+    {file = "contourpy-1.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:82199cb78276249796419fe36b7386bd8d2cc3f28b3bc19fe2454fe2e26c4c15"},
+    {file = "contourpy-1.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106fab697af11456fcba3e352ad50effe493a90f893fca6c2ca5c033820cea92"},
+    {file = "contourpy-1.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d14f12932a8d620e307f715857107b1d1845cc44fdb5da2bc8e850f5ceba9f87"},
+    {file = "contourpy-1.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:532fd26e715560721bb0d5fc7610fce279b3699b018600ab999d1be895b09415"},
+    {file = "contourpy-1.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b383144cf2d2c29f01a1e8170f50dacf0eac02d64139dcd709a8ac4eb3cfe"},
+    {file = "contourpy-1.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c49f73e61f1f774650a55d221803b101d966ca0c5a2d6d5e4320ec3997489441"},
+    {file = "contourpy-1.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d80b2c0300583228ac98d0a927a1ba6a2ba6b8a742463c564f1d419ee5b211e"},
+    {file = "contourpy-1.3.2-cp312-cp312-win32.whl", hash = "sha256:90df94c89a91b7362e1142cbee7568f86514412ab8a2c0d0fca72d7e91b62912"},
+    {file = "contourpy-1.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:8c942a01d9163e2e5cfb05cb66110121b8d07ad438a17f9e766317bcb62abf73"},
+    {file = "contourpy-1.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:de39db2604ae755316cb5967728f4bea92685884b1e767b7c24e983ef5f771cb"},
+    {file = "contourpy-1.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3f9e896f447c5c8618f1edb2bafa9a4030f22a575ec418ad70611450720b5b08"},
+    {file = "contourpy-1.3.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71e2bd4a1c4188f5c2b8d274da78faab884b59df20df63c34f74aa1813c4427c"},
+    {file = "contourpy-1.3.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de425af81b6cea33101ae95ece1f696af39446db9682a0b56daaa48cfc29f38f"},
+    {file = "contourpy-1.3.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:977e98a0e0480d3fe292246417239d2d45435904afd6d7332d8455981c408b85"},
+    {file = "contourpy-1.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:434f0adf84911c924519d2b08fc10491dd282b20bdd3fa8f60fd816ea0b48841"},
+    {file = "contourpy-1.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c66c4906cdbc50e9cba65978823e6e00b45682eb09adbb78c9775b74eb222422"},
+    {file = "contourpy-1.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8b7fc0cd78ba2f4695fd0a6ad81a19e7e3ab825c31b577f384aa9d7817dc3bef"},
+    {file = "contourpy-1.3.2-cp313-cp313-win32.whl", hash = "sha256:15ce6ab60957ca74cff444fe66d9045c1fd3e92c8936894ebd1f3eef2fff075f"},
+    {file = "contourpy-1.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:e1578f7eafce927b168752ed7e22646dad6cd9bca673c60bff55889fa236ebf9"},
+    {file = "contourpy-1.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0475b1f6604896bc7c53bb070e355e9321e1bc0d381735421a2d2068ec56531f"},
+    {file = "contourpy-1.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c85bb486e9be652314bb5b9e2e3b0d1b2e643d5eec4992c0fbe8ac71775da739"},
+    {file = "contourpy-1.3.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:745b57db7758f3ffc05a10254edd3182a2a83402a89c00957a8e8a22f5582823"},
+    {file = "contourpy-1.3.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:970e9173dbd7eba9b4e01aab19215a48ee5dd3f43cef736eebde064a171f89a5"},
+    {file = "contourpy-1.3.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6c4639a9c22230276b7bffb6a850dfc8258a2521305e1faefe804d006b2e532"},
+    {file = "contourpy-1.3.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc829960f34ba36aad4302e78eabf3ef16a3a100863f0d4eeddf30e8a485a03b"},
+    {file = "contourpy-1.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d32530b534e986374fc19eaa77fcb87e8a99e5431499949b828312bdcd20ac52"},
+    {file = "contourpy-1.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e298e7e70cf4eb179cc1077be1c725b5fd131ebc81181bf0c03525c8abc297fd"},
+    {file = "contourpy-1.3.2-cp313-cp313t-win32.whl", hash = "sha256:d0e589ae0d55204991450bb5c23f571c64fe43adaa53f93fc902a84c96f52fe1"},
+    {file = "contourpy-1.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:78e9253c3de756b3f6a5174d024c4835acd59eb3f8e2ca13e775dbffe1558f69"},
+    {file = "contourpy-1.3.2-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fd93cc7f3139b6dd7aab2f26a90dde0aa9fc264dbf70f6740d498a70b860b82c"},
+    {file = "contourpy-1.3.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:107ba8a6a7eec58bb475329e6d3b95deba9440667c4d62b9b6063942b61d7f16"},
+    {file = "contourpy-1.3.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ded1706ed0c1049224531b81128efbd5084598f18d8a2d9efae833edbd2b40ad"},
+    {file = "contourpy-1.3.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:5f5964cdad279256c084b69c3f412b7801e15356b16efa9d78aa974041903da0"},
+    {file = "contourpy-1.3.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49b65a95d642d4efa8f64ba12558fcb83407e58a2dfba9d796d77b63ccfcaff5"},
+    {file = "contourpy-1.3.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8c5acb8dddb0752bf252e01a3035b21443158910ac16a3b0d20e7fed7d534ce5"},
+    {file = "contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54"},
+]
+
+[package.dependencies]
+numpy = ">=1.23"
+
+[package.extras]
+bokeh = ["bokeh", "selenium"]
+docs = ["furo", "sphinx (>=7.2)", "sphinx-copybutton"]
+mypy = ["bokeh", "contourpy[bokeh,docs]", "docutils-stubs", "mypy (==1.15.0)", "types-Pillow"]
+test = ["Pillow", "contourpy[test-no-images]", "matplotlib"]
+test-no-images = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-xdist", "wurlitzer"]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+description = "Composable style cycles"
+optional = true
+python-versions = ">=3.8"
+files = [
+    {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
+    {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
+]
+
+[package.extras]
+docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
+tests = ["pytest", "pytest-cov", "pytest-xdist"]
+
+[[package]]
 name = "deltalake"
 version = "1.6.1"
 description = "Native Delta Lake Python binding based on delta-rs with Pandas integration"
@@ -245,6 +336,78 @@ typing-extensions = ">=4.8.0"
 [package.extras]
 all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
 standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+description = "Tools to manipulate font files"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "fonttools-4.63.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e3297a6a4059b4acc3a1e9a8b04741f240a80044eef08ebd32e8b5bcdddce75b"},
+    {file = "fonttools-4.63.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b1cd75a03ad8cb5bc40c90bfde68c0c47de423aa19e5c0f362b43520645eea94"},
+    {file = "fonttools-4.63.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0425b277a59cff3d80ca42162a8de360f318438a2ac83570842a678d826d579"},
+    {file = "fonttools-4.63.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d7e5c9973aa04c95650c96e5f5ad865fbf42d62079163ecfab1e01cbc2504c22"},
+    {file = "fonttools-4.63.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cb014d58140a38135f16064c74c652ed57aa0b75cbf8bb59cac821f7edb5334e"},
+    {file = "fonttools-4.63.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:032038247a96c1690f9f31e377c389383c902531b085aa4e4dabd6f57f870e69"},
+    {file = "fonttools-4.63.0-cp310-cp310-win32.whl", hash = "sha256:a8b33a82979e0a6a34ff435cc81317be1f95ec1ebb7a3a2d1c8a6a54f02ae44e"},
+    {file = "fonttools-4.63.0-cp310-cp310-win_amd64.whl", hash = "sha256:0c18358a155d75034911c5ee397a5b44cd19dd325dbb8b35fb60bf421d6a72ac"},
+    {file = "fonttools-4.63.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:2b8ae05d9eacf6081414d759c0a352769ac28ce31280d6bb8e77b03f9e3c449f"},
+    {file = "fonttools-4.63.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:79cdc9f567aec74a72918fd060283911406750cbc9fd28c1316023deb6ce31a9"},
+    {file = "fonttools-4.63.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c14b4fd138c4bafcca294765c547914e1aa431ae1ca94ab99d8db08c958bd3b"},
+    {file = "fonttools-4.63.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76ac49f929aecaf82d83250b8347e099d7aecba0f4726c1d9b6df3b8bb5fe18"},
+    {file = "fonttools-4.63.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dcf076a4474fe0d7367e5bbf5b052c7284fa1feca729c04176ce513521afd8a0"},
+    {file = "fonttools-4.63.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7dd683fef0663e9f0f45cf541d788d24caa3ec9db50796b588e1757d8b3bc007"},
+    {file = "fonttools-4.63.0-cp311-cp311-win32.whl", hash = "sha256:afefc1ed0a59785a7fb06ea7e1678e849c193e1e387db783579bc7b3056fcfcb"},
+    {file = "fonttools-4.63.0-cp311-cp311-win_amd64.whl", hash = "sha256:063e08bd17bd5a90127a14123de0d6a952dbc847695fd98b63c043d58057f90c"},
+    {file = "fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02"},
+    {file = "fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0"},
+    {file = "fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af"},
+    {file = "fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8"},
+    {file = "fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b"},
+    {file = "fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78"},
+    {file = "fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263"},
+    {file = "fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272"},
+    {file = "fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd"},
+    {file = "fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59"},
+    {file = "fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d"},
+    {file = "fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68"},
+    {file = "fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be"},
+    {file = "fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27"},
+    {file = "fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380"},
+    {file = "fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b"},
+    {file = "fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745"},
+    {file = "fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03"},
+    {file = "fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49"},
+    {file = "fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b"},
+    {file = "fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6"},
+    {file = "fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4"},
+    {file = "fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616"},
+    {file = "fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5"},
+    {file = "fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001"},
+    {file = "fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e"},
+    {file = "fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096"},
+    {file = "fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f"},
+    {file = "fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40"},
+    {file = "fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196"},
+    {file = "fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8"},
+    {file = "fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419"},
+    {file = "fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d"},
+    {file = "fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0"},
+]
+
+[package.extras]
+all = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "lxml (>=4.0)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres", "pycairo", "scipy", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.45.0)", "unicodedata2 (>=17.0.0)", "xattr", "zopfli (>=0.1.4)"]
+graphite = ["lz4 (>=1.7.4.2)"]
+interpolatable = ["munkres", "pycairo", "scipy"]
+lxml = ["lxml (>=4.0)"]
+pathops = ["skia-pathops (>=0.5.0)"]
+plot = ["matplotlib"]
+repacker = ["uharfbuzz (>=0.45.0)"]
+symfont = ["sympy"]
+type1 = ["xattr"]
+unicode = ["unicodedata2 (>=17.0.0)"]
+woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "h11"
@@ -358,6 +521,132 @@ files = [
 ]
 
 [[package]]
+name = "kiwisolver"
+version = "1.5.0"
+description = "A fast implementation of the Cassowary constraint solver"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:32cc0a5365239a6ea0c6ed461e8838d053b57e397443c0ca894dcc8e388d4374"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc0b66c1eec9021353a4b4483afb12dfd50e3669ffbb9152d6842eb34c7e29fd"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86e0287879f75621ae85197b0877ed2f8b7aa57b511c7331dce2eb6f4de7d476"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:62f59da443c4f4849f73a51a193b1d9d258dcad0c41bc4d1b8fb2bcc04bfeb22"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9190426b7aa26c5229501fa297b8d0653cfd3f5a36f7990c264e157cbf886b3b"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c8277104ded0a51e699c8c3aff63ce2c56d4ed5519a5f73e0fd7057f959a2b9e"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8f9baf6f0a6e7571c45c8863010b45e837c3ee1c2c77fcd6ef423be91b21fedb"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cff8e5383db4989311f99e814feeb90c4723eb4edca425b9d5d9c3fefcdd9537"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ebae99ed6764f2b5771c522477b311be313e8841d2e0376db2b10922daebbba4"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:d5cd5189fc2b6a538b75ae45433140c4823463918f7b1617c31e68b085c0022c"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f42c23db5d1521218a3276bb08666dcb662896a0be7347cba864eca45ff64ede"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:94eff26096eb5395136634622515b234ecb6c9979824c1f5004c6e3c3c85ccd2"},
+    {file = "kiwisolver-1.5.0-cp310-cp310-win_arm64.whl", hash = "sha256:dd952e03bfbb096cfe2dd35cd9e00f269969b67536cb4370994afc20ff2d0875"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9eed0f7edbb274413b6ee781cca50541c8c0facd3d6fd289779e494340a2b85c"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c4923e404d6bcd91b6779c009542e5647fef32e4a5d75e115e3bbac6f2335eb"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0df54df7e686afa55e6f21fb86195224a6d9beb71d637e8d7920c95cf0f89aac"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2517e24d7315eb51c10664cdb865195df38ab74456c677df67bb47f12d088a27"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff710414307fefa903e0d9bdf300972f892c23477829f49504e59834f4195398"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6176c1811d9d5a04fa391c490cc44f451e240697a16977f11c6f722efb9041db"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50847dca5d197fcbd389c805aa1a1cf32f25d2e7273dc47ab181a517666b68cc"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:01808c6d15f4c3e8559595d6d1fe6411c68e4a3822b4b9972b44473b24f4e679"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f1f9f4121ec58628c96baa3de1a55a4e3a333c5102c8e94b64e23bf7b2083309"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:b7d335370ae48a780c6e6a6bbfa97342f563744c39c35562f3f367665f5c1de2"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:800ee55980c18545af444d93fdd60c56b580db5cc54867d8cbf8a1dc0829938c"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:c438f6ca858697c9ab67eb28246c92508af972e114cac34e57a6d4ba17a3ac08"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8c63c91f95173f9c2a67c7c526b2cea976828a0e7fced9cdcead2802dc10f8a4"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:beb7f344487cdcb9e1efe4b7a29681b74d34c08f0043a327a74da852a6749e7b"},
+    {file = "kiwisolver-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:ad4ae4ffd1ee9cd11357b4c66b612da9888f4f4daf2f36995eda64bd45370cac"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384"},
+    {file = "kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276"},
+    {file = "kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2"},
+    {file = "kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681"},
+    {file = "kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7"},
+    {file = "kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:295d9ffe712caa9f8a3081de8d32fc60191b4b51c76f02f951fd8407253528f4"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:51e8c4084897de9f05898c2c2a39af6318044ae969d46ff7a34ed3f96274adca"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b83af57bdddef03c01a9138034c6ff03181a3028d9a1003b301eb1a55e161a3f"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf4679a3d71012a7c2bf360e5cd878fbd5e4fcac0896b56393dec239d81529ed"},
+    {file = "kiwisolver-1.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:41024ed50e44ab1a60d3fe0a9d15a4ccc9f5f2b1d814ff283c8d01134d5b81bc"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ec4c85dc4b687c7f7f15f553ff26a98bfe8c58f5f7f0ac8905f0ba4c7be60232"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:12e91c215a96e39f57989c8912ae761286ac5a9584d04030ceb3368a357f017a"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16"},
+    {file = "kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1"},
+    {file = "kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a"},
+]
+
+[[package]]
 name = "lightgbm"
 version = "4.6.0"
 description = "LightGBM Python-package"
@@ -381,6 +670,84 @@ arrow = ["cffi (>=1.15.1)", "pyarrow (>=6.0.1)"]
 dask = ["dask[array,dataframe,distributed] (>=2.0.0)", "pandas (>=0.24.0)"]
 pandas = ["pandas (>=0.24.0)"]
 scikit-learn = ["scikit-learn (>=0.24.2)"]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.9"
+description = "Python plotting package"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "matplotlib-3.10.9-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77210dce9cb8153dffc967efaae990543392563d5a376d4dd8539bebcb0ed217"},
+    {file = "matplotlib-3.10.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1e7698ac9868428e84d2c967424803b2472ff7167d9d6590d4204ed775343c3b"},
+    {file = "matplotlib-3.10.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1aa972116abb4c9d201bf245620b433726cb6856f3bef6a78f776a00f5c92d37"},
+    {file = "matplotlib-3.10.9-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae2f11957b27ce53497dd4d7b235c4d4f1faf383dfb39d0c5beb833bff883294"},
+    {file = "matplotlib-3.10.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b049278ddce116aaa1c1377ebf58adea909132dfce0281cf7e3a1ea9fc2e2c65"},
+    {file = "matplotlib-3.10.9-cp310-cp310-win_amd64.whl", hash = "sha256:82834c3c292d24d3a8aae77cd2d20019de69d692a34a970e4fdb8d33e2ea3dda"},
+    {file = "matplotlib-3.10.9-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:68cfdcede415f7c8f5577b03303dd94526cdb6d11036cecdc205e08733b2d2bb"},
+    {file = "matplotlib-3.10.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfca0129678bd56379db26c52b5d77ed7de314c047492fbdc763aa7501710cfb"},
+    {file = "matplotlib-3.10.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e436d155fa8a3399dc62683f8f5d0e2e50d25d0144a73edd73f82eec8f4abfb"},
+    {file = "matplotlib-3.10.9-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56fc0bd271b00025c6edfdc7c2dcd247372c8e1544971d62e1dc7c17367e8bf9"},
+    {file = "matplotlib-3.10.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a5a6104ed666402ba5106d7f36e0e0cdca4e8d7fa4d39708ca88019e2835a2eb"},
+    {file = "matplotlib-3.10.9-cp311-cp311-win_amd64.whl", hash = "sha256:d730e984eddf56974c3e72b6129c7ca462ac38dc624338f4b0b23eb23ecba00f"},
+    {file = "matplotlib-3.10.9-cp311-cp311-win_arm64.whl", hash = "sha256:51bf0ddbdc598e060d46c16b5590708f81a1624cefbaaf62f6a81bf9285b8c80"},
+    {file = "matplotlib-3.10.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0c3c28d9fbcc1fe7a03be236d73430cf6409c41fb2383a7ac52fe932b072cb1"},
+    {file = "matplotlib-3.10.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cb28c2bd769aa3e98322c6ab09854cbcc52ab69d2759d681bba3e327b2b320"},
+    {file = "matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae20801130378b82d647ff5047c07316295b68dc054ca6b3c13519d0ea624285"},
+    {file = "matplotlib-3.10.9-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c63ebcd8b4b169eb2f5c200552ae6b8be8999a005b6b507ed76fb8d7d674fe2"},
+    {file = "matplotlib-3.10.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d75d11c949914165976c621b2324f9ef162af7ebf4b057ddf95dd1dba7e5edcf"},
+    {file = "matplotlib-3.10.9-cp312-cp312-win_amd64.whl", hash = "sha256:d091f9d758b34aaaaa6331d13574bf01891d903b3dec59bfff458ef7551de5d6"},
+    {file = "matplotlib-3.10.9-cp312-cp312-win_arm64.whl", hash = "sha256:10cc5ce06d10231c36f40e875f3c7e8050362a4ee8f0ee5d29a6b3277d57bb42"},
+    {file = "matplotlib-3.10.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b580440f1ff81a0e34122051a3dfabb7e4b7f9e380629929bde0eff9af72165f"},
+    {file = "matplotlib-3.10.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b1b745c489cd1a77a0dc1120a05dc87af9798faebc913601feb8c73d89bf2d1e"},
+    {file = "matplotlib-3.10.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f3bcac1ca5ed000a6f4337d47ba67dfddf37ed6a46c15fd7f014997f7bf865f"},
+    {file = "matplotlib-3.10.9-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a8d66a55def891c33147ba3ba9bfcabf0b526a43764c818acbb4525e5ed0838"},
+    {file = "matplotlib-3.10.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d843374407c4017a6403b59c6c81606773d136f3259d5b6da3131bc814542cc2"},
+    {file = "matplotlib-3.10.9-cp313-cp313-win_amd64.whl", hash = "sha256:f4399f64b3e94cd500195490972ae1ee81170df1636fa15364d157d5bdd7b921"},
+    {file = "matplotlib-3.10.9-cp313-cp313-win_arm64.whl", hash = "sha256:ba7b3b8ef09eab7df0e86e9ae086faa433efbfbdb46afcb3aa16aabf779469a8"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:09218df8a93712bd6ea133e83a153c755448cf7868316c531cffcc43f69d1cc9"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:82368699727bfb7b0182e1aa13082e3c08e092fa1a25d3e1fd92405bff96f6d4"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3225f4e1edcb8c86c884ddf79ebe20ecd0a67d30188f279897554ccd8fded4dc"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de2445a0c6690d21b7eb6ce071cebad6d40a2e9bdf10d039074a96ba19797b99"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b2b9516251cb89ff618d757daec0e2ed1bf21248013844a853d87ef85ab3081d"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-win_amd64.whl", hash = "sha256:e9fae004b941b23ff2edcf1567a857ed77bafc8086ffa258190462328434faf8"},
+    {file = "matplotlib-3.10.9-cp313-cp313t-win_arm64.whl", hash = "sha256:6b63d9c7c769b88ab81e10dc86e4e0607cf56817b9f9e6cf24b2a5f1693b8e38"},
+    {file = "matplotlib-3.10.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:172db52c9e683f5d12eaf57f0f54834190e12581fe1cc2a19595a8f5acb4e77d"},
+    {file = "matplotlib-3.10.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97e35e8d39ccc85859095e01a53847432ba9a53ddf7986f7a54a11b73d0e143f"},
+    {file = "matplotlib-3.10.9-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aba1615dabe83188e19d4f75a253c6a08423e04c1425e64039f800050a69de6b"},
+    {file = "matplotlib-3.10.9-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34cf8167e023ad956c15f36302911d5406bd99a9862c1a8499ea6f7c0e015dc2"},
+    {file = "matplotlib-3.10.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59476c6d29d612b8e9bb6ce8c5b631be6ba8f9e3a2421f22a02b192c7dd28716"},
+    {file = "matplotlib-3.10.9-cp314-cp314-win_amd64.whl", hash = "sha256:336b9acc64d309063126edcdaca00db9373af3c476bb94388fe9c5a53ad13e6f"},
+    {file = "matplotlib-3.10.9-cp314-cp314-win_arm64.whl", hash = "sha256:2dc9477819ffd78ad12a20df1d9d6a6bd4fec6aaa9072681465fddca052f1456"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:da4e09638420548f31c354032a6250e473c68e5a4e96899b4844cf39ddea23fe"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:345f6f68ecc8da0ca56fad2ea08fde1a115eda530079eca185d50a7bc3e146c6"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4edcfbd8565339aa62f1cd4012f7180926fdbe71850f7b0d3c379c175cd6b66c"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6be157fe17fc37cb95ac1d7374cf717ce9259616edec911a78d9d26dae8522d4"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4e42042d54db34fda4e95a7bd3e5789c2a995d2dad3eb8850232ee534092fbbf"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-win_amd64.whl", hash = "sha256:c27df8b3848f32a83d1767566595e43cfaa4460380974da06f4279a7ec143c39"},
+    {file = "matplotlib-3.10.9-cp314-cp314t-win_arm64.whl", hash = "sha256:a49f1eadc84ca85fd72fa4e89e70e61bf86452df6f971af04b12c60761a0772c"},
+    {file = "matplotlib-3.10.9-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1872fb212a05b729e649754a72d5da61d03e0554d76e80303b6f83d1d2c0552b"},
+    {file = "matplotlib-3.10.9-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:985f2238880e2e69093f588f5fe2e46771747febf0649f3cf7f7b7480875317f"},
+    {file = "matplotlib-3.10.9-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6640f75af2c6148293caa0a2b39dd806a492dd66c8a8b04035813e33d0fd2585"},
+    {file = "matplotlib-3.10.9-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:42fb814efabe95c06c1994d8ab5a8385f43a249e23badd3ba931d4308e5bca20"},
+    {file = "matplotlib-3.10.9-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f76e640a5268850bfda54b5131b1b1941cc685e42c5fa98ed9f2d64038308cba"},
+    {file = "matplotlib-3.10.9-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3fc0364dfbe1d07f6d15c5ebd0c5bf89e126916e5a8667dd4a7a6e84c36653d4"},
+    {file = "matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358"},
+]
+
+[package.dependencies]
+contourpy = ">=1.0.1"
+cycler = ">=0.10"
+fonttools = ">=4.22.0"
+kiwisolver = ">=1.3.1"
+numpy = ">=1.23"
+packaging = ">=20.0"
+pillow = ">=8"
+pyparsing = ">=3"
+python-dateutil = ">=2.7"
+
+[package.extras]
+dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setuptools (>=64)", "setuptools_scm (>=7,<10)"]
 
 [[package]]
 name = "numpy"
@@ -579,6 +946,110 @@ numpy = ">=1.4"
 
 [package.extras]
 test = ["pytest", "pytest-cov", "scipy"]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+description = "Python Imaging Library (fork)"
+optional = true
+python-versions = ">=3.10"
+files = [
+    {file = "pillow-12.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:6c0016e7b354317c4e9e525b937ac8596c38d2d232b419529b9cd7a1cd46e39a"},
+    {file = "pillow-12.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bcc33feacfaefce60c12fd500a277533bdc02b10a19f7f6d348763d8140bbba7"},
+    {file = "pillow-12.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5594fc43d548a7ed94949d139aa1341b270f1863f11cfd37f5a6c8b778a6b67f"},
+    {file = "pillow-12.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0606c8bf2cdefea14a43530f7657cbbb7ecf1c4222512492ef4a4434a9501ec"},
+    {file = "pillow-12.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:85f998ea1848bc6757289e739cfbdda3a04adfd58b02fc018ce54d754a5ce468"},
+    {file = "pillow-12.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:25b9b82bb22e6e2b3cd07b39c68b7b862001226cb3dff7130d1cb914121b39ed"},
+    {file = "pillow-12.3.0-cp310-cp310-win32.whl", hash = "sha256:37dc8f7bbb66efe481bb60defacef820c950c24713fb44962ed6aa2a50966de1"},
+    {file = "pillow-12.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:300557495eb45ebb8aec96c2da9c4be642fbf7cd937278b4013ba894ea8eb0eb"},
+    {file = "pillow-12.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:514435a37670e3e5e08f3945b68718b6ed329bb84367777e16f9f4dfe1e61a0f"},
+    {file = "pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756"},
+    {file = "pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6"},
+    {file = "pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd"},
+    {file = "pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd"},
+    {file = "pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c"},
+    {file = "pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5"},
+    {file = "pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b"},
+    {file = "pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a"},
+    {file = "pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26"},
+    {file = "pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965"},
+    {file = "pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7"},
+    {file = "pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9"},
+    {file = "pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91"},
+    {file = "pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c"},
+    {file = "pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df"},
+    {file = "pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f"},
+    {file = "pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09"},
+    {file = "pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace"},
+    {file = "pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec"},
+    {file = "pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66"},
+    {file = "pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35"},
+    {file = "pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65"},
+    {file = "pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3"},
+    {file = "pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a"},
+    {file = "pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e"},
+    {file = "pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f"},
+    {file = "pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8"},
+    {file = "pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217"},
+    {file = "pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930"},
+    {file = "pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8"},
+    {file = "pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0"},
+    {file = "pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321"},
+    {file = "pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b"},
+    {file = "pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198"},
+    {file = "pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130"},
+    {file = "pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a"},
+    {file = "pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d"},
+    {file = "pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838"},
+    {file = "pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e"},
+    {file = "pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17"},
+    {file = "pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385"},
+    {file = "pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c"},
+    {file = "pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d"},
+    {file = "pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931"},
+    {file = "pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7"},
+    {file = "pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c"},
+    {file = "pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:0feb2e9d6ad6c9e3c06effe9d00f3f1e618a6643273576b016f591e9315a7139"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:9e881fca225083806662a5c43d627d215f258ff43c890f831966c7d7ba9c7402"},
+    {file = "pillow-12.3.0-cp315-cp315-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:4998562bf62a445225f22e07c896bb04b35b1b1f2eb6d760584c9c51d7a5f78c"},
+    {file = "pillow-12.3.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:dc624f6bc473dacdf7ef7eb8678d0d08edf15cd94fad6ae5c7d6cc67a4e4902f"},
+    {file = "pillow-12.3.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:71d6097b330eea8fd15097780c8e89cb1a8ce7838669f48c5bacd6f663dd4701"},
+    {file = "pillow-12.3.0-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:28ce87c5ab450a9dd970b52e5aca5fe63ed432d18a2eaddd1979a00a1ba24ace"},
+    {file = "pillow-12.3.0-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b02afb9b97f65fbca5f31db6a2a3ba21aa93030225f150fa3f249717e938fb4"},
+    {file = "pillow-12.3.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:1182d52bc2d5e5d7d0949503aa7e36d12f42205dc287e4883f407b1988820d39"},
+    {file = "pillow-12.3.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e795b7eb908249c4e43c7c99fac7c2c75dab0c43566e37db472a355f63693d71"},
+    {file = "pillow-12.3.0-cp315-cp315-win32.whl", hash = "sha256:57b3d78c95ba9059768b10e28b813002261d3f3dfc55cc48b0c988f625175827"},
+    {file = "pillow-12.3.0-cp315-cp315-win_amd64.whl", hash = "sha256:fa4ecea169a355be7a3ade2c783e2ed12f0e40d2c5621cda8b3297faf7fbb9f5"},
+    {file = "pillow-12.3.0-cp315-cp315-win_arm64.whl", hash = "sha256:877c3f311ff35410f690861c4409e7ccbf0cd2f878e50628a28e5a0bb689e658"},
+    {file = "pillow-12.3.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:e9871b1ffbfa9656b60aeee92ed5136a5742696006fa322b29ea3d8da0ecc9cf"},
+    {file = "pillow-12.3.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53aa02d20d10c3d814d536aa4e5ac9b84ca0ff5a88377963b085ad6822f93e64"},
+    {file = "pillow-12.3.0-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:446c34dcc4324b084a53b705127dc15717b22c5e140ae0a3c38349d4efec071e"},
+    {file = "pillow-12.3.0-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf1845d02ad822a369a49f2bb9345b1614744267682e7a03527dc3bf6eea1777"},
+    {file = "pillow-12.3.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:186941b6aef820ad110fb01fb06eb925374dc3a21b17e37ec9a53b250c6fe2d1"},
+    {file = "pillow-12.3.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:f13c32a3abd6079a66d9526e18dad9b6d280384d49d7c54040cd57b6424041d9"},
+    {file = "pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8"},
+    {file = "pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418"},
+    {file = "pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3"},
+    {file = "pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a"},
+    {file = "pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce"},
+]
+
+[package.extras]
+docs = ["furo", "olefile", "sphinx (>=8.2)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-inline-tabs", "sphinxext-opengraph"]
+fpx = ["olefile"]
+mic = ["olefile"]
+test-arrow = ["arro3-compute", "arro3-core", "nanoarrow", "pyarrow"]
+tests = ["coverage (>=7.4.2)", "defusedxml", "markdown2", "olefile", "packaging", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "setuptools", "trove-classifiers (>=2024.10.12)"]
+xmp = ["defusedxml"]
 
 [[package]]
 name = "pluggy"
@@ -912,6 +1383,20 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+description = "pyparsing - Classes and methods to define and execute parsing grammars"
+optional = true
+python-versions = ">=3.9"
+files = [
+    {file = "pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d"},
+    {file = "pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc"},
+]
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -1420,9 +1905,9 @@ scikit-learn = ["scikit-learn"]
 
 [extras]
 ml = ["lightgbm", "polars-ds", "scikit-learn", "statsmodels", "xgboost"]
-test = ["pytest"]
+test = ["matplotlib", "pytest"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "2a6e59894c70595792d3b227effb7cbc6bb2ae4d137e6df936d3d327822034ee"
+content-hash = "aa6997cac0206fe22f48923db06cec7978a3a10593c34cac8725b9b1bc6bbb81"

--- a/kernel_runtime/pyproject.toml
+++ b/kernel_runtime/pyproject.toml
@@ -26,10 +26,11 @@ lightgbm = {version = "^4.0.0", optional = true}
 statsmodels = {version = "^0.14.0", optional = true}
 polars-ds = {version = ">=0.11.0", optional = true}
 pytest = {version = ">=7.0.0", optional = true}
+matplotlib = {version = "^3.6.0", optional = true}
 
 [tool.poetry.extras]
 ml = ["scikit-learn", "xgboost", "lightgbm", "statsmodels", "polars-ds"]
-test = ["pytest"]
+test = ["pytest", "matplotlib"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.0.0"

--- a/kernel_runtime/tests/conftest.py
+++ b/kernel_runtime/tests/conftest.py
@@ -39,6 +39,7 @@ def _clear_global_state():
     artifact_store._loading_locks.clear()
     artifact_store._persist_pending.clear()
     main._display_output_store.clear()
+    main._artifact_preview_store.clear()
 
     yield
 
@@ -56,6 +57,7 @@ def _clear_global_state():
     artifact_store._loading_locks.clear()
     artifact_store._persist_pending.clear()
     main._display_output_store.clear()
+    main._artifact_preview_store.clear()
 
 
 @pytest.fixture()

--- a/kernel_runtime/tests/test_artifact_node_attribution.py
+++ b/kernel_runtime/tests/test_artifact_node_attribution.py
@@ -1,0 +1,103 @@
+"""Node-scoped attribution of published / deleted artifacts.
+
+Artifacts published on a shared kernel are attributed to the owning node via the
+``node_id`` stamped in the store metadata, never via a store-wide name diff. This
+guards against cross-node misattribution when independent nodes run concurrently
+on the same kernel — the artifact store is shared across every node in a flow.
+"""
+
+import threading
+
+from fastapi.testclient import TestClient
+
+from kernel_runtime import main
+
+
+def _execute(client: TestClient, code: str, node_id: int = 1, flow_id: int = 1):
+    return client.post(
+        "/execute",
+        json={
+            "node_id": node_id,
+            "code": code,
+            "flow_id": flow_id,
+            "input_paths": {},
+            "output_dir": "",
+        },
+    )
+
+
+def _published_names(resp) -> list[str]:
+    return sorted(a["name"] for a in resp.json()["artifacts_published"])
+
+
+def _deleted_names(resp) -> list[str]:
+    return sorted(resp.json()["artifacts_deleted"])
+
+
+class TestPublishedAttribution:
+    def test_excludes_artifact_from_another_node(self, client: TestClient):
+        # A foreign node's artifact landing in the shared store mid-execution
+        # (exactly what a concurrent node does) must not be attributed here.
+        code = (
+            "import kernel_runtime.main as _m\n"
+            "flowfile_ctx.publish_artifact('mine', {'x': 1})\n"
+            "_m.artifact_store.publish('foreign', {'y': 2}, node_id=999, flow_id=1)\n"
+        )
+        resp = _execute(client, code, node_id=1, flow_id=1)
+        assert resp.json()["success"] is True
+        assert _published_names(resp) == ["mine"]
+
+    def test_two_nodes_report_only_their_own(self, client: TestClient):
+        a = _execute(client, "flowfile_ctx.publish_artifact('a', {'v': 1})\n", node_id=1)
+        b = _execute(client, "flowfile_ctx.publish_artifact('b', {'v': 2})\n", node_id=2)
+        assert _published_names(a) == ["a"]
+        assert _published_names(b) == ["b"]
+
+    def test_concurrent_execution_no_cross_attribution(self, client: TestClient):
+        results: dict[int, list[str]] = {}
+
+        def worker(node_id: int, name: str, barrier: threading.Barrier) -> None:
+            barrier.wait()
+            code = f"flowfile_ctx.publish_artifact('{name}', {{'v': {node_id}}})\n"
+            results[node_id] = _published_names(_execute(client, code, node_id=node_id, flow_id=1))
+
+        for _ in range(8):
+            main.artifact_store.clear(flow_id=1)
+            results.clear()
+            barrier = threading.Barrier(2)
+            t1 = threading.Thread(target=worker, args=(1, "a", barrier))
+            t2 = threading.Thread(target=worker, args=(2, "b", barrier))
+            t1.start()
+            t2.start()
+            t1.join(timeout=30)
+            t2.join(timeout=30)
+            assert results.get(1) == ["a"]
+            assert results.get(2) == ["b"]
+
+
+class TestDeletedAttribution:
+    def test_reports_own_delete(self, client: TestClient):
+        code = (
+            "flowfile_ctx.publish_artifact('keep', {'x': 1})\n"
+            "flowfile_ctx.publish_artifact('gone', {'y': 2})\n"
+            "flowfile_ctx.delete_artifact('gone')\n"
+        )
+        resp = _execute(client, code, node_id=1, flow_id=1)
+        assert resp.json()["success"] is True
+        assert _published_names(resp) == ["keep"]
+        assert _deleted_names(resp) == ["gone"]
+
+    def test_excludes_foreign_delete(self, client: TestClient):
+        # Pre-seed a foreign artifact, then have this node's execution remove it
+        # directly (simulating a concurrent foreign delete). It must not be
+        # attributed to this node's deletions.
+        main.artifact_store.publish("foreign", {"y": 2}, node_id=999, flow_id=1)
+        code = (
+            "import kernel_runtime.main as _m\n"
+            "flowfile_ctx.publish_artifact('mine', {'x': 1})\n"
+            "_m.artifact_store.delete('foreign', flow_id=1)\n"
+        )
+        resp = _execute(client, code, node_id=1, flow_id=1)
+        assert resp.json()["success"] is True
+        assert _published_names(resp) == ["mine"]
+        assert _deleted_names(resp) == []

--- a/kernel_runtime/tests/test_artifact_preview.py
+++ b/kernel_runtime/tests/test_artifact_preview.py
@@ -1,0 +1,110 @@
+"""Tests for artifact preview publishing (publish_artifact preview=True) and retrieval."""
+
+from fastapi.testclient import TestClient
+
+from kernel_runtime import flowfile_client
+
+_MPL_CHART = (
+    "import matplotlib\n"
+    'matplotlib.use("Agg")\n'
+    "import matplotlib.pyplot as plt\n"
+    "fig, ax = plt.subplots()\n"
+    "ax.plot([1, 2, 3])\n"
+    'flowfile_ctx.publish_artifact("chart", fig, preview={preview})\n'
+)
+
+
+def _execute(client: TestClient, code: str, node_id: int = 1, flow_id: int = 1):
+    return client.post(
+        "/execute",
+        json={
+            "node_id": node_id,
+            "code": code,
+            "flow_id": flow_id,
+            "input_paths": {},
+            "output_dir": "",
+        },
+    )
+
+
+class TestArtifactPreviewViaExecute:
+    def test_matplotlib_preview_published_and_fetchable(self, client: TestClient):
+        resp = _execute(client, _MPL_CHART.format(preview=True))
+        data = resp.json()
+        assert data["success"] is True
+        published = data["artifacts_published"]
+        assert len(published) == 1
+        assert published[0]["name"] == "chart"
+        assert published[0]["has_preview"] is True
+        assert published[0]["preview_mime"] == "image/png"
+
+        preview = client.get("/artifact_preview", params={"flow_id": 1, "name": "chart"})
+        assert preview.status_code == 200
+        blob = preview.json()
+        assert blob is not None
+        assert blob["mime_type"] == "image/png"
+        assert blob["data"]
+        assert blob["title"] == "chart"
+
+    def test_default_preview_false(self, client: TestClient):
+        resp = _execute(client, _MPL_CHART.format(preview=False))
+        published = resp.json()["artifacts_published"]
+        assert published[0]["has_preview"] is False
+        assert published[0]["preview_mime"] is None
+
+        preview = client.get("/artifact_preview", params={"flow_id": 1, "name": "chart"})
+        assert preview.status_code == 200
+        assert preview.json() is None
+
+    def test_non_renderable_object_stores_no_preview(self, client: TestClient):
+        resp = _execute(client, 'flowfile_ctx.publish_artifact("cfg", {"a": 1}, preview=True)')
+        data = resp.json()
+        assert data["success"] is True
+        published = data["artifacts_published"]
+        assert published[0]["name"] == "cfg"
+        assert published[0]["has_preview"] is False
+        assert published[0]["preview_mime"] is None
+
+        preview = client.get("/artifact_preview", params={"flow_id": 1, "name": "cfg"})
+        assert preview.json() is None
+
+    def test_html_string_preview(self, client: TestClient):
+        resp = _execute(client, 'flowfile_ctx.publish_artifact("report", "<b>hi</b>", preview=True)')
+        published = resp.json()["artifacts_published"]
+        assert published[0]["has_preview"] is True
+        assert published[0]["preview_mime"] == "text/html"
+
+        blob = client.get("/artifact_preview", params={"flow_id": 1, "name": "report"}).json()
+        assert blob["mime_type"] == "text/html"
+        assert blob["data"] == "<b>hi</b>"
+
+    def test_reexecute_without_preview_clears_stored_preview(self, client: TestClient):
+        first = _execute(client, _MPL_CHART.format(preview=True))
+        assert first.json()["artifacts_published"][0]["has_preview"] is True
+        assert client.get("/artifact_preview", params={"flow_id": 1, "name": "chart"}).json() is not None
+
+        second = _execute(client, _MPL_CHART.format(preview=False))
+        assert second.json()["artifacts_published"][0]["has_preview"] is False
+        assert client.get("/artifact_preview", params={"flow_id": 1, "name": "chart"}).json() is None
+
+
+class TestRenderDisplayPayload:
+    def test_matplotlib_figure_returns_png(self):
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2, 3])
+        payload = flowfile_client._render_display_payload(fig)
+        plt.close(fig)
+        assert payload is not None
+        assert payload["mime_type"] == "image/png"
+        assert payload["data"]
+
+    def test_plain_string_returns_none(self):
+        assert flowfile_client._render_display_payload("just plain text") is None
+
+    def test_dict_returns_none(self):
+        assert flowfile_client._render_display_payload({"a": 1}) is None


### PR DESCRIPTION
This pull request adds support for artifact preview metadata and improves the handling of custom (user-defined) nodes in the flow graph, especially when copying nodes or restoring flows. It also introduces a new API endpoint for retrieving artifact previews, enhances logging noise suppression in kernel code generation, and includes comprehensive tests for the new and updated behaviors.

**Artifact Preview Metadata**

* Added `has_preview` and `preview_mime` fields to `ArtifactRef` and `PublishedArtifact`, ensuring that preview metadata is tracked, serialized, and surfaced in node summaries and kernel wire models. [[1]](diffhunk://#diff-837b254424dd850e575e8b9c6b38379d25fdf6c6462e8c8a23677c583a945170R30-R31) [[2]](diffhunk://#diff-837b254424dd850e575e8b9c6b38379d25fdf6c6462e8c8a23677c583a945170R42-R43) [[3]](diffhunk://#diff-837b254424dd850e575e8b9c6b38379d25fdf6c6462e8c8a23677c583a945170R114-R115) [[4]](diffhunk://#diff-837b254424dd850e575e8b9c6b38379d25fdf6c6462e8c8a23677c583a945170R421-R422) [[5]](diffhunk://#diff-88b56f03602bb778e1a810a05d701b28b9e31b97c44083542f52e068b7b3fb13R165-R166)
* Updated tests to verify round-trip of preview metadata and ensure backward compatibility with legacy payloads.

**Custom Node Handling Improvements**

* Refactored flow restoration and node copying logic to use a unified `_place_user_defined_node` method, ensuring that custom nodes are always handled correctly, including when their type is missing/uninstalled. [[1]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48L1380-R1380) [[2]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R1974-R1991) [[3]](diffhunk://#diff-dbf2223090ac75a1e4904f08ae306ffc7e56b8360d0fa341ea2d082b38774057L337-R336) [[4]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R5892-R5895) [[5]](diffhunk://#diff-dbf7454fd9f7e1ff7f2a3564dedb3cfbe45f5a71c53fc85abbe6fb5656173d48R5912-R5914)
* Added tests to guarantee that copying custom nodes works reliably and missing custom nodes degrade gracefully to placeholders.

**Kernel API Enhancements**

* Added a new `/artifact_preview` endpoint and corresponding manager method to retrieve rendered preview blobs for published artifacts. [[1]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdR1863-R1874) [[2]](diffhunk://#diff-939fb76c76ac28ede0dd722f5c0c84b7d59ef86bd6480b61fa842b01286cef01R436-R457)

**Kernel Code Generation and Logging**

* Expanded the set of noisy loggers suppressed during kernel execution to include `matplotlib`, `PIL`, `fontTools`, and `kernel_runtime`, reducing log clutter in the test panel. [[1]](diffhunk://#diff-dc38e36be74641e4ae99e54c86437ff3243d1b095c828110b71d95e9cf7f7e65L183-R184) [[2]](diffhunk://#diff-dc38e36be74641e4ae99e54c86437ff3243d1b095c828110b71d95e9cf7f7e65L198-R201)

**Testing and Compatibility**

* Introduced and updated tests to cover new artifact preview fields, legacy compatibility, and kernel wire model behavior.

These changes collectively improve artifact metadata handling, robustness and reliability of user-defined node management, and developer/user experience.