### PR TITLE
Feature/improve draggable dock items

### DIFF
--- a/flowfile_frontend/CLAUDE.md
+++ b/flowfile_frontend/CLAUDE.md
@@ -32,6 +32,7 @@ Pure client. Talks to `flowfile_core` over HTTP; never to `flowfile_worker` dire
 - No JSX/TSX: React (`react`/`react-dom` v19, pinned via `overrides`) is only a dynamic `import("react")` inside the `@kanaries/graphic-walker` Vue wrappers. `vite.config.mjs` deliberately omits `@vitejs/plugin-react`; `tsconfig.json` excludes `*.tsx`/`*.jsx`.
 - AG Grid is the **modular** `@ag-grid-community/*` v31 (`ModuleRegistry.registerModules`; not the monolithic `ag-grid-community`).
 - OAuth: the GA connection opens the **system browser** (`desktop.openExternal`) because Google blocks embedded webviews; the generic `open_oauth` command opens a modal Tauri webview window (`oauth.rs`) for providers that allow it.
+- Canvas overlay panels (`components/common/DraggableItem/`) persist **user intent only** (dock side + per-axis size/offset/gap, localStorage `overlayPositionAndSize.v4_*`), written solely at gesture end via `stateStore.commitIntent`; the on-screen rect is derived per frame by the pure `layoutGeometry.computeLayout(intent, config, containerBounds, minimized)` against the single shared container measurement `Canvas.vue` registers. **Never persist derived geometry** — that split is the fix for the historical drawer-collapse corruption (150×100 panels). Docked panels resize via splitter edges, pop out only past a 48px deliberate drag, and snap back into a dock when released within 40px of an edge.
 
 ## Running / entry points
 From this dir (`npm install` first):

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/DraggableItem.vue
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/DraggableItem.vue
@@ -5,15 +5,13 @@
     :class="{
       'no-transition': isResizing,
       minimized: isMinimized,
-      'in-group': itemState.group,
-      synced: itemState.syncDimensions,
     }"
     :style="{
-      width: isMinimized ? 'auto' : itemState.width + 'px',
-      height: isMinimized ? 'auto' : itemState.height + 'px',
-      top: itemState.top + 'px',
-      left: itemState.left + 'px',
-      zIndex: itemState.zIndex,
+      width: isMinimized ? 'auto' : rect.width + 'px',
+      height: isMinimized ? 'auto' : rect.height + 'px',
+      top: rect.top + 'px',
+      left: rect.left + 'px',
+      zIndex: itemStore.zIndexFor(props.id),
     }"
   >
     <div class="header" @mousedown="startMove" @dblclick="handleHeaderDblClick">
@@ -28,43 +26,43 @@
       </button>
 
       <button
-        v-if="showRight && itemState.stickynessPosition !== 'right'"
+        v-if="showRight && intent.dock !== 'right'"
         class="minimal-button"
         data-tooltip="true"
         title="Move to Right"
-        @click="moveToRight"
+        @click="dockTo('right')"
       >
         <span class="icon">→</span>
       </button>
       <button
-        v-if="showBottom && itemState.stickynessPosition !== 'bottom'"
+        v-if="showBottom && intent.dock !== 'bottom'"
         class="minimal-button"
         data-tooltip="true"
         title="Move to Bottom"
-        @click="moveToBottom"
+        @click="dockTo('bottom')"
       >
         <span class="icon">↓</span>
       </button>
       <button
-        v-if="showLeft && itemState.stickynessPosition !== 'left'"
+        v-if="showLeft && intent.dock !== 'left'"
         class="minimal-button"
         data-tooltip="true"
         title="Move to Left"
-        @click="moveToLeft"
+        @click="dockTo('left')"
       >
         <span class="icon">←</span>
       </button>
       <button
-        v-if="showTop && itemState.stickynessPosition !== 'top'"
+        v-if="showTop && intent.dock !== 'top'"
         class="minimal-button"
         data-tooltip="true"
         title="Move to Top"
-        @click="moveToTop"
+        @click="dockTo('top')"
       >
         <span class="icon">↑</span>
       </button>
       <button
-        v-if="allowFullScreen && !itemState.fullScreen"
+        v-if="allowFullScreen && !intent.fullScreen"
         class="minimal-button"
         data-tooltip="true"
         data-tooltip-text="Toggle Full Screen"
@@ -73,7 +71,7 @@
         <span class="icon">⬜</span>
       </button>
       <button
-        v-if="allowFullScreen && itemState.fullScreen"
+        v-if="allowFullScreen && intent.fullScreen"
         class="minimal-button"
         data-tooltip="true"
         data-tooltip-text="Exit Full Screen"
@@ -103,25 +101,25 @@
 
     <div
       class="draggable-line right-vertical"
-      @mousedown.stop="startResizeRight"
+      @mousedown.stop="beginResize($event, 'right')"
       @mouseenter="resizeOnEnter($event, 'right')"
       @dblclick.stop="handleResizeBarDblClick"
     ></div>
     <div
       class="draggable-line bottom-horizontal"
-      @mousedown.stop="startResizeBottom"
+      @mousedown.stop="beginResize($event, 'bottom')"
       @mouseenter="resizeOnEnter($event, 'bottom')"
       @dblclick.stop="handleResizeBarDblClick"
     ></div>
     <div
       class="draggable-line top-horizontal"
-      @mousedown.stop="startResizeTop"
+      @mousedown.stop="beginResize($event, 'top')"
       @mouseenter="resizeOnEnter($event, 'top')"
       @dblclick.stop="handleResizeBarDblClick"
     ></div>
     <div
       class="draggable-line left-vertical"
-      @mousedown.stop="startResizeLeft"
+      @mousedown.stop="beginResize($event, 'left')"
       @mouseenter="resizeOnEnter($event, 'left')"
       @dblclick.stop="handleResizeBarDblClick"
     ></div>
@@ -129,23 +127,29 @@
 </template>
 
 <script setup lang="ts">
-// TODO(refactor): ~1027 LOC, god component. Plan to extract:
-//   - useDraggableResize composable: per-edge resize handlers (~lines 365-457)
-//   - useDraggablePosition composable: move/sticky helpers (~lines 475-545)
-//   - DraggableItemHeader.vue: header controls (~lines 19-87)
-//   - useGroupSync composable: group dimension sync (~lines 285-316)
+// Renders one overlay panel from persisted USER INTENT (store) derived
+// against the shared canvas container — see layoutGeometry.ts for the
+// intent-vs-derived contract. During a gesture the local gestureRect
+// overrides the derived rect at 60Hz; intent is committed once, at mouseup.
+import { computed, onBeforeUnmount, ref, watch, watchEffect } from "vue";
+
 import {
-  ref,
-  computed,
-  onMounted,
-  onBeforeUnmount,
-  defineExpose,
-  defineProps,
-  nextTick,
-  watch,
-} from "vue";
+  clampRectToBounds,
+  computeLayout,
+  defaultIntent,
+  intentFromRect,
+  isContainerUsable,
+  snapSideForRect,
+  type AxisBehaviour,
+  type DockSide,
+  type PanelConfig,
+  type PanelDock,
+  type PanelIntent,
+  type RenderRect,
+} from "./layoutGeometry";
 import { useItemStore } from "./stateStore";
-import type { ItemLayout, AxisBehaviour } from "./stateStore";
+import { useDraggablePosition } from "./useDraggablePosition";
+import { useDraggableResize } from "./useDraggableResize";
 
 const props = defineProps({
   id: {
@@ -165,10 +169,6 @@ const props = defineProps({
     default: false,
   },
   showBottom: {
-    type: Boolean,
-    default: false,
-  },
-  showPresets: {
     type: Boolean,
     default: false,
   },
@@ -193,7 +193,6 @@ const props = defineProps({
     type: String as () => AxisBehaviour,
     default: null,
   },
-
   initialLeft: {
     type: Number,
     default: null,
@@ -222,14 +221,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  group: {
-    type: String,
-    default: null,
-  },
-  syncDimensions: {
-    type: Boolean,
-    default: false,
-  },
   // Tab strip rendered in the header. Empty ⇒ the `title` shows as a single
   // static tab (so every panel header looks the same).
   tabs: {
@@ -245,17 +236,6 @@ const props = defineProps({
 const emit = defineEmits(["update:activeTab"]);
 
 const itemStore = useItemStore();
-const itemState = ref(
-  itemStore.items[props.id] || {
-    width: props.initialWidth || 400,
-    height: props.initialHeight || 300,
-    left: props.initialLeft || 100,
-    top: props.initialTop || 100,
-    group: props.group,
-    syncDimensions: props.syncDimensions,
-    zIndex: 100,
-  },
-);
 
 // Unset ⇒ legacy rule: "fill" when no initial size was given, else "fixed".
 const resolvedWidthBehaviour = computed<AxisBehaviour>(
@@ -265,114 +245,132 @@ const resolvedHeightBehaviour = computed<AxisBehaviour>(
   () => props.heightBehaviour ?? (props.initialHeight ? "fixed" : "fill"),
 );
 
-const isDragging = ref(false);
-const isResizing = ref(false);
-const startX = ref(0);
-const startY = ref(0);
-const startWidth = ref(0);
-const startHeight = ref(0);
-const startLeft = ref(0);
-const startTop = ref(0);
+const panelCfg = computed<PanelConfig>(() => ({
+  defaultDock: props.initialPosition as PanelDock,
+  h: {
+    behaviour: resolvedWidthBehaviour.value,
+    defaultSize: props.initialWidth ?? null,
+    defaultOffset: props.initialLeft ?? (props.initialPosition === "free" ? 100 : 0),
+  },
+  v: {
+    behaviour: resolvedHeightBehaviour.value,
+    defaultSize: props.initialHeight ?? null,
+    defaultOffset: props.initialTop ?? (props.initialPosition === "free" ? 100 : 0),
+  },
+}));
+
+// Registration needs no DOM; doing it in setup means the first render already
+// has the loaded (or migrated) intent. The watch keeps the store's config
+// fresh for resetLayout when reactive defaults (e.g. Canvas height override)
+// change — re-registering is idempotent for the intent itself.
+itemStore.registerPanel(props.id, panelCfg.value);
+watch(panelCfg, (cfg) => itemStore.registerPanel(props.id, cfg));
+
+const intent = computed<PanelIntent>(
+  () => itemStore.items[props.id] ?? defaultIntent(panelCfg.value),
+);
+
 const isMinimized = ref(false);
-const activeLine = ref<HTMLElement | null>(null);
-let resizeTimeout: ReturnType<typeof setTimeout>;
+const gestureRect = ref<RenderRect | null>(null);
+const lastGoodRect = ref<RenderRect | null>(null);
 
-const resizeDirection = ref<"top" | "bottom" | "left" | "right" | null>(null);
-const initialGroupStates = ref<
-  Record<string, { top: number; left: number; width: number; height: number }>
->({});
+const derivedRect = computed<RenderRect | null>(() =>
+  computeLayout(intent.value, panelCfg.value, itemStore.containerBounds, isMinimized.value),
+);
 
-// Track previous container (canvas <main>) dimensions for proportional
-// repositioning. Seeded in onMounted from the live container — panels are
-// absolutely positioned inside <main>, so every bounds calculation must use the
-// container, not the window (which is taller by the page header).
-const prevContainerWidth = ref(0);
-const prevContainerHeight = ref(0);
-
-// Container bounds captured once at the start of a resize gesture. The container
-// can't change mid-drag, and reading it per-mousemove would force a reflow.
-const resizeBounds = ref<{ width: number; height: number }>({ width: 0, height: 0 });
-
-const resizeDelay = ref<ReturnType<typeof setTimeout> | null>(null);
-const resizeOnEnter = (e: MouseEvent, position: "top" | "bottom" | "left" | "right") => {
-  if (resizeDelay.value) clearTimeout(resizeDelay.value);
-  resizeDelay.value = setTimeout(() => {
-    if (itemStore.inResizing && !isResizing.value) {
-      switch (position) {
-        case "right":
-          startResizeRight(e);
-          break;
-        case "bottom":
-          startResizeBottom(e);
-          break;
-        case "top":
-          startResizeTop(e);
-          break;
-        case "left":
-          startResizeLeft(e);
-          break;
-      }
-    }
-  }, 200);
-};
-
-const savePositionAndSize = () => {
-  itemStore.setItemState(props.id, {
-    width: itemState.value.width,
-    height: itemState.value.height,
-    left: itemState.value.left,
-    top: itemState.value.top,
-    stickynessPosition: itemState.value.stickynessPosition,
-    fullWidth: itemState.value.fullWidth,
-    fullHeight: itemState.value.fullHeight,
-    zIndex: itemState.value.zIndex,
-    fullScreen: itemState.value.fullScreen,
-    group: itemState.value.group,
-    syncDimensions: itemState.value.syncDimensions,
-  });
-
-  itemStore.saveItemState(props.id);
-
-  if (itemState.value.group && itemState.value.syncDimensions && isResizing.value) {
-    const groupItems = itemStore.groups[itemState.value.group];
-    if (groupItems) {
-      const initialActiveState = initialGroupStates.value[props.id];
-      if (!initialActiveState) return;
-
-      const deltaX = itemState.value.left - initialActiveState.left;
-      const deltaY = itemState.value.top - initialActiveState.top;
-
-      groupItems.forEach((itemId) => {
-        if (itemId === props.id) return;
-
-        const initialItemState = initialGroupStates.value[itemId];
-        if (itemStore.items[itemId]?.syncDimensions && initialItemState) {
-          const updates: Partial<ItemLayout> = {
-            width: itemState.value.width,
-            height: itemState.value.height,
-          };
-
-          if (resizeDirection.value === "top") {
-            updates.top = initialItemState.top + deltaY;
-          }
-          if (resizeDirection.value === "left") {
-            updates.left = initialItemState.left + deltaX;
-          }
-
-          itemStore.setItemState(itemId, updates);
-          itemStore.saveItemState(itemId);
-        }
-      });
-    }
+watchEffect(() => {
+  if (derivedRect.value && !gestureRect.value) {
+    lastGoodRect.value = derivedRect.value;
   }
+});
+
+const rect = computed<RenderRect>(
+  () =>
+    gestureRect.value ??
+    derivedRect.value ??
+    lastGoodRect.value ?? {
+      // Pre-container fallback (first frame only): defaults, unclamped — the
+      // .overlay max-width/height CSS caps any overflow.
+      left: panelCfg.value.h.defaultOffset,
+      top: panelCfg.value.v.defaultOffset,
+      width: panelCfg.value.h.defaultSize ?? 300,
+      height: panelCfg.value.v.defaultSize ?? 300,
+    },
+);
+
+const allowedDockSides = computed<DockSide[]>(() => {
+  const sides = new Set<DockSide>();
+  if (props.showRight) sides.add("right");
+  if (props.showBottom) sides.add("bottom");
+  if (props.showLeft) sides.add("left");
+  if (props.showTop) sides.add("top");
+  if (props.initialPosition !== "free") sides.add(props.initialPosition as DockSide);
+  return [...sides];
+});
+
+const registerClick = () => itemStore.clickOnItem(props.id);
+
+const commitRect = (finalRect: RenderRect, dock: PanelDock) => {
+  const bounds = { ...itemStore.containerBounds };
+  // A broken container measurement would turn the rect into garbage intent —
+  // drop the gesture instead (the derived rect simply resumes).
+  if (!isContainerUsable(bounds)) return;
+  const settled = clampRectToBounds(finalRect, bounds, isMinimized.value);
+  itemStore.commitIntent(
+    props.id,
+    intentFromRect(settled, dock, panelCfg.value, bounds, isMinimized.value),
+  );
 };
 
-const loadPositionAndSize = () => {
-  itemStore.loadItemState(props.id);
-  if (itemStore.items[props.id]) {
-    itemState.value = itemStore.items[props.id];
+const dockTo = (side: DockSide) => {
+  // While fullscreen the derived rect is the container — view state, not a
+  // layout to commit. Exit fullscreen instead; the panel then docks normally.
+  if (intent.value.fullScreen) {
+    itemStore.setFullScreen(props.id, false);
+    return;
   }
+  commitRect(rect.value, side);
 };
+
+const {
+  isResizing,
+  beginResize,
+  resizeOnEnter,
+  teardown: teardownResize,
+} = useDraggableResize({
+  gestureRect,
+  getRect: () => ({ ...rect.value }),
+  getBounds: () => ({ ...itemStore.containerBounds }),
+  isEnabled: () => !intent.value.fullScreen,
+  setSharedResizing: (value) => {
+    itemStore.inResizing = value;
+  },
+  isSharedResizing: () => itemStore.inResizing,
+  onStart: registerClick,
+  onCommit: (finalRect) => commitRect(finalRect, intent.value.dock),
+});
+
+const {
+  isDragging,
+  startMove,
+  teardown: teardownMove,
+} = useDraggablePosition({
+  // A fullscreen panel is not draggable — its rect is view state and a drag
+  // commit would persist container-sized geometry as layout.
+  allowFreeMove: () => props.allowFreeMove && !intent.value.fullScreen,
+  gestureRect,
+  getRect: () => ({ ...rect.value }),
+  getDock: () => intent.value.dock,
+  onStart: registerClick,
+  onCommit: (finalRect) => {
+    const bounds = { ...itemStore.containerBounds };
+    if (!isContainerUsable(bounds)) return;
+    // Magnetic snap-back: releasing near an allowed edge re-docks (VSCode-
+    // style); otherwise the panel becomes a free intent.
+    const snapSide = snapSideForRect(finalRect, bounds, allowedDockSides.value);
+    commitRect(finalRect, snapSide ?? "free");
+  },
+});
 
 const toggleMinimize = () => {
   if (!isMinimized.value && props.onMinimize) {
@@ -381,26 +379,12 @@ const toggleMinimize = () => {
   isMinimized.value = !isMinimized.value;
 };
 
-const handleReziging = (e: MouseEvent) => {
-  activeLine.value = e.target as HTMLElement;
-  activeLine.value.classList.add("resizing-highlight-line");
-  isResizing.value = true;
-  itemStore.inResizing = true;
-};
-
-// Re-anchor the "scale" baseline to the current container after a fullscreen
-// round-trip changes the panel size out-of-band — otherwise the next resize
-// applies a phantom delta to the restored size.
-const syncScaleBaseline = () => {
-  const c = getStickyContainer();
-  prevContainerWidth.value = c.width;
-  prevContainerHeight.value = c.height;
+const setFullScreen = (makeFull: boolean) => {
+  itemStore.setFullScreen(props.id, makeFull);
 };
 
 const toggleFullScreen = () => {
   itemStore.toggleFullScreen(props.id);
-  loadPositionAndSize();
-  syncScaleBaseline();
 };
 
 const handleResizeBarDblClick = (e: MouseEvent) => {
@@ -425,635 +409,17 @@ const handleHeaderDblClick = (e: MouseEvent) => {
   toggleFullScreen();
 };
 
-const captureGroupInitialStates = () => {
-  if (itemState.value.group && itemState.value.syncDimensions) {
-    initialGroupStates.value = {};
-    const groupItems = itemStore.groups[itemState.value.group];
-    if (groupItems) {
-      groupItems.forEach((id) => {
-        const item = itemStore.items[id];
-        if (item) {
-          initialGroupStates.value[id] = {
-            top: item.top,
-            left: item.left,
-            width: item.width,
-            height: item.height,
-          };
-        }
-      });
-    }
-  }
-};
-
-const startResizeRight = (e: MouseEvent) => {
-  registerClick();
-  e.preventDefault();
-  handleReziging(e);
-  resizeDirection.value = "right";
-  captureGroupInitialStates();
-  resizeBounds.value = getStickyContainer();
-  startX.value = e.clientX;
-  startWidth.value = itemState.value.width;
-  document.addEventListener("mousemove", onResizeWidth);
-  document.addEventListener("mouseup", stopResize);
-};
-
-const onResizeWidth = (e: MouseEvent) => {
-  if (isResizing.value) {
-    const deltaX = e.clientX - startX.value;
-    const newWidth = startWidth.value + deltaX;
-    if (newWidth > 100 && newWidth < resizeBounds.value.width) {
-      itemState.value.width = newWidth;
-      savePositionAndSize();
-    }
-  }
-};
-
-const startResizeBottom = (e: MouseEvent) => {
-  registerClick();
-  e.preventDefault();
-  handleReziging(e);
-  resizeDirection.value = "bottom";
-  captureGroupInitialStates();
-  resizeBounds.value = getStickyContainer();
-  startY.value = e.clientY;
-  startHeight.value = itemState.value.height;
-  document.addEventListener("mousemove", onResizeHeight);
-  document.addEventListener("mouseup", stopResize);
-};
-
-const onResizeHeight = (e: MouseEvent) => {
-  if (isResizing.value) {
-    const deltaY = e.clientY - startY.value;
-    const newHeight = startHeight.value + deltaY;
-    if (newHeight > 100 && newHeight < resizeBounds.value.height) {
-      itemState.value.height = newHeight;
-      savePositionAndSize();
-    }
-  }
-};
-
-const startResizeTop = (e: MouseEvent) => {
-  registerClick();
-  e.preventDefault();
-  handleReziging(e);
-  resizeDirection.value = "top";
-  captureGroupInitialStates();
-  resizeBounds.value = getStickyContainer();
-  startY.value = e.clientY;
-  startTop.value = itemState.value.top;
-  startHeight.value = itemState.value.height;
-  document.addEventListener("mousemove", onResizeTop);
-  document.addEventListener("mouseup", stopResize);
-};
-
-const onResizeTop = (e: MouseEvent) => {
-  if (isResizing.value) {
-    const deltaY = e.clientY - startY.value;
-    const newTop = startTop.value + deltaY;
-    const newHeight = startHeight.value - deltaY;
-    if (newHeight > 100 && newHeight < resizeBounds.value.height && newTop >= 0) {
-      itemState.value.top = newTop;
-      itemState.value.height = newHeight;
-      savePositionAndSize();
-    }
-  }
-};
-
-const startResizeLeft = (e: MouseEvent) => {
-  registerClick();
-  e.preventDefault();
-  handleReziging(e);
-  resizeDirection.value = "left";
-  captureGroupInitialStates();
-  resizeBounds.value = getStickyContainer();
-  startX.value = e.clientX;
-  startLeft.value = itemState.value.left;
-  startWidth.value = itemState.value.width;
-  document.addEventListener("mousemove", onResizeLeft);
-  document.addEventListener("mouseup", stopResize);
-};
-
-const onResizeLeft = (e: MouseEvent) => {
-  if (isResizing.value) {
-    const deltaX = e.clientX - startX.value;
-    const newLeft = startLeft.value + deltaX;
-    const newWidth = startWidth.value - deltaX;
-    if (newWidth > 100 && newWidth < resizeBounds.value.width) {
-      itemState.value.left = newLeft;
-      itemState.value.width = newWidth;
-      savePositionAndSize();
-    }
-  }
-};
-
-const stopResize = () => {
-  if (isResizing.value) {
-    isResizing.value = false;
-    resizeDirection.value = null;
-    initialGroupStates.value = {};
-    if (activeLine.value) {
-      activeLine.value.classList.remove("resizing-highlight-line");
-    }
-    itemStore.inResizing = false;
-    document.removeEventListener("mousemove", onResizeWidth);
-    document.removeEventListener("mousemove", onResizeHeight);
-    document.removeEventListener("mousemove", onResizeTop);
-    document.removeEventListener("mousemove", onResizeLeft);
-    itemStore.flushItemState(props.id);
-  }
-};
-
-// Pixel threshold a mousedown must travel before we treat the gesture as a
-// drag. Without this, a header dblclick (two mousedowns + tiny cursor
-// jitter) would fire onMove with deltas of 1–2 px, drift the panel, and
-// then snapshot the drifted position into prev{Top,Left} on
-// `setFullScreen(true)` — so dblclick → fullscreen → dblclick restored
-// the panel slightly lower each cycle. Matches the standard OS drag
-// threshold so deliberate drags still feel responsive.
-const DRAG_THRESHOLD_PX = 4;
-let dragActivated = false;
-
-const startMove = (e: MouseEvent) => {
-  registerClick();
-  if (!props.allowFreeMove) return;
-  e.preventDefault();
-  if (
-    (e.target as HTMLElement).classList.contains("icon") ||
-    (e.target as HTMLElement).classList.contains("minimal-button")
-  )
-    return;
-
-  isDragging.value = true;
-  dragActivated = false;
-  startX.value = e.clientX;
-  startY.value = e.clientY;
-  startLeft.value = itemState.value.left;
-  startTop.value = itemState.value.top;
-  document.addEventListener("mousemove", onMove);
-  document.addEventListener("mouseup", stopMove);
-  // stickynessPosition is flipped to "free" only once the threshold trips
-  // (inside onMove) — a dblclick gesture must not silently un-stick a
-  // sticky-positioned panel.
-};
-
-const onMove = (e: MouseEvent) => {
-  if (!isDragging.value) return;
-  const deltaX = e.clientX - startX.value;
-  const deltaY = e.clientY - startY.value;
-  if (!dragActivated) {
-    if (Math.abs(deltaX) < DRAG_THRESHOLD_PX && Math.abs(deltaY) < DRAG_THRESHOLD_PX) return;
-    dragActivated = true;
-    itemState.value.stickynessPosition = "free";
-  }
-  itemState.value.left = startLeft.value + deltaX;
-  itemState.value.top = startTop.value + deltaY;
-};
-
-const stopMove = () => {
-  if (isDragging.value) {
-    isDragging.value = false;
-    document.removeEventListener("mousemove", onMove);
-    document.removeEventListener("mouseup", stopMove);
-
-    // No-op if the gesture stayed under the drag threshold — nothing
-    // changed, so there's nothing to persist (and persisting a drifted
-    // mid-dblclick position is exactly the bug this guards against).
-    if (dragActivated) {
-      savePositionAndSize();
-      // Make the final position durable immediately — debounced writes would
-      // be lost if the user closes the tab within 250 ms of releasing the drag.
-      itemStore.flushItemState(props.id);
-    }
-    dragActivated = false;
-  }
-};
-
-// Returns the element panels are actually positioned against (the overlay's
-// offsetParent — the canvas <main>). Sticky/move math is relative to this
-// element's INSIDE, so `(left=0, top=0)` is its top-left corner. Returns a
-// degenerate {0,0} when the overlay is unmounted or its offsetParent is null
-// (detached / display:none / mid-route-transition) so callers bail instead of
-// measuring an unreliable container — never fall back to instance.parent, which
-// self-references the overlay itself once nested in a TabbedDrawer wrapper.
-const getStickyContainer = (): { width: number; height: number } => {
-  const overlayEl = document.getElementById(props.id);
-  const offsetParent = overlayEl?.offsetParent as HTMLElement | null;
-  if (offsetParent) {
-    return { width: offsetParent.clientWidth, height: offsetParent.clientHeight };
-  }
-  return { width: 0, height: 0 };
-};
-
-// Below this the container is treated as unreliable (mid-transition / unlaid-out)
-// and geometry recompute+persist is skipped — the panel keeps its last-good size.
-// A real canvas is always far larger; `.overlay { max-width/height:100% }` caps
-// the panel visually if a saved size ever exceeds the container.
-const MIN_CONTAINER_W = 200;
-const MIN_CONTAINER_H = 150;
-const isContainerUsable = (c: { width: number; height: number }): boolean =>
-  c.width >= MIN_CONTAINER_W && c.height >= MIN_CONTAINER_H;
-
-const moveToRight = () => {
-  const c = getStickyContainer();
-  itemState.value.left = c.width - itemState.value.width;
-  itemState.value.top = 0;
-  itemState.value.stickynessPosition = "right";
-  if (resolvedHeightBehaviour.value === "fill") {
-    itemState.value.height = c.height;
-  }
-  savePositionAndSize();
-};
-
-const moveToBottom = () => {
-  const c = getStickyContainer();
-  itemState.value.left = props.initialLeft || 0;
-  itemState.value.top = c.height - (itemState.value.height + (props.initialTop || 0));
-  itemState.value.stickynessPosition = "bottom";
-  if (resolvedWidthBehaviour.value === "fill") {
-    itemState.value.width = c.width - (props.initialLeft || 0);
-  }
-  savePositionAndSize();
-};
-
-const moveToLeft = () => {
-  const c = getStickyContainer();
-  itemState.value.left = 0;
-  itemState.value.top = 0;
-  itemState.value.stickynessPosition = "left";
-  if (resolvedHeightBehaviour.value === "fill") {
-    itemState.value.height = c.height;
-  }
-  savePositionAndSize();
-};
-
-const moveToTop = () => {
-  const c = getStickyContainer();
-  itemState.value.left = 0;
-  itemState.value.top = 0;
-  itemState.value.stickynessPosition = "top";
-  if (resolvedWidthBehaviour.value === "fill") {
-    itemState.value.width = c.width;
-  }
-  savePositionAndSize();
-};
-
-const applyStickyPosition = () => {
-  const c = getStickyContainer();
-  // Bail before any mutation if the container measurement is unreliable (unlaid-out
-  // / mid-route-transition / detached) — recomputing against it collapses the panel
-  // and, worse, persists the collapse to localStorage.
-  if (!isContainerUsable(c)) return;
-
-  // Resizing while fullscreen should keep the panel filling the canvas, not run
-  // the shrink/reposition math below.
-  if (itemState.value.fullScreen) {
-    itemState.value.width = c.width;
-    itemState.value.height = c.height;
-    itemState.value.left = 0;
-    itemState.value.top = 0;
-    prevContainerWidth.value = c.width;
-    prevContainerHeight.value = c.height;
-    savePositionAndSize();
-    return;
-  }
-
-  const wB = resolvedWidthBehaviour.value;
-  const hB = resolvedHeightBehaviour.value;
-
-  // "scale": absorb the container delta to keep a constant gap to the edge.
-  // Runs before effHeight/shrink-clamp so the position math sees the new size.
-  if (wB === "scale" && prevContainerWidth.value > 0) {
-    itemState.value.width = Math.max(
-      100,
-      itemState.value.width + (c.width - prevContainerWidth.value),
-    );
-  }
-  if (hB === "scale" && prevContainerHeight.value > 0) {
-    itemState.value.height = Math.max(
-      100,
-      itemState.value.height + (c.height - prevContainerHeight.value),
-    );
-  }
-
-  // A minimized panel renders as a ~35px header (CSS overrides its size), so its
-  // stored height is the pre-collapse value — use the rendered height for the
-  // vertical position math instead.
-  const effHeight = isMinimized.value ? 35 : itemState.value.height;
-
-  // Shrink an expanded panel to fit a smaller canvas before positioning it.
-  if (!isMinimized.value) {
-    itemState.value.width = Math.min(itemState.value.width, c.width);
-    itemState.value.height = Math.min(itemState.value.height, c.height);
-  }
-
-  switch (itemState.value.stickynessPosition) {
-    case "top":
-      itemState.value.left = props.initialLeft || 0;
-      itemState.value.top = 0;
-      if (wB === "fill") {
-        itemState.value.width = c.width - (props.initialLeft || 0);
-      }
-      break;
-
-    case "bottom":
-      itemState.value.left = props.initialLeft || 0;
-      itemState.value.top = Math.max(0, c.height - effHeight - (props.initialTop || 0));
-      if (wB === "fill") {
-        itemState.value.width = c.width - (props.initialLeft || 0);
-      }
-      break;
-
-    case "left":
-      itemState.value.left = 0;
-      if (hB === "scale") {
-        // Preserve the user's vertical offset — the scale step already kept the
-        // height gap; only keep it on-screen (mirrors the "free" branch).
-        itemState.value.top = Math.max(
-          0,
-          Math.min(itemState.value.top, Math.max(0, c.height - effHeight)),
-        );
-      } else {
-        itemState.value.top = props.initialTop || 0;
-        if (hB === "fill") {
-          itemState.value.height = c.height - (props.initialTop || 0);
-        }
-      }
-      break;
-
-    case "right":
-      itemState.value.left = Math.max(0, c.width - itemState.value.width);
-      if (hB === "scale") {
-        itemState.value.top = Math.max(
-          0,
-          Math.min(itemState.value.top, Math.max(0, c.height - effHeight)),
-        );
-      } else {
-        itemState.value.top = props.initialTop || 0;
-        if (hB === "fill") {
-          itemState.value.height = c.height - (props.initialTop || 0);
-        }
-      }
-      break;
-
-    case "free":
-    default: {
-      if (prevContainerWidth.value > 0 && prevContainerHeight.value > 0) {
-        // Use the panel's CENTER, not its top-left corner, to decide alignment.
-        // A wide panel docked right (left ≈ half the canvas) would otherwise fail
-        // the `left > width/2` test and stop following the right edge as the
-        // canvas grows — leaving it stranded "in the middle".
-        const wasRightAligned =
-          itemState.value.left + itemState.value.width / 2 > prevContainerWidth.value / 2;
-        const wasBottomAligned =
-          itemState.value.top + effHeight / 2 > prevContainerHeight.value / 2;
-
-        // Don't re-anchor a "scale" axis — the scale step already tracked it.
-        if (wasRightAligned && wB !== "scale") {
-          const distanceFromRight =
-            prevContainerWidth.value - itemState.value.left - itemState.value.width;
-          itemState.value.left = Math.max(0, c.width - itemState.value.width - distanceFromRight);
-        }
-
-        if (wasBottomAligned && hB !== "scale") {
-          const distanceFromBottom = prevContainerHeight.value - itemState.value.top - effHeight;
-          itemState.value.top = Math.max(0, c.height - effHeight - distanceFromBottom);
-        }
-      }
-
-      // Keep the panel inside the canvas: fully when expanded; header-visible
-      // when minimized (its rendered width is content-driven, so fall back to a
-      // minimum-visible margin rather than the stale stored width).
-      const minVisible = 100;
-      const maxLeft = Math.max(
-        0,
-        c.width - (isMinimized.value ? minVisible : itemState.value.width),
-      );
-      const maxTop = Math.max(0, c.height - effHeight);
-      itemState.value.left = Math.max(0, Math.min(itemState.value.left, maxLeft));
-      itemState.value.top = Math.max(0, Math.min(itemState.value.top, maxTop));
-      break;
-    }
-  }
-
-  prevContainerWidth.value = c.width;
-  prevContainerHeight.value = c.height;
-
-  savePositionAndSize();
-};
-
-// Fill-axis default sizes read from the canvas container (the overlay's
-// offsetParent), NOT instance.parent — the latter points at this overlay once
-// the panel is nested in a wrapper (TabbedDrawer), which self-references to a
-// tiny size and breaks the reset-layout defaults.
-const calculateWidth = () => {
-  if (props.initialWidth) {
-    return props.initialWidth;
-  } else if (props.initialPosition === "top" || props.initialPosition === "bottom") {
-    return Math.max(300, getStickyContainer().width - (props.initialLeft || 0));
-  } else return 300;
-};
-
-const calculateHeight = () => {
-  if (props.initialHeight) {
-    return props.initialHeight;
-  } else if (props.initialPosition === "left" || props.initialPosition === "right") {
-    return Math.max(300, getStickyContainer().height - (props.initialTop || 0));
-  } else return 300;
-};
-
-const handleResize = () => {
-  clearTimeout(resizeTimeout);
-  resizeTimeout = setTimeout(applyStickyPosition, 1);
-};
-
-const parentResizeObserver = new ResizeObserver(() => {
-  handleResize();
-});
-
-const observeParentResize = () => {
-  // Observe the exact element bounds are read from (the overlay's offsetParent,
-  // i.e. the canvas <main>). Never fall back to instance.parent — for a
-  // TabbedDrawer-nested overlay that IS this overlay, so it would feed the
-  // overlay's own size back into applyStickyPosition. If offsetParent isn't
-  // resolved yet, skip; the post-layout nextTick / window-resize drives the
-  // first reflow.
-  const overlayEl = document.getElementById(props.id);
-  const parentElement = overlayEl?.offsetParent as HTMLElement | null;
-  if (parentElement) {
-    parentResizeObserver.observe(parentElement);
-  }
-};
-
-const handleWindowResize = () => {
-  handleResize();
-};
-
-const registerClick = () => {
-  itemStore.clickOnItem(props.id);
-};
-
-const setFullScreen = (makeFull: boolean) => {
-  itemStore.setFullScreen(props.id, makeFull);
-  loadPositionAndSize();
-  syncScaleBaseline();
-};
-
-watch(
-  () => itemStore.items[props.id],
-  (newState) => {
-    if (newState) {
-      if (isDragging.value || isResizing.value) {
-        itemState.value.zIndex = newState.zIndex;
-      } else {
-        itemState.value = { ...newState };
-      }
-    }
-  },
-  { deep: true },
-);
-
-watch(
-  () => ({ group: props.group, syncDimensions: props.syncDimensions }),
-  ({ group, syncDimensions }) => {
-    itemStore.setItemState(props.id, {
-      group,
-      syncDimensions,
-    });
-    itemState.value.group = group;
-    itemState.value.syncDimensions = syncDimensions;
-  },
-);
-
-nextTick().then(() => {
-  observeParentResize();
-});
-
-// Instance-scoped reset handler. Replaces a previous global registry on
-// `(window as any)[resetHandler_${id}]` that leaked references when the
-// component unmounted without running its cleanup.
-let layoutResetHandler: (() => void) | null = null;
-
-const clampStateToViewport = (state: ItemLayout) => {
-  const c = getStickyContainer();
-  // Bail before first layout / during a route transition — clamping against an
-  // unreliable container would collapse the panel toward the 150/100 floors and
-  // persist it; the post-mount applyStickyPosition (nextTick) re-clamps once laid out.
-  if (!isContainerUsable(c)) return;
-  const minVisible = 100;
-  state.width = Math.max(150, Math.min(state.width, c.width));
-  state.height = Math.max(100, Math.min(state.height, Math.max(150, c.height)));
-  state.left = Math.max(0, Math.min(state.left, Math.max(0, c.width - minVisible)));
-  state.top = Math.max(0, Math.min(state.top, Math.max(0, c.height - minVisible)));
-};
-
-onMounted(() => {
-  // Capture the canvas container size now (not at module-eval time) so the
-  // proportional repositioning math in applyStickyPosition stays accurate.
-  const initialBounds = getStickyContainer();
-  prevContainerWidth.value = initialBounds.width;
-  prevContainerHeight.value = initialBounds.height;
-
-  const initialWidth = calculateWidth();
-  const initialHeight = calculateHeight();
-  const initialLeft = props.initialLeft || 100;
-  const initialTop = props.initialTop || 100;
-
-  // IMPORTANT: Register the true initial state FIRST
-  itemStore.registerInitialState(props.id, {
-    width: initialWidth,
-    height: initialHeight,
-    left: initialLeft,
-    top: initialTop,
-    stickynessPosition: props.initialPosition,
-    fullWidth: !props.initialWidth,
-    fullHeight: !props.initialHeight,
-    group: props.group,
-    syncDimensions: props.syncDimensions,
-  });
-
-  const hasSavedState = itemStore.hasSavedState(props.id);
-
-  if (!hasSavedState) {
-    itemStore.setItemState(props.id, {
-      width: initialWidth,
-      height: initialHeight,
-      left: initialLeft,
-      top: initialTop,
-      fullHeight: !props.initialHeight,
-      fullWidth: !props.initialWidth,
-      stickynessPosition: props.initialPosition,
-      group: props.group,
-      syncDimensions: props.syncDimensions,
-    });
-    itemState.value = itemStore.items[props.id];
-
-    if (props.initialPosition !== "free") {
-      nextTick(() => {
-        applyStickyPosition();
-      });
-    }
-  } else {
-    loadPositionAndSize();
-    // Saved width/height/left/top from a different viewport size can place
-    // the panel partially or fully off-screen. Clamp before first paint.
-    clampStateToViewport(itemState.value);
-    itemStore.setItemState(props.id, { ...itemState.value });
-
-    if (itemState.value.stickynessPosition && itemState.value.stickynessPosition !== "free") {
-      nextTick(() => {
-        applyStickyPosition();
-      });
-    }
-  }
-
-  layoutResetHandler = () => {
-    itemState.value = { ...itemStore.items[props.id] };
-
-    // Ensure stickynessPosition is restored from initial state (props.initialPosition)
-    // This guarantees sticky items like logViewer snap back to their original position
-    const initialStickyPosition =
-      itemStore.initialItemStates[props.id]?.stickynessPosition || props.initialPosition;
-    if (initialStickyPosition && initialStickyPosition !== "free") {
-      itemState.value.stickynessPosition = initialStickyPosition;
-      nextTick(() => {
-        applyStickyPosition();
-      });
-    }
-  };
-
-  window.addEventListener("layout-reset", layoutResetHandler);
-  window.addEventListener("resize", handleWindowResize);
-  document.addEventListener("mouseup", stopResize);
+onBeforeUnmount(() => {
+  teardownResize();
+  teardownMove();
 });
 
 defineExpose({
   setFullScreen,
 });
-
-onBeforeUnmount(() => {
-  if (layoutResetHandler) {
-    window.removeEventListener("layout-reset", layoutResetHandler);
-    layoutResetHandler = null;
-  }
-  // Cancel pending debounced reflows — a leaked applyStickyPosition firing ~1ms
-  // after unmount would measure a detached container and persist a collapse.
-  clearTimeout(resizeTimeout);
-  if (resizeDelay.value) clearTimeout(resizeDelay.value);
-  window.removeEventListener("resize", handleWindowResize);
-  parentResizeObserver.disconnect();
-  document.removeEventListener("mouseup", stopResize);
-  document.removeEventListener("mousemove", onMove);
-  document.removeEventListener("mouseup", stopMove);
-  document.removeEventListener("mousemove", onResizeWidth);
-  document.removeEventListener("mousemove", onResizeHeight);
-  document.removeEventListener("mousemove", onResizeTop);
-  document.removeEventListener("mousemove", onResizeLeft);
-});
 </script>
 
 <style scoped>
-/* (Styles are unchanged) */
 .minimal-button {
   background: none;
   border: none;
@@ -1117,17 +483,6 @@ onBeforeUnmount(() => {
   color: var(--color-text-primary);
   background-color: var(--color-background-hover);
 }
-.group-badge {
-  background-color: var(--color-accent);
-  color: var(--color-text-inverse);
-  padding: 2px 6px;
-  border-radius: 3px;
-  font-size: 11px;
-  margin-right: 4px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-  user-select: none;
-}
 
 /* VS Code-style tab strip in the header. `align-self: stretch` + negative
    vertical margin makes the tabs fill the 35px header so the active underline
@@ -1168,12 +523,6 @@ button.dragitem-tab:hover {
   cursor: move;
   user-select: none;
   font-size: 10px;
-}
-.title-text {
-  flex-grow: 1;
-  padding: 0 8px;
-  font-size: 14px;
-  color: var(--color-text-primary);
 }
 .overlay.minimized {
   width: auto !important;

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/DraggableItem.vue
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/DraggableItem.vue
@@ -141,7 +141,6 @@ import {
   onBeforeUnmount,
   defineExpose,
   defineProps,
-  getCurrentInstance,
   nextTick,
   watch,
 } from "vue";
@@ -275,7 +274,6 @@ const startHeight = ref(0);
 const startLeft = ref(0);
 const startTop = ref(0);
 const isMinimized = ref(false);
-const instance = getCurrentInstance();
 const activeLine = ref<HTMLElement | null>(null);
 let resizeTimeout: ReturnType<typeof setTimeout>;
 
@@ -633,17 +631,28 @@ const stopMove = () => {
 
 // Returns the element panels are actually positioned against (the overlay's
 // offsetParent — the canvas <main>). Sticky/move math is relative to this
-// element's INSIDE, so `(left=0, top=0)` is its top-left corner. Falls back
-// to the Vue parent root only if the overlay isn't mounted yet.
+// element's INSIDE, so `(left=0, top=0)` is its top-left corner. Returns a
+// degenerate {0,0} when the overlay is unmounted or its offsetParent is null
+// (detached / display:none / mid-route-transition) so callers bail instead of
+// measuring an unreliable container — never fall back to instance.parent, which
+// self-references the overlay itself once nested in a TabbedDrawer wrapper.
 const getStickyContainer = (): { width: number; height: number } => {
   const overlayEl = document.getElementById(props.id);
   const offsetParent = overlayEl?.offsetParent as HTMLElement | null;
-  const ref = offsetParent ?? (instance?.parent?.vnode.el as HTMLElement | null);
-  if (ref) {
-    return { width: ref.clientWidth, height: ref.clientHeight };
+  if (offsetParent) {
+    return { width: offsetParent.clientWidth, height: offsetParent.clientHeight };
   }
-  return { width: window.innerWidth, height: window.innerHeight };
+  return { width: 0, height: 0 };
 };
+
+// Below this the container is treated as unreliable (mid-transition / unlaid-out)
+// and geometry recompute+persist is skipped — the panel keeps its last-good size.
+// A real canvas is always far larger; `.overlay { max-width/height:100% }` caps
+// the panel visually if a saved size ever exceeds the container.
+const MIN_CONTAINER_W = 200;
+const MIN_CONTAINER_H = 150;
+const isContainerUsable = (c: { width: number; height: number }): boolean =>
+  c.width >= MIN_CONTAINER_W && c.height >= MIN_CONTAINER_H;
 
 const moveToRight = () => {
   const c = getStickyContainer();
@@ -691,9 +700,10 @@ const moveToTop = () => {
 
 const applyStickyPosition = () => {
   const c = getStickyContainer();
-  // Bail before any mutation if the container isn't laid out yet — clamping
-  // against a 0-sized box would collapse the panel.
-  if (c.width <= 0 || c.height <= 0) return;
+  // Bail before any mutation if the container measurement is unreliable (unlaid-out
+  // / mid-route-transition / detached) — recomputing against it collapses the panel
+  // and, worse, persists the collapse to localStorage.
+  if (!isContainerUsable(c)) return;
 
   // Resizing while fullscreen should keep the panel filling the canvas, not run
   // the shrink/reposition math below.
@@ -863,11 +873,13 @@ const parentResizeObserver = new ResizeObserver(() => {
 
 const observeParentResize = () => {
   // Observe the exact element bounds are read from (the overlay's offsetParent,
-  // i.e. the canvas <main>), falling back to the Vue parent root.
+  // i.e. the canvas <main>). Never fall back to instance.parent — for a
+  // TabbedDrawer-nested overlay that IS this overlay, so it would feed the
+  // overlay's own size back into applyStickyPosition. If offsetParent isn't
+  // resolved yet, skip; the post-layout nextTick / window-resize drives the
+  // first reflow.
   const overlayEl = document.getElementById(props.id);
-  const parentElement =
-    (overlayEl?.offsetParent as HTMLElement | null) ??
-    (instance?.parent?.vnode.el as HTMLElement | null);
+  const parentElement = overlayEl?.offsetParent as HTMLElement | null;
   if (parentElement) {
     parentResizeObserver.observe(parentElement);
   }
@@ -924,9 +936,10 @@ let layoutResetHandler: (() => void) | null = null;
 
 const clampStateToViewport = (state: ItemLayout) => {
   const c = getStickyContainer();
-  // Bail before first layout — clamping against a 0-sized box would collapse the
-  // panel; the post-mount applyStickyPosition (nextTick) re-clamps once laid out.
-  if (c.width <= 0 || c.height <= 0) return;
+  // Bail before first layout / during a route transition — clamping against an
+  // unreliable container would collapse the panel toward the 150/100 floors and
+  // persist it; the post-mount applyStickyPosition (nextTick) re-clamps once laid out.
+  if (!isContainerUsable(c)) return;
   const minVisible = 100;
   state.width = Math.max(150, Math.min(state.width, c.width));
   state.height = Math.max(100, Math.min(state.height, Math.max(150, c.height)));
@@ -1023,6 +1036,10 @@ onBeforeUnmount(() => {
     window.removeEventListener("layout-reset", layoutResetHandler);
     layoutResetHandler = null;
   }
+  // Cancel pending debounced reflows — a leaked applyStickyPosition firing ~1ms
+  // after unmount would measure a detached container and persist a collapse.
+  clearTimeout(resizeTimeout);
+  if (resizeDelay.value) clearTimeout(resizeDelay.value);
   window.removeEventListener("resize", handleWindowResize);
   parentResizeObserver.disconnect();
   document.removeEventListener("mouseup", stopResize);

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/layoutGeometry.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/layoutGeometry.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MINIMIZED_HEADER_PX,
+  MIN_PANEL_H,
+  clampRectToBounds,
+  computeLayout,
+  defaultIntent,
+  intentFromRect,
+  isContainerUsable,
+  snapSideForRect,
+  type Bounds,
+  type PanelConfig,
+  type PanelIntent,
+  type RenderRect,
+} from "./layoutGeometry";
+
+const container: Bounds = { width: 1200, height: 900 };
+
+// Shaped like the designer's panels (drawerRegistry + Canvas defaults); the
+// non-zero v offset exercises the offset math the real configs default to 0.
+const rightDrawerCfg: PanelConfig = {
+  defaultDock: "right",
+  h: { behaviour: "fixed", defaultSize: 600, defaultOffset: 0 },
+  v: { behaviour: "scale", defaultSize: 700, defaultOffset: 8 },
+};
+
+const bottomDockCfg: PanelConfig = {
+  defaultDock: "bottom",
+  h: { behaviour: "scale", defaultSize: null, defaultOffset: 180 },
+  v: { behaviour: "fixed", defaultSize: 225, defaultOffset: 0 },
+};
+
+const paletteCfg: PanelConfig = {
+  defaultDock: "left",
+  h: { behaviour: "fixed", defaultSize: 230, defaultOffset: 0 },
+  v: { behaviour: "scale", defaultSize: null, defaultOffset: 0 },
+};
+
+const freeCfg: PanelConfig = {
+  defaultDock: "free",
+  h: { behaviour: "fixed", defaultSize: 400, defaultOffset: 100 },
+  v: { behaviour: "fixed", defaultSize: 300, defaultOffset: 100 },
+};
+
+const intentWith = (cfg: PanelConfig, patch: Partial<PanelIntent>): PanelIntent => ({
+  ...defaultIntent(cfg),
+  ...patch,
+});
+
+describe("isContainerUsable", () => {
+  it("rejects zero, tiny, and non-finite bounds", () => {
+    expect(isContainerUsable({ width: 0, height: 0 })).toBe(false);
+    expect(isContainerUsable({ width: 199, height: 900 })).toBe(false);
+    expect(isContainerUsable({ width: 1200, height: 149 })).toBe(false);
+    expect(isContainerUsable({ width: NaN, height: 900 })).toBe(false);
+  });
+
+  it("accepts the floor and above", () => {
+    expect(isContainerUsable({ width: 200, height: 150 })).toBe(true);
+    expect(isContainerUsable(container)).toBe(true);
+  });
+});
+
+describe("computeLayout — docked", () => {
+  it("right dock defaults: flush right, default width/offset/height", () => {
+    const rect = computeLayout(defaultIntent(rightDrawerCfg), rightDrawerCfg, container, false);
+    expect(rect).toEqual({ left: 600, top: 8, width: 600, height: 700 });
+  });
+
+  it("right dock with a user gap derives height as a span", () => {
+    const intent = intentWith(rightDrawerCfg, {
+      v: { size: null, offset: 8, gap: 200 },
+    });
+    const rect = computeLayout(intent, rightDrawerCfg, container, false);
+    expect(rect).toEqual({ left: 600, top: 8, width: 600, height: 692 });
+  });
+
+  it("scale-gap invariance: a transient container shrink cannot corrupt recovery", () => {
+    const intent = intentWith(rightDrawerCfg, {
+      v: { size: null, offset: 8, gap: 200 },
+    });
+    const before = computeLayout(intent, rightDrawerCfg, container, false);
+    const shrunk = computeLayout(intent, rightDrawerCfg, { width: 1200, height: 300 }, false);
+    // Render floor engages during the shrink but the intent is untouched...
+    expect(shrunk?.height).toBe(MIN_PANEL_H);
+    // ...so restoring the container restores the exact original rect.
+    const after = computeLayout(intent, rightDrawerCfg, container, false);
+    expect(after).toEqual(before);
+  });
+
+  it("returns null for an unusable container (caller keeps last good rect)", () => {
+    const intent = defaultIntent(rightDrawerCfg);
+    expect(computeLayout(intent, rightDrawerCfg, { width: 0, height: 0 }, false)).toBeNull();
+    expect(computeLayout(intent, rightDrawerCfg, { width: 180, height: 900 }, false)).toBeNull();
+  });
+
+  it("bottom dock defaults: flush bottom, span width from the left offset", () => {
+    const rect = computeLayout(defaultIntent(bottomDockCfg), bottomDockCfg, container, false);
+    expect(rect).toEqual({ left: 180, top: 675, width: 1020, height: 225 });
+  });
+
+  it("bottom dock minimized positions by the header height", () => {
+    const rect = computeLayout(defaultIntent(bottomDockCfg), bottomDockCfg, container, true);
+    expect(rect?.top).toBe(900 - MINIMIZED_HEADER_PX);
+    expect(rect?.height).toBe(225);
+  });
+
+  it("left palette defaults to full height at the left edge", () => {
+    const rect = computeLayout(defaultIntent(paletteCfg), paletteCfg, container, false);
+    expect(rect).toEqual({ left: 0, top: 0, width: 230, height: 900 });
+  });
+
+  it("a fill axis stretches to the container and ignores a stored gap", () => {
+    const cfg: PanelConfig = {
+      defaultDock: "top",
+      h: { behaviour: "fill", defaultSize: null, defaultOffset: 20 },
+      v: { behaviour: "fixed", defaultSize: 200, defaultOffset: 0 },
+    };
+    const intent = intentWith(cfg, { h: { size: null, offset: null, gap: 300 } });
+    const rect = computeLayout(intent, cfg, container, false);
+    expect(rect).toEqual({ left: 20, top: 0, width: 1180, height: 200 });
+  });
+
+  it("clamps an oversized panel to the container", () => {
+    const intent = intentWith(rightDrawerCfg, {
+      h: { size: 5000, offset: null, gap: null },
+    });
+    const rect = computeLayout(intent, rightDrawerCfg, container, false);
+    expect(rect?.width).toBe(1200);
+    expect(rect?.left).toBe(0);
+  });
+});
+
+describe("computeLayout — fullscreen and free", () => {
+  it("fullscreen fills the container", () => {
+    const intent = intentWith(rightDrawerCfg, { fullScreen: true });
+    expect(computeLayout(intent, rightDrawerCfg, container, false)).toEqual({
+      left: 0,
+      top: 0,
+      width: 1200,
+      height: 900,
+    });
+  });
+
+  it("free near-anchored uses offsets", () => {
+    const intent = intentWith(freeCfg, {
+      dock: "free",
+      h: { size: 400, offset: 50, gap: null },
+      v: { size: 300, offset: 70, gap: null },
+    });
+    expect(computeLayout(intent, freeCfg, container, false)).toEqual({
+      left: 50,
+      top: 70,
+      width: 400,
+      height: 300,
+    });
+  });
+
+  it("free far-anchored keeps the gap to the far edge", () => {
+    const intent = intentWith(freeCfg, {
+      dock: "free",
+      h: { size: 400, offset: null, gap: 50 },
+      v: { size: 300, offset: null, gap: 60 },
+    });
+    expect(computeLayout(intent, freeCfg, container, false)).toEqual({
+      left: 750,
+      top: 540,
+      width: 400,
+      height: 300,
+    });
+  });
+
+  it("free far-anchored minimized positions by the header height", () => {
+    const intent = intentWith(freeCfg, {
+      dock: "free",
+      h: { size: 400, offset: null, gap: 0 },
+      v: { size: 300, offset: null, gap: 0 },
+    });
+    const rect = computeLayout(intent, freeCfg, container, true);
+    expect(rect?.top).toBe(900 - MINIMIZED_HEADER_PX);
+  });
+
+  it("free panels are clamped fully inside the container", () => {
+    const intent = intentWith(freeCfg, {
+      dock: "free",
+      h: { size: 400, offset: 5000, gap: null },
+      v: { size: 300, offset: 5000, gap: null },
+    });
+    expect(computeLayout(intent, freeCfg, container, false)).toEqual({
+      left: 800,
+      top: 600,
+      width: 400,
+      height: 300,
+    });
+  });
+});
+
+describe("intentFromRect", () => {
+  it("right dock records width as size and the vertical span as offset+gap", () => {
+    const rect: RenderRect = { left: 600, top: 8, width: 600, height: 692 };
+    const intent = intentFromRect(rect, "right", rightDrawerCfg, container);
+    expect(intent).toEqual({
+      dock: "right",
+      h: { size: 600, offset: null, gap: null },
+      v: { size: null, offset: 8, gap: 200 },
+      fullScreen: false,
+    });
+  });
+
+  it("bottom dock records height as size and the horizontal span", () => {
+    const rect: RenderRect = { left: 180, top: 675, width: 1020, height: 225 };
+    const intent = intentFromRect(rect, "bottom", bottomDockCfg, container);
+    expect(intent).toEqual({
+      dock: "bottom",
+      h: { size: null, offset: 180, gap: 0 },
+      v: { size: 225, offset: null, gap: null },
+      fullScreen: false,
+    });
+  });
+
+  it("free anchors each axis by the panel-center half", () => {
+    const nearRect: RenderRect = { left: 100, top: 100, width: 300, height: 200 };
+    expect(intentFromRect(nearRect, "free", freeCfg, container)).toEqual({
+      dock: "free",
+      h: { size: 300, offset: 100, gap: null },
+      v: { size: 200, offset: 100, gap: null },
+      fullScreen: false,
+    });
+    const farRect: RenderRect = { left: 800, top: 650, width: 300, height: 200 };
+    expect(intentFromRect(farRect, "free", freeCfg, container)).toEqual({
+      dock: "free",
+      h: { size: 300, offset: null, gap: 100 },
+      v: { size: 200, offset: null, gap: 50 },
+      fullScreen: false,
+    });
+  });
+
+  it("round-trips through computeLayout for in-bounds rects", () => {
+    const cases: Array<{ rect: RenderRect; dock: PanelIntent["dock"]; cfg: PanelConfig }> = [
+      { rect: { left: 640, top: 8, width: 560, height: 700 }, dock: "right", cfg: rightDrawerCfg },
+      {
+        rect: { left: 200, top: 660, width: 1000, height: 240 },
+        dock: "bottom",
+        cfg: bottomDockCfg,
+      },
+      { rect: { left: 0, top: 40, width: 260, height: 860 }, dock: "left", cfg: paletteCfg },
+      { rect: { left: 750, top: 540, width: 400, height: 300 }, dock: "free", cfg: freeCfg },
+      { rect: { left: 50, top: 70, width: 400, height: 300 }, dock: "free", cfg: freeCfg },
+    ];
+    for (const { rect, dock, cfg } of cases) {
+      const intent = intentFromRect(rect, dock, cfg, container);
+      expect(computeLayout(intent, cfg, container, false)).toEqual(rect);
+    }
+  });
+});
+
+describe("clampRectToBounds", () => {
+  it("pulls an off-canvas rect fully inside (so commits never store negatives)", () => {
+    expect(clampRectToBounds({ left: -80, top: -20, width: 400, height: 300 }, container)).toEqual({
+      left: 0,
+      top: 0,
+      width: 400,
+      height: 300,
+    });
+    expect(clampRectToBounds({ left: 1100, top: 850, width: 400, height: 300 }, container)).toEqual(
+      { left: 800, top: 600, width: 400, height: 300 },
+    );
+  });
+
+  it("shrinks a rect larger than the container", () => {
+    expect(clampRectToBounds({ left: 0, top: 0, width: 2000, height: 1200 }, container)).toEqual({
+      left: 0,
+      top: 0,
+      width: 1200,
+      height: 900,
+    });
+  });
+
+  it("leaves an in-bounds rect untouched", () => {
+    const rect: RenderRect = { left: 50, top: 60, width: 300, height: 200 };
+    expect(clampRectToBounds(rect, container)).toEqual(rect);
+  });
+
+  it("clamps a minimized rect by its on-screen header height", () => {
+    // Full height 500 would force top <= 400; the visible 35px strip fits
+    // down to 900 - 35 = 865.
+    const rect: RenderRect = { left: 50, top: 700, width: 300, height: 500 };
+    expect(clampRectToBounds(rect, container, true).top).toBe(700);
+    expect(clampRectToBounds({ ...rect, top: 880 }, container, true).top).toBe(865);
+    expect(clampRectToBounds(rect, container, false).top).toBe(400);
+  });
+});
+
+describe("minimized free-panel round-trip (drag-release must not teleport)", () => {
+  it("a minimized panel released in the lower half re-renders at the same top", () => {
+    // Stored height 500, minimized (35px on screen), released at top=500.
+    const released: RenderRect = { left: 300, top: 500, width: 300, height: 500 };
+    const settled = clampRectToBounds(released, container, true);
+    const intent = intentFromRect(settled, "free", freeCfg, container, true);
+    const rendered = computeLayout(intent, freeCfg, container, true);
+    expect(rendered?.top).toBe(500);
+    expect(rendered?.left).toBe(300);
+    // The stored expanded height survives the round-trip untouched.
+    expect(intent.v.size).toBe(500);
+  });
+});
+
+describe("snapSideForRect", () => {
+  const allowed: Array<"top" | "bottom" | "left" | "right"> = ["right", "bottom", "left", "top"];
+
+  it("snaps to a side within the zone and not outside it", () => {
+    const nearRight: RenderRect = { left: 770, top: 300, width: 400, height: 200 };
+    expect(snapSideForRect(nearRight, container, allowed)).toBe("right");
+    const farFromAll: RenderRect = { left: 400, top: 300, width: 300, height: 200 };
+    expect(snapSideForRect(farFromAll, container, allowed)).toBeNull();
+  });
+
+  it("the nearest edge wins at a corner", () => {
+    // 20px from the bottom, 35px from the right.
+    const corner: RenderRect = { left: 765, top: 680, width: 400, height: 200 };
+    expect(snapSideForRect(corner, container, allowed)).toBe("bottom");
+  });
+
+  it("only allowed sides are considered", () => {
+    const nearLeft: RenderRect = { left: 10, top: 300, width: 300, height: 200 };
+    expect(snapSideForRect(nearLeft, container, ["right"])).toBeNull();
+    expect(snapSideForRect(nearLeft, container, ["left"])).toBe("left");
+  });
+
+  it("ties resolve in allowed order", () => {
+    // 30px from both the right and the bottom edge.
+    const tie: RenderRect = { left: 770, top: 670, width: 400, height: 200 };
+    expect(snapSideForRect(tie, container, ["right", "bottom"])).toBe("right");
+    expect(snapSideForRect(tie, container, ["bottom", "right"])).toBe("bottom");
+  });
+});

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/layoutGeometry.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/layoutGeometry.ts
@@ -1,0 +1,330 @@
+// Pure geometry for the canvas overlay panels. No Vue, no DOM.
+//
+// The core contract of the overlay system: localStorage holds USER INTENT
+// (chosen dock side, sizes, offsets — written only on explicit gestures) and
+// the on-screen rect is DERIVED here from intent × container every time. A
+// mis-measured container can therefore produce at worst one bad frame, never
+// a bad save: recovery is automatic once the container reports sane bounds.
+
+export type AxisBehaviour = "scale" | "fixed" | "fill";
+export type DockSide = "top" | "bottom" | "left" | "right";
+export type PanelDock = DockSide | "free";
+
+export interface Bounds {
+  width: number;
+  height: number;
+}
+
+export interface RenderRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+// Per-axis user intent. Exactly which fields apply depends on the dock mode
+// and the axis behaviour:
+//  - "fixed" axis: `size` in px.
+//  - "scale" axis (docked): the panel spans [offset, containerExtent - gap];
+//    `size` is derived, so a stale container can never corrupt it.
+//  - "fill" axis: spans [offset, containerExtent]; user gap is ignored.
+//  - free mode: `size` in px, positioned by `offset` (near-edge anchored) OR
+//    `gap` (far-edge anchored) — never both.
+// null = "the user never chose" → fall back to the panel's config default.
+export interface AxisIntent {
+  size: number | null;
+  offset: number | null;
+  gap: number | null;
+}
+
+export interface PanelIntent {
+  dock: PanelDock;
+  h: AxisIntent;
+  v: AxisIntent;
+  fullScreen: boolean;
+}
+
+export interface AxisConfig {
+  behaviour: AxisBehaviour;
+  defaultSize: number | null;
+  defaultOffset: number;
+}
+
+export interface PanelConfig {
+  defaultDock: PanelDock;
+  h: AxisConfig;
+  v: AxisConfig;
+}
+
+// Interactive resize floors. A persisted extent at or below these is provably
+// not user-produced (gesture handlers clamp above them), which is what lets
+// the v3 migration treat such records as corruption.
+export const MIN_PANEL_W = 150;
+export const MIN_PANEL_H = 100;
+
+// Rendered height of a minimized panel (header only, CSS-driven).
+export const MINIMIZED_HEADER_PX = 35;
+
+// A docked panel's header must travel this far before it pops out to free
+// mode — deliberate undocking, not cursor jitter (the old 4px threshold let a
+// sloppy dblclick permanently undock a drawer).
+export const POP_OUT_THRESHOLD_PX = 48;
+
+// Releasing a dragged panel with an edge inside this zone re-docks it to that
+// side (magnetic snap-back).
+export const SNAP_ZONE_PX = 40;
+
+// Below this the container is treated as unreliable (mid-layout, mid-route
+// transition, pre-window-restore) and no geometry is derived — the caller
+// keeps its last good rect. A real canvas is always far larger.
+export const MIN_CONTAINER_W = 200;
+export const MIN_CONTAINER_H = 150;
+
+export const isContainerUsable = (c: Bounds): boolean =>
+  Number.isFinite(c.width) &&
+  Number.isFinite(c.height) &&
+  c.width >= MIN_CONTAINER_W &&
+  c.height >= MIN_CONTAINER_H;
+
+export const defaultIntent = (cfg: PanelConfig): PanelIntent => ({
+  dock: cfg.defaultDock,
+  h: { size: null, offset: null, gap: null },
+  v: { size: null, offset: null, gap: null },
+  fullScreen: false,
+});
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(value, max));
+
+// Span axes (scale/fill): position from the near edge, size to the far edge.
+const spanAxis = (
+  intent: AxisIntent,
+  cfg: AxisConfig,
+  extent: number,
+): { offset: number; size: number } => {
+  const offset = clamp(intent.offset ?? cfg.defaultOffset, 0, extent);
+  let size: number;
+  if (cfg.behaviour === "fill") {
+    size = extent - offset;
+  } else if (intent.gap !== null) {
+    size = extent - offset - intent.gap;
+  } else if (cfg.defaultSize !== null) {
+    size = cfg.defaultSize;
+  } else {
+    size = extent - offset;
+  }
+  return { offset, size };
+};
+
+const fixedAxisSize = (intent: AxisIntent, cfg: AxisConfig, fallback: number): number =>
+  intent.size ?? cfg.defaultSize ?? fallback;
+
+export function computeLayout(
+  intent: PanelIntent,
+  cfg: PanelConfig,
+  container: Bounds,
+  minimized: boolean,
+): RenderRect | null {
+  if (!isContainerUsable(container)) return null;
+
+  if (intent.fullScreen) {
+    return { left: 0, top: 0, width: container.width, height: container.height };
+  }
+
+  let left: number;
+  let top: number;
+  let width: number;
+  let height: number;
+
+  const verticalDockedAxis = (): { top: number; height: number } => {
+    if (cfg.v.behaviour === "fixed") {
+      return {
+        top: clamp(intent.v.offset ?? cfg.v.defaultOffset, 0, container.height),
+        height: fixedAxisSize(intent.v, cfg.v, 300),
+      };
+    }
+    const { offset, size } = spanAxis(intent.v, cfg.v, container.height);
+    return { top: offset, height: size };
+  };
+
+  const horizontalDockedAxis = (): { left: number; width: number } => {
+    if (cfg.h.behaviour === "fixed") {
+      return {
+        left: clamp(intent.h.offset ?? cfg.h.defaultOffset, 0, container.width),
+        width: fixedAxisSize(intent.h, cfg.h, 300),
+      };
+    }
+    const { offset, size } = spanAxis(intent.h, cfg.h, container.width);
+    return { left: offset, width: size };
+  };
+
+  switch (intent.dock) {
+    case "right": {
+      width = fixedAxisSize(intent.h, cfg.h, 300);
+      width = clamp(width, MIN_PANEL_W, container.width);
+      left = container.width - width;
+      ({ top, height } = verticalDockedAxis());
+      break;
+    }
+    case "left": {
+      width = fixedAxisSize(intent.h, cfg.h, 300);
+      width = clamp(width, MIN_PANEL_W, container.width);
+      left = 0;
+      ({ top, height } = verticalDockedAxis());
+      break;
+    }
+    case "bottom": {
+      height = fixedAxisSize(intent.v, cfg.v, 300);
+      height = clamp(height, MIN_PANEL_H, container.height);
+      const effHeight = minimized ? MINIMIZED_HEADER_PX : height;
+      top = container.height - effHeight;
+      ({ left, width } = horizontalDockedAxis());
+      break;
+    }
+    case "top": {
+      height = fixedAxisSize(intent.v, cfg.v, 300);
+      height = clamp(height, MIN_PANEL_H, container.height);
+      top = 0;
+      ({ left, width } = horizontalDockedAxis());
+      break;
+    }
+    case "free":
+    default: {
+      width = fixedAxisSize(intent.h, cfg.h, 400);
+      height = fixedAxisSize(intent.v, cfg.v, 300);
+      width = clamp(width, MIN_PANEL_W, container.width);
+      height = clamp(height, MIN_PANEL_H, container.height);
+      const effHeight = minimized ? MINIMIZED_HEADER_PX : height;
+      left =
+        intent.h.gap !== null
+          ? container.width - width - intent.h.gap
+          : (intent.h.offset ?? cfg.h.defaultOffset);
+      top =
+        intent.v.gap !== null
+          ? container.height - effHeight - intent.v.gap
+          : (intent.v.offset ?? cfg.v.defaultOffset);
+      break;
+    }
+  }
+
+  width = clamp(width, MIN_PANEL_W, container.width);
+  height = clamp(height, MIN_PANEL_H, container.height);
+  const effHeight = minimized ? MINIMIZED_HEADER_PX : height;
+  left = clamp(left, 0, Math.max(0, container.width - width));
+  top = clamp(top, 0, Math.max(0, container.height - effHeight));
+
+  return { left, top, width, height };
+}
+
+// Pull a rect fully inside the container. Gesture rects are deliberately
+// unclamped while dragging (panels may hang off-canvas mid-gesture, as
+// before); the commit must record the settled, in-bounds geometry — negative
+// offsets would be rejected by sanitizeIntent on the next load.
+export function clampRectToBounds(
+  rect: RenderRect,
+  container: Bounds,
+  minimized = false,
+): RenderRect {
+  const width = Math.min(rect.width, container.width);
+  const height = Math.min(rect.height, container.height);
+  // A minimized panel renders as a 35px header while rect.height keeps the
+  // stored expanded size — clamp its position by what's actually on screen.
+  const effHeight = minimized ? MINIMIZED_HEADER_PX : height;
+  return {
+    width,
+    height,
+    left: clamp(rect.left, 0, Math.max(0, container.width - width)),
+    top: clamp(rect.top, 0, Math.max(0, container.height - effHeight)),
+  };
+}
+
+// Gesture-stop inverse of computeLayout: capture the final on-screen rect as
+// user intent (sizes for fixed axes, offset+gap spans for scale/fill axes,
+// anchored offsets for free mode).
+export function intentFromRect(
+  rect: RenderRect,
+  dock: PanelDock,
+  cfg: PanelConfig,
+  container: Bounds,
+  minimized = false,
+): PanelIntent {
+  const spanIntentH = (): AxisIntent => ({
+    size: null,
+    offset: rect.left,
+    gap: container.width - rect.left - rect.width,
+  });
+  const spanIntentV = (): AxisIntent => ({
+    size: null,
+    offset: rect.top,
+    gap: container.height - rect.top - rect.height,
+  });
+
+  let h: AxisIntent;
+  let v: AxisIntent;
+
+  switch (dock) {
+    case "right":
+    case "left":
+      h = { size: rect.width, offset: null, gap: null };
+      v =
+        cfg.v.behaviour === "fixed"
+          ? { size: rect.height, offset: rect.top, gap: null }
+          : spanIntentV();
+      break;
+    case "top":
+    case "bottom":
+      v = { size: rect.height, offset: null, gap: null };
+      h =
+        cfg.h.behaviour === "fixed"
+          ? { size: rect.width, offset: rect.left, gap: null }
+          : spanIntentH();
+      break;
+    case "free":
+    default: {
+      // Anchor each axis to the container half the panel's center sits in, so
+      // a right/bottom-hugging panel keeps hugging as the container resizes.
+      // Vertical anchoring uses the on-screen height (35px when minimized) —
+      // computeLayout positions with the same effHeight, so the round-trip
+      // must too or a minimized drop in the lower half jumps on release.
+      const effHeight = minimized ? MINIMIZED_HEADER_PX : rect.height;
+      const farH = rect.left + rect.width / 2 > container.width / 2;
+      const farV = rect.top + effHeight / 2 > container.height / 2;
+      h = {
+        size: rect.width,
+        offset: farH ? null : rect.left,
+        gap: farH ? container.width - rect.left - rect.width : null,
+      };
+      v = {
+        size: rect.height,
+        offset: farV ? null : rect.top,
+        gap: farV ? container.height - rect.top - effHeight : null,
+      };
+      break;
+    }
+  }
+
+  return { dock, h, v, fullScreen: false };
+}
+
+// Which dock side (if any) a released rect should snap to. Nearest edge wins;
+// ties resolve in `allowed` order.
+export function snapSideForRect(
+  rect: RenderRect,
+  container: Bounds,
+  allowed: DockSide[],
+): DockSide | null {
+  const distances: Record<DockSide, number> = {
+    left: rect.left,
+    right: container.width - (rect.left + rect.width),
+    top: rect.top,
+    bottom: container.height - (rect.top + rect.height),
+  };
+  let best: DockSide | null = null;
+  for (const side of allowed) {
+    const d = distances[side];
+    if (d <= SNAP_ZONE_PX && (best === null || d < distances[best])) {
+      best = side;
+    }
+  }
+  return best;
+}

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/layoutIntent.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/layoutIntent.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import type { PanelConfig } from "./layoutGeometry";
+import { intentStorageKey, legacyV3StorageKey, migrateV3, sanitizeIntent } from "./layoutIntent";
+
+const rightDrawerCfg: PanelConfig = {
+  defaultDock: "right",
+  h: { behaviour: "fixed", defaultSize: 600, defaultOffset: 0 },
+  v: { behaviour: "scale", defaultSize: 700, defaultOffset: 8 },
+};
+
+const bottomDockCfg: PanelConfig = {
+  defaultDock: "bottom",
+  h: { behaviour: "scale", defaultSize: null, defaultOffset: 180 },
+  v: { behaviour: "fixed", defaultSize: 225, defaultOffset: 0 },
+};
+
+const v3Record = (patch: Record<string, unknown> = {}): Record<string, unknown> => ({
+  width: 640,
+  height: 800,
+  left: 560,
+  top: 8,
+  stickynessPosition: "right",
+  fullWidth: false,
+  fullHeight: false,
+  zIndex: 100,
+  fullScreen: false,
+  clicked: false,
+  ...patch,
+});
+
+describe("storage keys", () => {
+  it("v4 and v3 keys use the shared prefix with distinct versions", () => {
+    expect(intentStorageKey("rightDrawer")).toBe("overlayPositionAndSize.v4_rightDrawer");
+    expect(legacyV3StorageKey("rightDrawer")).toBe("overlayPositionAndSize.v3_rightDrawer");
+  });
+});
+
+describe("migrateV3 — corruption fingerprints", () => {
+  it("rejects the exact reported bug record (150x100 at top:0 left:464)", () => {
+    const bug = v3Record({ width: 150, height: 100, left: 464, top: 0 });
+    expect(migrateV3(bug, rightDrawerCfg)).toBeNull();
+  });
+
+  it("rejects one-axis crushes that older sweeps missed", () => {
+    expect(migrateV3(v3Record({ width: 600, height: 100 }), rightDrawerCfg)).toBeNull();
+    expect(migrateV3(v3Record({ width: 100, height: 400 }), rightDrawerCfg)).toBeNull();
+  });
+
+  it("rejects non-finite, negative, and absurd geometry", () => {
+    expect(migrateV3(v3Record({ width: NaN }), rightDrawerCfg)).toBeNull();
+    expect(migrateV3(v3Record({ left: -20 }), rightDrawerCfg)).toBeNull();
+    expect(migrateV3(v3Record({ top: 50000 }), rightDrawerCfg)).toBeNull();
+    expect(migrateV3(v3Record({ height: "300" }), rightDrawerCfg)).toBeNull();
+    expect(migrateV3("{ not json", rightDrawerCfg)).toBeNull();
+    expect(migrateV3(null, rightDrawerCfg)).toBeNull();
+  });
+
+  it("rejects unknown and retired dock values", () => {
+    expect(migrateV3(v3Record({ stickynessPosition: "bottom-center" }), rightDrawerCfg)).toBeNull();
+    expect(migrateV3(v3Record({ stickynessPosition: "middle" }), rightDrawerCfg)).toBeNull();
+  });
+});
+
+describe("migrateV3 — healthy records", () => {
+  it("keeps only the fixed-axis size for a right-docked drawer", () => {
+    expect(migrateV3(v3Record(), rightDrawerCfg)).toEqual({
+      dock: "right",
+      h: { size: 640, offset: null, gap: null },
+      // Scale-axis height is a derived value in v3 (the corruptible one) and
+      // the top offset was a seeded default — both re-derive from defaults.
+      v: { size: null, offset: null, gap: null },
+      fullScreen: false,
+    });
+  });
+
+  it("keeps only the height for the bottom dock (left was a seeded default)", () => {
+    const record = v3Record({
+      width: 1020,
+      height: 225,
+      left: 180,
+      top: 675,
+      stickynessPosition: "bottom",
+    });
+    expect(migrateV3(record, bottomDockCfg)).toEqual({
+      dock: "bottom",
+      h: { size: null, offset: null, gap: null },
+      v: { size: 225, offset: null, gap: null },
+      fullScreen: false,
+    });
+  });
+
+  it("keeps sizes and offsets for a free panel", () => {
+    const record = v3Record({
+      width: 500,
+      height: 400,
+      left: 120,
+      top: 60,
+      stickynessPosition: "free",
+    });
+    expect(migrateV3(record, rightDrawerCfg)).toEqual({
+      dock: "free",
+      h: { size: 500, offset: 120, gap: null },
+      v: { size: 400, offset: 60, gap: null },
+      fullScreen: false,
+    });
+  });
+
+  it("drops an out-of-range fixed size but keeps the rest of the record", () => {
+    const record = v3Record({ width: 7000 });
+    expect(migrateV3(record, rightDrawerCfg)).toEqual({
+      dock: "right",
+      h: { size: null, offset: null, gap: null },
+      v: { size: null, offset: null, gap: null },
+      fullScreen: false,
+    });
+  });
+});
+
+describe("sanitizeIntent", () => {
+  it("accepts migrateV3 output unchanged (idempotence)", () => {
+    const migrated = migrateV3(v3Record(), rightDrawerCfg);
+    expect(migrated).not.toBeNull();
+    expect(sanitizeIntent(migrated)).toEqual(migrated);
+  });
+
+  it("normalizes persisted fullScreen back to false", () => {
+    const migrated = migrateV3(v3Record(), rightDrawerCfg);
+    expect(sanitizeIntent({ ...migrated, fullScreen: true })?.fullScreen).toBe(false);
+  });
+
+  it("rejects structural garbage", () => {
+    expect(sanitizeIntent(null)).toBeNull();
+    expect(sanitizeIntent("nope")).toBeNull();
+    expect(sanitizeIntent({})).toBeNull();
+    expect(sanitizeIntent({ dock: "diagonal", h: {}, v: {} })).toBeNull();
+    const migrated = migrateV3(v3Record(), rightDrawerCfg);
+    expect(sanitizeIntent({ ...migrated, h: undefined })).toBeNull();
+  });
+
+  it("rejects below-minimum, negative, and non-finite axis values", () => {
+    const base = migrateV3(v3Record(), rightDrawerCfg)!;
+    expect(sanitizeIntent({ ...base, h: { size: 100, offset: null, gap: null } })).toBeNull();
+    expect(sanitizeIntent({ ...base, v: { size: null, offset: -5, gap: null } })).toBeNull();
+    expect(sanitizeIntent({ ...base, v: { size: null, offset: null, gap: NaN } })).toBeNull();
+    expect(sanitizeIntent({ ...base, v: { size: null, offset: null, gap: "8" } })).toBeNull();
+  });
+
+  it("clamps over-maximum values instead of resetting the layout (huge displays)", () => {
+    const base = migrateV3(v3Record(), rightDrawerCfg)!;
+    expect(sanitizeIntent({ ...base, h: { size: 7000, offset: null, gap: null } })?.h.size).toBe(
+      6000,
+    );
+    expect(sanitizeIntent({ ...base, v: { size: null, offset: 20000, gap: null } })?.v.offset).toBe(
+      10000,
+    );
+  });
+
+  it("treats missing axis fields as null", () => {
+    const intent = sanitizeIntent({ dock: "right", h: { size: 600 }, v: {} });
+    expect(intent).toEqual({
+      dock: "right",
+      h: { size: 600, offset: null, gap: null },
+      v: { size: null, offset: null, gap: null },
+      fullScreen: false,
+    });
+  });
+});

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/layoutIntent.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/layoutIntent.ts
@@ -1,0 +1,137 @@
+// Persistence layer for panel layout intent: storage keys, validation of
+// stored records, and one-time migration of legacy v3 geometry. Pure — no
+// Vue, no DOM, no direct localStorage access (the store owns I/O).
+
+import type { AxisIntent, PanelConfig, PanelDock, PanelIntent } from "./layoutGeometry";
+import { MIN_PANEL_H, MIN_PANEL_W } from "./layoutGeometry";
+
+// v4: layout records store user INTENT (dock + per-axis size/offset/gap),
+// not derived on-screen geometry. v3 records stored the rendered rect and
+// were corruptible by adaptive clamps; they are migrated on first load.
+export const STORAGE_VERSION = 4;
+export const intentStorageKey = (id: string): string =>
+  `overlayPositionAndSize.v${STORAGE_VERSION}_${id}`;
+export const legacyV3StorageKey = (id: string): string => `overlayPositionAndSize.v3_${id}`;
+
+const MAX_PANEL_PX = 6000;
+const MAX_OFFSET_PX = 10000;
+
+const DOCK_VALUES: readonly PanelDock[] = ["top", "bottom", "left", "right", "free"];
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const inRange = (value: number, min: number, max: number): boolean => value >= min && value <= max;
+
+// Below-minimum and non-finite values are rejected (gestures can't produce
+// them — they mark corruption); over-maximum values are CLAMPED, not
+// rejected: a legitimate gesture on a very large display can exceed the
+// caps, and resetting the whole layout over it would punish real intent.
+const sanitizeAxis = (raw: unknown, minSize: number): AxisIntent | null => {
+  if (typeof raw !== "object" || raw === null) return null;
+  const axis = raw as Record<string, unknown>;
+  const out: AxisIntent = { size: null, offset: null, gap: null };
+  if (axis.size !== null && axis.size !== undefined) {
+    if (!isFiniteNumber(axis.size) || axis.size < minSize) return null;
+    out.size = Math.min(axis.size, MAX_PANEL_PX);
+  }
+  if (axis.offset !== null && axis.offset !== undefined) {
+    if (!isFiniteNumber(axis.offset) || axis.offset < 0) return null;
+    out.offset = Math.min(axis.offset, MAX_OFFSET_PX);
+  }
+  if (axis.gap !== null && axis.gap !== undefined) {
+    if (!isFiniteNumber(axis.gap) || axis.gap < 0) return null;
+    out.gap = Math.min(axis.gap, MAX_OFFSET_PX);
+  }
+  return out;
+};
+
+// Validate a stored v4 record. Returns a normalized intent or null (caller
+// falls back to defaults). fullScreen is deliberately reset: it is transient
+// view state whose driver (e.g. ExploreData) re-establishes it per session.
+export function sanitizeIntent(raw: unknown): PanelIntent | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const record = raw as Record<string, unknown>;
+  if (!DOCK_VALUES.includes(record.dock as PanelDock)) return null;
+  const h = sanitizeAxis(record.h, MIN_PANEL_W);
+  const v = sanitizeAxis(record.v, MIN_PANEL_H);
+  if (!h || !v) return null;
+  return { dock: record.dock as PanelDock, h, v, fullScreen: false };
+}
+
+interface V3Record {
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+  stickynessPosition: PanelDock;
+}
+
+const parseV3 = (raw: unknown): V3Record | null => {
+  if (typeof raw !== "object" || raw === null) return null;
+  const record = raw as Record<string, unknown>;
+  if (
+    !isFiniteNumber(record.width) ||
+    !isFiniteNumber(record.height) ||
+    !isFiniteNumber(record.left) ||
+    !isFiniteNumber(record.top)
+  ) {
+    return null;
+  }
+  if (!DOCK_VALUES.includes(record.stickynessPosition as PanelDock)) return null;
+  return {
+    width: record.width,
+    height: record.height,
+    left: record.left,
+    top: record.top,
+    stickynessPosition: record.stickynessPosition as PanelDock,
+  };
+};
+
+// Migrate a legacy v3 record (rendered-rect shape) to intent. Returns null
+// for unusable records — including the corruption fingerprint: the gesture
+// handlers floored strictly above 100px per axis, so any stored extent at or
+// below that can only come from the old adaptive clamps gone wrong.
+export function migrateV3(raw: unknown, cfg: PanelConfig): PanelIntent | null {
+  const record = parseV3(raw);
+  if (!record) return null;
+  if (record.width <= 100 || record.height <= 100) return null;
+  if (record.left < 0 || record.top < 0) return null;
+  if (record.left > MAX_OFFSET_PX || record.top > MAX_OFFSET_PX) return null;
+
+  const sizeOrNull = (value: number, minSize: number): number | null =>
+    inRange(value, minSize, MAX_PANEL_PX) ? value : null;
+
+  const empty = (): AxisIntent => ({ size: null, offset: null, gap: null });
+
+  const dock = record.stickynessPosition;
+  const h = empty();
+  const v = empty();
+
+  // Docked panels keep only the perpendicular "fixed" size — the one value
+  // that is unambiguously user intent in a v3 record. Scale/fill sizes are
+  // derived values (exactly where corruption lived), and the parallel-axis
+  // offsets (right-dock top, bottom-dock left) were seeded app defaults far
+  // more often than user choices — dropping them lets the current defaults
+  // (flush top, next-to-palette) apply.
+  switch (dock) {
+    case "right":
+    case "left":
+      if (cfg.h.behaviour === "fixed") h.size = sizeOrNull(record.width, MIN_PANEL_W);
+      if (cfg.v.behaviour === "fixed") v.size = sizeOrNull(record.height, MIN_PANEL_H);
+      break;
+    case "top":
+    case "bottom":
+      if (cfg.v.behaviour === "fixed") v.size = sizeOrNull(record.height, MIN_PANEL_H);
+      if (cfg.h.behaviour === "fixed") h.size = sizeOrNull(record.width, MIN_PANEL_W);
+      break;
+    case "free":
+      h.size = sizeOrNull(record.width, MIN_PANEL_W);
+      h.offset = record.left;
+      v.size = sizeOrNull(record.height, MIN_PANEL_H);
+      v.offset = record.top;
+      break;
+  }
+
+  return { dock, h, v, fullScreen: false };
+}

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/stateStore.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/stateStore.test.ts
@@ -1,0 +1,123 @@
+// Unit tests for the store's one-time geometry sanitizer: instantiating the
+// store must drop only current-version panel entries pinned at the collapse
+// fingerprint (width <= 150 && height <= 100) and leave everything else intact.
+// Pinia + a fake localStorage are set up per-test. The fake stores data as
+// enumerable own-properties so `Object.keys(localStorage)` (used by the sweep)
+// behaves like a real Storage — a Map-backed fake would hide the keys.
+
+import { setActivePinia, createPinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useItemStore } from "./stateStore";
+
+function fakeLocalStorage(): Storage {
+  const ls = {} as Record<string, string> & Storage;
+  Object.defineProperties(ls, {
+    getItem: {
+      value: (k: string) => (Object.prototype.hasOwnProperty.call(ls, k) ? ls[k] : null),
+      enumerable: false,
+    },
+    setItem: {
+      value: (k: string, v: string) => {
+        ls[k] = String(v);
+      },
+      enumerable: false,
+    },
+    removeItem: {
+      value: (k: string) => {
+        delete ls[k];
+      },
+      enumerable: false,
+    },
+    clear: {
+      value: () => {
+        for (const k of Object.keys(ls)) delete ls[k];
+      },
+      enumerable: false,
+    },
+    key: { value: (i: number) => Object.keys(ls)[i] ?? null, enumerable: false },
+    length: { get: () => Object.keys(ls).length, enumerable: false },
+  });
+  return ls;
+}
+
+const key = (id: string) => `overlayPositionAndSize.v3_${id}`;
+
+const layout = (width: number, height: number) =>
+  JSON.stringify({
+    width,
+    height,
+    left: 20,
+    top: 8,
+    stickynessPosition: "right",
+    fullWidth: false,
+    fullHeight: false,
+    zIndex: 100,
+    fullScreen: false,
+    clicked: false,
+  });
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", fakeLocalStorage());
+  setActivePinia(createPinia());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("purgeCorruptedGeometry (via store init)", () => {
+  it("drops an entry pinned at the exact collapse floor (150x100)", () => {
+    localStorage.setItem(key("rightDrawer"), layout(150, 100));
+    useItemStore();
+    expect(localStorage.getItem(key("rightDrawer"))).toBeNull();
+  });
+
+  it("drops entries at or below the fingerprint (width<=150 && height<=100)", () => {
+    localStorage.setItem(key("a"), layout(120, 80));
+    localStorage.setItem(key("b"), layout(150, 100));
+    localStorage.setItem(key("c"), layout(90, 90));
+    useItemStore();
+    expect(localStorage.getItem(key("a"))).toBeNull();
+    expect(localStorage.getItem(key("b"))).toBeNull();
+    expect(localStorage.getItem(key("c"))).toBeNull();
+  });
+
+  it("keeps a healthy saved layout", () => {
+    localStorage.setItem(key("rightDrawer"), layout(600, 400));
+    useItemStore();
+    expect(localStorage.getItem(key("rightDrawer"))).toBe(layout(600, 400));
+  });
+
+  it("keeps entries just outside the fingerprint on either axis", () => {
+    // width over the floor — a real (if narrow) panel, not a collapse.
+    localStorage.setItem(key("wide"), layout(151, 100));
+    // height over the floor — unreachable by the collapse bug.
+    localStorage.setItem(key("tall"), layout(150, 101));
+    useItemStore();
+    expect(localStorage.getItem(key("wide"))).toBe(layout(151, 100));
+    expect(localStorage.getItem(key("tall"))).toBe(layout(150, 101));
+  });
+
+  it("removes only the corrupted entry from a mixed set", () => {
+    localStorage.setItem(key("bad"), layout(150, 100));
+    localStorage.setItem(key("good"), layout(500, 300));
+    useItemStore();
+    expect(localStorage.getItem(key("bad"))).toBeNull();
+    expect(localStorage.getItem(key("good"))).toBe(layout(500, 300));
+  });
+
+  it("drops an entry with unparseable JSON", () => {
+    localStorage.setItem(key("broken"), "{ not json");
+    useItemStore();
+    expect(localStorage.getItem(key("broken"))).toBeNull();
+  });
+
+  it("ignores unrelated localStorage keys", () => {
+    localStorage.setItem("someOtherKey", "value");
+    localStorage.setItem("layoutControlsPositionV2", '{"x":10,"y":20}');
+    useItemStore();
+    expect(localStorage.getItem("someOtherKey")).toBe("value");
+    expect(localStorage.getItem("layoutControlsPositionV2")).toBe('{"x":10,"y":20}');
+  });
+});

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/stateStore.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/stateStore.test.ts
@@ -1,13 +1,13 @@
-// Unit tests for the store's one-time geometry sanitizer: instantiating the
-// store must drop only current-version panel entries pinned at the collapse
-// fingerprint (width <= 150 && height <= 100) and leave everything else intact.
-// Pinia + a fake localStorage are set up per-test. The fake stores data as
-// enumerable own-properties so `Object.keys(localStorage)` (used by the sweep)
-// behaves like a real Storage — a Map-backed fake would hide the keys.
+// Unit tests for the intent store: v3→v4 migration at panel registration
+// (corrupted records heal to defaults, healthy ones convert), gesture-only
+// persistence, and reset. Pinia + a fake localStorage are set up per-test.
+// The fake stores data as enumerable own-properties so `Object.keys(...)`
+// (used by the legacy-key purge) behaves like a real Storage.
 
-import { setActivePinia, createPinia } from "pinia";
+import { createPinia, setActivePinia } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { defaultIntent, type PanelConfig } from "./layoutGeometry";
 import { useItemStore } from "./stateStore";
 
 function fakeLocalStorage(): Storage {
@@ -41,9 +41,10 @@ function fakeLocalStorage(): Storage {
   return ls;
 }
 
-const key = (id: string) => `overlayPositionAndSize.v3_${id}`;
+const v3Key = (id: string) => `overlayPositionAndSize.v3_${id}`;
+const v4Key = (id: string) => `overlayPositionAndSize.v4_${id}`;
 
-const layout = (width: number, height: number) =>
+const v3Layout = (width: number, height: number, patch: Record<string, unknown> = {}) =>
   JSON.stringify({
     width,
     height,
@@ -55,7 +56,14 @@ const layout = (width: number, height: number) =>
     zIndex: 100,
     fullScreen: false,
     clicked: false,
+    ...patch,
   });
+
+const rightDrawerCfg: PanelConfig = {
+  defaultDock: "right",
+  h: { behaviour: "fixed", defaultSize: 600, defaultOffset: 0 },
+  v: { behaviour: "scale", defaultSize: 700, defaultOffset: 8 },
+};
 
 beforeEach(() => {
   vi.stubGlobal("localStorage", fakeLocalStorage());
@@ -66,58 +74,144 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("purgeCorruptedGeometry (via store init)", () => {
-  it("drops an entry pinned at the exact collapse floor (150x100)", () => {
-    localStorage.setItem(key("rightDrawer"), layout(150, 100));
-    useItemStore();
-    expect(localStorage.getItem(key("rightDrawer"))).toBeNull();
+describe("v3 migration at panel registration", () => {
+  it("heals the exact collapse fingerprint (150x100) to defaults", () => {
+    localStorage.setItem(v3Key("rightDrawer"), v3Layout(150, 100, { left: 464, top: 0 }));
+    const store = useItemStore();
+    const intent = store.registerPanel("rightDrawer", rightDrawerCfg);
+    expect(intent).toEqual(defaultIntent(rightDrawerCfg));
+    expect(localStorage.getItem(v3Key("rightDrawer"))).toBeNull();
+    expect(localStorage.getItem(v4Key("rightDrawer"))).toBeNull();
   });
 
-  it("drops entries at or below the fingerprint (width<=150 && height<=100)", () => {
-    localStorage.setItem(key("a"), layout(120, 80));
-    localStorage.setItem(key("b"), layout(150, 100));
-    localStorage.setItem(key("c"), layout(90, 90));
-    useItemStore();
-    expect(localStorage.getItem(key("a"))).toBeNull();
-    expect(localStorage.getItem(key("b"))).toBeNull();
-    expect(localStorage.getItem(key("c"))).toBeNull();
+  it("heals one-axis crushes the old sweep missed", () => {
+    localStorage.setItem(v3Key("rightDrawer"), v3Layout(600, 100));
+    const store = useItemStore();
+    expect(store.registerPanel("rightDrawer", rightDrawerCfg)).toEqual(
+      defaultIntent(rightDrawerCfg),
+    );
+    expect(localStorage.getItem(v3Key("rightDrawer"))).toBeNull();
   });
 
-  it("keeps a healthy saved layout", () => {
-    localStorage.setItem(key("rightDrawer"), layout(600, 400));
-    useItemStore();
-    expect(localStorage.getItem(key("rightDrawer"))).toBe(layout(600, 400));
+  it("converts a healthy v3 record to a v4 intent record", () => {
+    localStorage.setItem(v3Key("rightDrawer"), v3Layout(640, 800));
+    const store = useItemStore();
+    const intent = store.registerPanel("rightDrawer", rightDrawerCfg);
+    expect(intent).toEqual({
+      dock: "right",
+      h: { size: 640, offset: null, gap: null },
+      v: { size: null, offset: null, gap: null },
+      fullScreen: false,
+    });
+    expect(localStorage.getItem(v3Key("rightDrawer"))).toBeNull();
+    expect(JSON.parse(localStorage.getItem(v4Key("rightDrawer"))!)).toEqual(intent);
   });
 
-  it("keeps entries just outside the fingerprint on either axis", () => {
-    // width over the floor — a real (if narrow) panel, not a collapse.
-    localStorage.setItem(key("wide"), layout(151, 100));
-    // height over the floor — unreachable by the collapse bug.
-    localStorage.setItem(key("tall"), layout(150, 101));
-    useItemStore();
-    expect(localStorage.getItem(key("wide"))).toBe(layout(151, 100));
-    expect(localStorage.getItem(key("tall"))).toBe(layout(150, 101));
+  it("drops unparseable v3 JSON and falls back to defaults", () => {
+    localStorage.setItem(v3Key("broken"), "{ not json");
+    const store = useItemStore();
+    expect(store.registerPanel("broken", rightDrawerCfg)).toEqual(defaultIntent(rightDrawerCfg));
+    expect(localStorage.getItem(v3Key("broken"))).toBeNull();
+  });
+});
+
+describe("v4 load", () => {
+  it("loads a healthy v4 record", () => {
+    const saved = {
+      dock: "right",
+      h: { size: 500, offset: null, gap: null },
+      v: { size: null, offset: 8, gap: 250 },
+      fullScreen: false,
+    };
+    localStorage.setItem(v4Key("rightDrawer"), JSON.stringify(saved));
+    const store = useItemStore();
+    expect(store.registerPanel("rightDrawer", rightDrawerCfg)).toEqual(saved);
   });
 
-  it("removes only the corrupted entry from a mixed set", () => {
-    localStorage.setItem(key("bad"), layout(150, 100));
-    localStorage.setItem(key("good"), layout(500, 300));
-    useItemStore();
-    expect(localStorage.getItem(key("bad"))).toBeNull();
-    expect(localStorage.getItem(key("good"))).toBe(layout(500, 300));
+  it("drops a degenerate v4 record and heals to defaults", () => {
+    localStorage.setItem(
+      v4Key("rightDrawer"),
+      JSON.stringify({ dock: "right", h: { size: 20 }, v: {} }),
+    );
+    const store = useItemStore();
+    expect(store.registerPanel("rightDrawer", rightDrawerCfg)).toEqual(
+      defaultIntent(rightDrawerCfg),
+    );
+    expect(localStorage.getItem(v4Key("rightDrawer"))).toBeNull();
   });
 
-  it("drops an entry with unparseable JSON", () => {
-    localStorage.setItem(key("broken"), "{ not json");
-    useItemStore();
-    expect(localStorage.getItem(key("broken"))).toBeNull();
+  it("keeps the in-session intent when a panel remounts", () => {
+    const store = useItemStore();
+    store.registerPanel("rightDrawer", rightDrawerCfg);
+    const resized = {
+      ...defaultIntent(rightDrawerCfg),
+      h: { size: 480, offset: null, gap: null },
+    };
+    store.commitIntent("rightDrawer", resized);
+    // Drawer close/open remounts the component; the session intent must win.
+    expect(store.registerPanel("rightDrawer", rightDrawerCfg)).toEqual(resized);
+  });
+});
+
+describe("persistence discipline", () => {
+  it("commitIntent writes the v4 record", () => {
+    const store = useItemStore();
+    store.registerPanel("rightDrawer", rightDrawerCfg);
+    const intent = {
+      ...defaultIntent(rightDrawerCfg),
+      h: { size: 480, offset: null, gap: null },
+    };
+    store.commitIntent("rightDrawer", intent);
+    expect(JSON.parse(localStorage.getItem(v4Key("rightDrawer"))!)).toEqual(intent);
   });
 
-  it("ignores unrelated localStorage keys", () => {
+  it("registering a panel with no stored record writes nothing", () => {
+    const store = useItemStore();
+    store.registerPanel("rightDrawer", rightDrawerCfg);
+    expect(localStorage.getItem(v4Key("rightDrawer"))).toBeNull();
+  });
+
+  it("resetLayout removes stored records and restores defaults", () => {
+    const store = useItemStore();
+    store.registerPanel("rightDrawer", rightDrawerCfg);
+    store.commitIntent("rightDrawer", {
+      ...defaultIntent(rightDrawerCfg),
+      h: { size: 480, offset: null, gap: null },
+    });
+    store.resetLayout();
+    expect(localStorage.getItem(v4Key("rightDrawer"))).toBeNull();
+    expect(store.items["rightDrawer"]).toEqual(defaultIntent(rightDrawerCfg));
+  });
+});
+
+describe("legacy key handling at store init", () => {
+  it("purges pre-v3 keys and group keys, keeps v3 and v4 and unrelated keys", () => {
+    localStorage.setItem("overlayPositionAndSize_old", "{}");
+    localStorage.setItem("overlayPositionAndSize.v2_x", "{}");
+    localStorage.setItem("overlayGroups.v3", "{}");
+    localStorage.setItem(v3Key("rightDrawer"), v3Layout(640, 800));
+    localStorage.setItem(v4Key("bottomDock"), "{}");
     localStorage.setItem("someOtherKey", "value");
     localStorage.setItem("layoutControlsPositionV2", '{"x":10,"y":20}');
     useItemStore();
+    expect(localStorage.getItem("overlayPositionAndSize_old")).toBeNull();
+    expect(localStorage.getItem("overlayPositionAndSize.v2_x")).toBeNull();
+    expect(localStorage.getItem("overlayGroups.v3")).toBeNull();
+    expect(localStorage.getItem(v3Key("rightDrawer"))).not.toBeNull();
+    expect(localStorage.getItem(v4Key("bottomDock"))).not.toBeNull();
     expect(localStorage.getItem("someOtherKey")).toBe("value");
     expect(localStorage.getItem("layoutControlsPositionV2")).toBe('{"x":10,"y":20}');
+  });
+});
+
+describe("z-order", () => {
+  it("bringToFront raises the panel above its peers, fullscreen pins the top", () => {
+    const store = useItemStore();
+    store.registerPanel("a", rightDrawerCfg);
+    store.registerPanel("b", rightDrawerCfg);
+    store.bringToFront("a");
+    expect(store.zIndexFor("a")).toBeGreaterThan(store.zIndexFor("b"));
+    store.setFullScreen("b", true);
+    expect(store.zIndexFor("b")).toBeGreaterThan(store.zIndexFor("a"));
   });
 });

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/stateStore.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/stateStore.ts
@@ -1,26 +1,44 @@
 import { defineStore } from "pinia";
-import { ref, computed } from "vue";
+import { ref } from "vue";
+
+import { defaultIntent, type Bounds, type PanelConfig, type PanelIntent } from "./layoutGeometry";
+import {
+  STORAGE_VERSION,
+  intentStorageKey,
+  legacyV3StorageKey,
+  migrateV3,
+  sanitizeIntent,
+} from "./layoutIntent";
 import { Z_INDEX } from "./zIndex";
 
-// Bump when the localStorage shape or coordinate system changes — old keys are
-// purged on next load. Last bump: right-side panels merged into one tabbed
-// `rightDrawer`, so the old per-panel ids (nodeSettings/aiAssistant/...) are gone.
-const STORAGE_VERSION = 3;
-const itemStorageKey = (id: string) => `overlayPositionAndSize.v${STORAGE_VERSION}_${id}`;
-const groupsStorageKey = `overlayGroups.v${STORAGE_VERSION}`;
+// The store holds per-panel USER INTENT (see layoutGeometry.ts for the
+// intent-vs-derived contract) plus session state: z-order and the shared
+// canvas container bounds. commitIntent is the ONLY localStorage writer, and
+// it only runs on explicit user gestures — derived geometry is never saved,
+// so a mis-measured container can no longer corrupt a stored layout.
+
+const safeParse = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+};
 
 const purgeLegacyKeys = () => {
   try {
     for (const key of Object.keys(localStorage)) {
-      // Drop any panel-position / group key from an older version (underscore
-      // pre-v2 legacy AND dotted `.v2_` etc.) — keep only the current version.
+      // Keep current-version intent records and v3 records (consumed by the
+      // one-time migration at panel registration); drop anything older.
       if (
         key.startsWith("overlayPositionAndSize") &&
-        !key.includes(`.v${STORAGE_VERSION}_`)
+        !key.includes(`.v${STORAGE_VERSION}_`) &&
+        !key.includes(".v3_")
       ) {
         localStorage.removeItem(key);
       }
-      if (key.startsWith("overlayGroups") && key !== groupsStorageKey) {
+      // Panel grouping was removed (it never had live consumers).
+      if (key.startsWith("overlayGroups")) {
         localStorage.removeItem(key);
       }
     }
@@ -28,580 +46,238 @@ const purgeLegacyKeys = () => {
     // localStorage can throw in private mode / quota exhaustion — ignore.
   }
 };
-
-// One-time heal of geometry corrupted by an older build that persisted panel
-// sizes measured against a collapsed container (route-transition / unlaid-out
-// canvas). Such a panel is pinned at the code's floor constants — width 150
-// (clampStateToViewport) and height 100 (the "scale"-axis floor) — a size the
-// UI cannot otherwise produce (interactive resize floors at >100px, clamp floors
-// width at >=150). Drop only current-version keys matching that exact
-// fingerprint so the panel recomputes its initial size on next mount; every
-// other saved layout (positions, groups, non-corrupted sizes) is left intact.
-const CORRUPT_MAX_WIDTH = 150;
-const CORRUPT_MAX_HEIGHT = 100;
-const purgeCorruptedGeometry = () => {
-  try {
-    for (const key of Object.keys(localStorage)) {
-      if (!key.startsWith("overlayPositionAndSize") || !key.includes(`.v${STORAGE_VERSION}_`)) {
-        continue;
-      }
-      const raw = localStorage.getItem(key);
-      if (!raw) continue;
-      try {
-        const state = JSON.parse(raw);
-        if (
-          typeof state?.width === "number" &&
-          typeof state?.height === "number" &&
-          state.width <= CORRUPT_MAX_WIDTH &&
-          state.height <= CORRUPT_MAX_HEIGHT
-        ) {
-          localStorage.removeItem(key);
-        }
-      } catch {
-        // Corrupted JSON — drop it so a clean state is written next save.
-        localStorage.removeItem(key);
-      }
-    }
-  } catch {
-    // localStorage can throw in private mode / quota exhaustion — ignore.
-  }
-};
-
-// Looks up the canvas <main> element so fullscreen panels fill the canvas
-// region (not the viewport, which would overlap the page header).
-const getCanvasBounds = (): { width: number; height: number } => {
-  if (typeof document === "undefined") {
-    return { width: 0, height: 0 };
-  }
-  const main = document.querySelector("main");
-  if (main) {
-    const rect = main.getBoundingClientRect();
-    return { width: rect.width, height: rect.height };
-  }
-  return { width: window.innerWidth, height: window.innerHeight };
-};
-
-// Per-axis resize response: "scale" keeps a constant gap to the edge, "fill"
-// stretches to the container, "fixed" stays put.
-export type AxisBehaviour = "scale" | "fixed" | "fill";
-
-export interface ItemLayout {
-  width: number;
-  height: number;
-  left: number;
-  top: number;
-  stickynessPosition: "top" | "bottom" | "left" | "right" | "free" | "bottom-center";
-  fullWidth: boolean;
-  fullHeight: boolean;
-  zIndex: number;
-  fullScreen: boolean;
-  prevWidth?: number;
-  prevHeight?: number;
-  prevLeft?: number;
-  prevTop?: number;
-  clicked: boolean;
-  group?: string;
-  syncDimensions?: boolean;
-}
-
-export interface ItemInitialState {
-  width?: number;
-  height?: number;
-  left?: number;
-  top?: number;
-  stickynessPosition?: "top" | "bottom" | "left" | "right" | "free";
-  group?: string;
-  syncDimensions?: boolean;
-  fullWidth?: boolean;
-  fullHeight?: boolean;
-}
 
 export const useItemStore = defineStore("itemStore", () => {
-  // Run-once cleanup of pre-v2 localStorage keys on first store instantiation,
-  // then heal any panels a prior build collapsed to the floor constants.
   purgeLegacyKeys();
-  purgeCorruptedGeometry();
 
-  const items = ref<Record<string, ItemLayout>>({});
-  const initialItemStates = ref<Record<string, ItemInitialState>>({});
-  const groups = ref<Record<string, string[]>>({});
+  const items = ref<Record<string, PanelIntent>>({});
+  const panelConfigs = ref<Record<string, PanelConfig>>({});
+  const zIndices = ref<Record<string, number>>({});
+  const containerBounds = ref<Bounds>({ width: 0, height: 0 });
   const inResizing = ref(false);
-  const idItemClicked = ref<string | null>(null);
-  const idItemVisible = ref<string | null>(null);
 
-  // Z-index constants (see zIndex.ts for the full hierarchy).
   const BASE_Z_INDEX = Z_INDEX.PANEL_BASE;
   const MAX_Z_INDEX = Z_INDEX.PANEL_MAX;
   const FULLSCREEN_Z_INDEX = Z_INDEX.FULLSCREEN;
 
-  // Per-id debounce timers for localStorage writes. Drag/resize fires at every
-  // mousemove (~60 Hz), so without throttling we'd hammer localStorage with
-  // hundreds of writes per gesture. 250 ms trailing-edge is invisible to the
-  // user and survives reload because stop handlers flush immediately.
-  const writeTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  const SAVE_DEBOUNCE_MS = 250;
+  // --- container -----------------------------------------------------------
 
-  const persistItem = (id: string) => {
-    const state = items.value[id];
-    if (!state) return;
-    try {
-      localStorage.setItem(itemStorageKey(id), JSON.stringify(state));
-      if (state.group) {
-        localStorage.setItem(groupsStorageKey, JSON.stringify({ groups: groups.value }));
+  let containerObserver: ResizeObserver | null = null;
+
+  // One shared measurement of the canvas <main> — panels derive geometry from
+  // this instead of each observing (and mis-resolving) their own offsetParent.
+  const registerContainer = (el: HTMLElement): (() => void) => {
+    containerObserver?.disconnect();
+    containerBounds.value = { width: el.clientWidth, height: el.clientHeight };
+    containerObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        containerBounds.value = {
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        };
       }
+    });
+    containerObserver.observe(el);
+    return () => {
+      containerObserver?.disconnect();
+      containerObserver = null;
+      // Keep the last bounds: zeroing them would blank every panel rect
+      // during a route transition.
+    };
+  };
+
+  // --- intent load / persist ----------------------------------------------
+
+  const loadIntent = (id: string, cfg: PanelConfig): PanelIntent => {
+    const v4Key = intentStorageKey(id);
+    try {
+      const rawV4 = localStorage.getItem(v4Key);
+      if (rawV4 !== null) {
+        const intent = sanitizeIntent(safeParse(rawV4));
+        if (intent) return intent;
+        // Degenerate record — drop it so the panel heals to defaults.
+        localStorage.removeItem(v4Key);
+      }
+      const v3Key = legacyV3StorageKey(id);
+      const rawV3 = localStorage.getItem(v3Key);
+      if (rawV3 !== null) {
+        localStorage.removeItem(v3Key);
+        const migrated = migrateV3(safeParse(rawV3), cfg);
+        if (migrated) {
+          localStorage.setItem(v4Key, JSON.stringify(migrated));
+          return migrated;
+        }
+      }
+    } catch {
+      // localStorage unavailable — session-only layout.
+    }
+    return defaultIntent(cfg);
+  };
+
+  const registerPanel = (id: string, cfg: PanelConfig): PanelIntent => {
+    panelConfigs.value[id] = cfg;
+    if (zIndices.value[id] === undefined) {
+      zIndices.value[id] = BASE_Z_INDEX + Object.keys(zIndices.value).length;
+    }
+    // A remounting panel (drawer close/open) keeps its in-session intent.
+    if (!items.value[id]) {
+      items.value[id] = loadIntent(id, cfg);
+    }
+    return items.value[id];
+  };
+
+  // The only localStorage writer. Called on gesture end (resize-stop,
+  // drag-stop, dock, fullscreen, arrange, reset) — never from derived
+  // geometry, which is what made the old store corruptible.
+  const commitIntent = (id: string, intent: PanelIntent) => {
+    items.value[id] = intent;
+    try {
+      localStorage.setItem(intentStorageKey(id), JSON.stringify(intent));
     } catch {
       // Ignore quota / private-mode failures.
     }
   };
 
-  const layoutPresets = {
-    sidePanel: { width: 400, height: "100%" },
-    bottomPanel: { width: "100%", height: 300 },
-    dataView: { width: 600, height: 400 },
-    logView: { width: 600, height: 400 },
-  };
-
-  const getGroupItems = computed(() => (groupName: string) => {
-    if (!groups.value[groupName]) return [];
-    return groups.value[groupName].map((id) => items.value[id]).filter(Boolean);
-  });
-
-  const registerInitialState = (id: string, initialState: ItemInitialState) => {
-    // Only register if not already registered (preserve the true initial state)
-    if (!initialItemStates.value[id]) {
-      initialItemStates.value[id] = { ...initialState };
-    }
-  };
+  // --- z-order (session only) ---------------------------------------------
 
   const normalizeZIndices = () => {
-    const nonFullscreenEntries = Object.entries(items.value)
-      .filter(([, item]) => !item.fullScreen)
-      .sort((a, b) => a[1].zIndex - b[1].zIndex);
-
-    nonFullscreenEntries.forEach(([entryId, item], index) => {
-      item.zIndex = BASE_Z_INDEX + index;
-      saveItemState(entryId);
-    });
+    Object.entries(zIndices.value)
+      .filter(([id]) => !items.value[id]?.fullScreen)
+      .sort((a, b) => a[1] - b[1])
+      .forEach(([id], index) => {
+        zIndices.value[id] = BASE_Z_INDEX + index;
+      });
   };
 
   const bringToFront = (id: string) => {
-    if (!items.value[id]) {
-      console.warn(`Item ${id} not found`);
-      return;
+    if (zIndices.value[id] === undefined) {
+      zIndices.value[id] = BASE_Z_INDEX + Object.keys(zIndices.value).length;
     }
-
-    if (items.value[id].fullScreen) return;
+    if (items.value[id]?.fullScreen) return;
 
     let maxZIndex = BASE_Z_INDEX - 1;
-    Object.entries(items.value).forEach(([itemId, item]) => {
-      if (!item.fullScreen && itemId !== id) {
-        maxZIndex = Math.max(maxZIndex, item.zIndex);
+    for (const [otherId, z] of Object.entries(zIndices.value)) {
+      if (otherId !== id && !items.value[otherId]?.fullScreen) {
+        maxZIndex = Math.max(maxZIndex, z);
       }
-    });
-
-    if (items.value[id].zIndex > maxZIndex) return;
-
-    items.value[id].zIndex = maxZIndex + 1;
-
-    // Normalize if z-indices are getting too high to prevent unbounded growth
-    if (items.value[id].zIndex > MAX_Z_INDEX) {
-      normalizeZIndices();
-    } else {
-      saveItemState(id);
     }
+    if (zIndices.value[id] > maxZIndex) return;
+    zIndices.value[id] = maxZIndex + 1;
+    if (zIndices.value[id] > MAX_Z_INDEX) normalizeZIndices();
   };
 
-  const setItemState = (id: string, state: Partial<ItemLayout>) => {
-    if (!items.value[id]) {
-      items.value[id] = {
-        width: 400,
-        height: 300,
-        left: 100,
-        top: 100,
-        stickynessPosition: "free",
-        fullWidth: false,
-        fullHeight: false,
-        zIndex: BASE_Z_INDEX,
-        fullScreen: false,
-        clicked: false,
-      };
-    }
+  const zIndexFor = (id: string): number =>
+    items.value[id]?.fullScreen ? FULLSCREEN_Z_INDEX : (zIndices.value[id] ?? BASE_Z_INDEX);
 
-    const oldGroup = items.value[id].group;
-    Object.assign(items.value[id], state);
-
-    if (state.group !== undefined) {
-      if (oldGroup && groups.value[oldGroup]) {
-        groups.value[oldGroup] = groups.value[oldGroup].filter((itemId) => itemId !== id);
-      }
-
-      if (state.group) {
-        if (!groups.value[state.group]) {
-          groups.value[state.group] = [];
-        }
-        if (!groups.value[state.group].includes(id)) {
-          groups.value[state.group].push(id);
-        }
-
-        if (state.syncDimensions) {
-          syncGroupDimensions(state.group, id);
-        }
-      }
-    }
+  const clickOnItem = (id: string) => {
+    if (items.value[id]?.fullScreen) return;
+    bringToFront(id);
   };
 
-  const syncGroupDimensions = (groupName: string, sourceId?: string) => {
-    const groupItems = groups.value[groupName];
-    if (!groupItems || groupItems.length < 2) return;
+  // --- fullscreen ----------------------------------------------------------
 
-    const referenceId = sourceId || groupItems[0];
-    const reference = items.value[referenceId];
-    if (!reference) return;
-
-    groupItems.forEach((id) => {
-      if (id !== referenceId && items.value[id]?.syncDimensions) {
-        items.value[id].width = reference.width;
-        items.value[id].height = reference.height;
-        saveItemState(id);
-      }
-    });
-  };
-
-  const arrangeItems = (arrangement: "cascade" | "tile" | "stack") => {
-    const visibleItems = Object.entries(items.value)
-      .filter(([, item]) => !item.fullScreen)
-      .sort((a, b) => a[1].zIndex - b[1].zIndex);
-
-    switch (arrangement) {
-      case "cascade": {
-        let offset = 0;
-        visibleItems.forEach(([id, item]) => {
-          item.left = 100 + offset;
-          item.top = 100 + offset;
-          item.stickynessPosition = "free";
-          offset += 30;
-          saveItemState(id);
-        });
-        break;
-      }
-
-      case "tile": {
-        const screenWidth = window.innerWidth;
-        const screenHeight = window.innerHeight;
-        const itemCount = visibleItems.length;
-        const cols = Math.ceil(Math.sqrt(itemCount));
-        const rows = Math.ceil(itemCount / cols);
-        const itemWidth = Math.floor(screenWidth / cols) - 20;
-        const itemHeight = Math.floor(screenHeight / rows) - 20;
-
-        visibleItems.forEach(([id, item], index) => {
-          const col = index % cols;
-          const row = Math.floor(index / cols);
-          item.left = col * (itemWidth + 10) + 10;
-          item.top = row * (itemHeight + 10) + 10;
-          item.width = itemWidth;
-          item.height = itemHeight;
-          item.stickynessPosition = "free";
-          saveItemState(id);
-        });
-        break;
-      }
-
-      case "stack": {
-        visibleItems.forEach(([id, item]) => {
-          item.left = 100;
-          item.top = 100;
-          item.stickynessPosition = "free";
-          saveItemState(id);
-        });
-        break;
-      }
-    }
-  };
-
-  const saveItemState = (id: string) => {
-    const existing = writeTimers.get(id);
-    if (existing) clearTimeout(existing);
-    writeTimers.set(
-      id,
-      setTimeout(() => {
-        writeTimers.delete(id);
-        persistItem(id);
-      }, SAVE_DEBOUNCE_MS),
-    );
-  };
-
-  // Flush a pending write immediately. Call from drag-stop / resize-stop so
-  // the final state is durable even if the user closes the tab in <250 ms.
-  const flushItemState = (id: string) => {
-    const existing = writeTimers.get(id);
-    if (existing) {
-      clearTimeout(existing);
-      writeTimers.delete(id);
-    }
-    persistItem(id);
-  };
-
-  const loadItemState = (id: string) => {
-    const savedState = localStorage.getItem(itemStorageKey(id));
-    if (savedState) {
-      try {
-        const state = JSON.parse(savedState);
-        // Clamp restored z-index to prevent inflated values from localStorage.
-        if (state.zIndex !== undefined && state.zIndex > MAX_Z_INDEX) {
-          state.zIndex = BASE_Z_INDEX;
-        }
-        setItemState(id, state);
-      } catch {
-        // Corrupted entry — drop it so next save overwrites cleanly.
-        localStorage.removeItem(itemStorageKey(id));
-      }
-    }
-
-    const savedGroups = localStorage.getItem(groupsStorageKey);
-    if (savedGroups) {
-      try {
-        const groupData = JSON.parse(savedGroups);
-        groups.value = groupData.groups || {};
-      } catch {
-        localStorage.removeItem(groupsStorageKey);
-      }
-    }
-  };
-
-  const applyPreset = (id: string, presetName: keyof typeof layoutPresets) => {
-    const preset = layoutPresets[presetName];
-    const updates: Partial<ItemLayout> = {};
-
-    if (preset.width === "100%") {
-      updates.width = window.innerWidth;
-      updates.fullWidth = true;
-    } else {
-      updates.width = preset.width as number;
-      updates.fullWidth = false;
-    }
-
-    if (preset.height === "100%") {
-      updates.height = window.innerHeight;
-      updates.fullHeight = true;
-    } else {
-      updates.height = preset.height as number;
-      updates.fullHeight = false;
-    }
-
-    setItemState(id, updates);
-    saveItemState(id);
+  const setFullScreen = (id: string, fullScreen: boolean) => {
+    const intent = items.value[id];
+    if (!intent || intent.fullScreen === fullScreen) return;
+    // Persisted, but sanitizeIntent resets it on load: fullscreen is transient
+    // view state whose driver (e.g. ExploreData) re-establishes it per session.
+    commitIntent(id, { ...intent, fullScreen });
   };
 
   const toggleFullScreen = (id: string) => {
-    if (!items.value[id]) return;
-    setFullScreen(id, !items.value[id].fullScreen);
+    const intent = items.value[id];
+    if (!intent) return;
+    setFullScreen(id, !intent.fullScreen);
   };
 
-  const setFullScreen = (id: string, fullScreen: boolean) => {
-    if (!items.value[id]) return;
+  // --- layout actions ------------------------------------------------------
 
-    if (items.value[id].fullScreen !== fullScreen) {
-      if (fullScreen) {
-        Object.keys(items.value).forEach((otherId) => {
-          if (otherId !== id) {
-            items.value[otherId].zIndex = 1;
-          }
+  const arrangeItems = (arrangement: "cascade" | "tile" | "stack") => {
+    const c = containerBounds.value;
+    const ids = Object.keys(items.value)
+      .filter((id) => !items.value[id].fullScreen)
+      .sort((a, b) => (zIndices.value[a] ?? 0) - (zIndices.value[b] ?? 0));
+
+    switch (arrangement) {
+      case "cascade": {
+        ids.forEach((id, index) => {
+          const intent = items.value[id];
+          commitIntent(id, {
+            dock: "free",
+            h: { ...intent.h, offset: 100 + index * 30, gap: null },
+            v: { ...intent.v, offset: 100 + index * 30, gap: null },
+            fullScreen: false,
+          });
         });
-
-        items.value[id].fullScreen = true;
-        items.value[id].prevWidth = items.value[id].width;
-        items.value[id].prevHeight = items.value[id].height;
-        items.value[id].prevLeft = items.value[id].left;
-        items.value[id].prevTop = items.value[id].top;
-
-        // Fill the canvas region (main element), not the viewport — panels
-        // are positioned inside <main> so width/height are container-relative.
-        const bounds = getCanvasBounds();
-        items.value[id].width = bounds.width;
-        items.value[id].height = bounds.height;
-        items.value[id].left = 0;
-        items.value[id].top = 0;
-        items.value[id].zIndex = FULLSCREEN_Z_INDEX;
-      } else {
-        items.value[id].fullScreen = false;
-        // ?? not || — a legitimately-saved 0 (panel flush at top/left) must not
-        // fall through to the default and shift the panel on restore.
-        items.value[id].width = items.value[id].prevWidth ?? 400;
-        items.value[id].height = items.value[id].prevHeight ?? 300;
-        items.value[id].left = items.value[id].prevLeft ?? 100;
-        items.value[id].top = items.value[id].prevTop ?? 100;
-
-        Object.keys(items.value).forEach((otherId) => {
-          items.value[otherId].zIndex = BASE_Z_INDEX;
-        });
+        break;
       }
-
-      flushItemState(id);
-      clickOnItem(id);
+      case "tile": {
+        const cols = Math.ceil(Math.sqrt(ids.length));
+        const rows = Math.ceil(ids.length / cols);
+        const itemWidth = Math.max(150, Math.floor(c.width / cols) - 20);
+        const itemHeight = Math.max(100, Math.floor(c.height / rows) - 20);
+        ids.forEach((id, index) => {
+          const col = index % cols;
+          const row = Math.floor(index / cols);
+          commitIntent(id, {
+            dock: "free",
+            h: { size: itemWidth, offset: col * (itemWidth + 10) + 10, gap: null },
+            v: { size: itemHeight, offset: row * (itemHeight + 10) + 10, gap: null },
+            fullScreen: false,
+          });
+        });
+        break;
+      }
+      case "stack": {
+        ids.forEach((id) => {
+          const intent = items.value[id];
+          commitIntent(id, {
+            dock: "free",
+            h: { ...intent.h, offset: 100, gap: null },
+            v: { ...intent.v, offset: 100, gap: null },
+            fullScreen: false,
+          });
+        });
+        break;
+      }
     }
-  };
-
-  const resetLayout = () => {
-    // Cancel any pending debounced writes — we're about to overwrite state.
-    writeTimers.forEach((timer) => clearTimeout(timer));
-    writeTimers.clear();
-
-    Object.keys(items.value).forEach((id) => {
-      localStorage.removeItem(itemStorageKey(id));
-    });
-
-    localStorage.removeItem(groupsStorageKey);
-
-    groups.value = {};
-
-    Object.keys(initialItemStates.value).forEach((id) => {
-      const initialState = initialItemStates.value[id];
-      if (!initialState) return;
-
-      const resetState: ItemLayout = {
-        width: initialState.width || 400,
-        height: initialState.height || 300,
-        left: initialState.left || 100,
-        top: initialState.top || 100,
-        stickynessPosition: initialState.stickynessPosition || "free",
-        fullWidth: initialState.fullWidth || false,
-        fullHeight: initialState.fullHeight || false,
-        zIndex: BASE_Z_INDEX,
-        fullScreen: false,
-        clicked: false,
-        group: initialState.group,
-        syncDimensions: initialState.syncDimensions,
-      };
-
-      items.value[id] = resetState;
-
-      if (resetState.group) {
-        if (!groups.value[resetState.group]) {
-          groups.value[resetState.group] = [];
-        }
-        if (!groups.value[resetState.group].includes(id)) {
-          groups.value[resetState.group].push(id);
-        }
-      }
-    });
-
-    // Emit a custom event to notify components to re-apply sticky positions
-    // This event should trigger each DraggableItem to call its applyStickyPosition method
-    setTimeout(() => {
-      window.dispatchEvent(
-        new CustomEvent("layout-reset", {
-          detail: { initialStates: initialItemStates.value },
-        }),
-      );
-    }, 0);
   };
 
   const resetSingleItem = (id: string) => {
-    const initialState = initialItemStates.value[id];
-    if (!initialState) {
-      console.warn(`No initial state found for item ${id}`);
-      return;
-    }
-
-    const pending = writeTimers.get(id);
-    if (pending) {
-      clearTimeout(pending);
-      writeTimers.delete(id);
-    }
-
-    localStorage.removeItem(itemStorageKey(id));
-
-    const resetState: ItemLayout = {
-      width: initialState.width || 400,
-      height: initialState.height || 300,
-      left: initialState.left || 100,
-      top: initialState.top || 100,
-      stickynessPosition: initialState.stickynessPosition || "free",
-      fullWidth: initialState.fullWidth || false,
-      fullHeight: initialState.fullHeight || false,
-      zIndex: items.value[id]?.zIndex || BASE_Z_INDEX,
-      fullScreen: false,
-      clicked: false,
-      group: initialState.group,
-      syncDimensions: initialState.syncDimensions,
-    };
-
-    items.value[id] = resetState;
-  };
-
-  const clickOnItem = (id: string) => {
-    if (!items.value[id] || items.value[id].fullScreen) return;
-
-    bringToFront(id);
-    idItemClicked.value = id;
-  };
-
-  const setResizing = (resizing: boolean) => {
-    inResizing.value = resizing;
-  };
-
-  const getResizing = () => {
-    return inResizing.value;
-  };
-
-  const scrollOnItem = (id: string) => {
-    const itemElement = document.getElementById(id);
-    if (!itemElement) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            idItemVisible.value = id;
-            bringToFront(id);
-          } else if (idItemVisible.value === id) {
-            items.value[id].zIndex = BASE_Z_INDEX;
-            idItemVisible.value = null;
-          }
-        });
-      },
-      {
-        threshold: 0.5,
-      },
-    );
-
-    observer.observe(itemElement);
-  };
-
-  const hasSavedState = (id: string): boolean => {
+    const cfg = panelConfigs.value[id];
+    if (!cfg) return;
     try {
-      return localStorage.getItem(itemStorageKey(id)) !== null;
+      localStorage.removeItem(intentStorageKey(id));
     } catch {
-      return false;
+      // Ignore.
     }
+    items.value[id] = defaultIntent(cfg);
+  };
+
+  const resetLayout = () => {
+    for (const id of Object.keys(panelConfigs.value)) {
+      resetSingleItem(id);
+    }
+    normalizeZIndices();
   };
 
   return {
-    inResizing,
     items,
-    groups,
-    layoutPresets,
-    initialItemStates,
-    registerInitialState,
-    setItemState,
-    saveItemState,
-    flushItemState,
-    loadItemState,
-    hasSavedState,
-    setResizing,
-    getResizing,
+    panelConfigs,
+    zIndices,
+    containerBounds,
+    inResizing,
+    registerContainer,
+    registerPanel,
+    commitIntent,
+    bringToFront,
+    zIndexFor,
     clickOnItem,
-    scrollOnItem,
-    idItemVisible,
-    toggleFullScreen,
     setFullScreen,
+    toggleFullScreen,
     arrangeItems,
-    syncGroupDimensions,
-    applyPreset,
-    getGroupItems,
     resetLayout,
     resetSingleItem,
-    bringToFront,
   };
 });

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/stateStore.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/stateStore.ts
@@ -29,6 +29,44 @@ const purgeLegacyKeys = () => {
   }
 };
 
+// One-time heal of geometry corrupted by an older build that persisted panel
+// sizes measured against a collapsed container (route-transition / unlaid-out
+// canvas). Such a panel is pinned at the code's floor constants — width 150
+// (clampStateToViewport) and height 100 (the "scale"-axis floor) — a size the
+// UI cannot otherwise produce (interactive resize floors at >100px, clamp floors
+// width at >=150). Drop only current-version keys matching that exact
+// fingerprint so the panel recomputes its initial size on next mount; every
+// other saved layout (positions, groups, non-corrupted sizes) is left intact.
+const CORRUPT_MAX_WIDTH = 150;
+const CORRUPT_MAX_HEIGHT = 100;
+const purgeCorruptedGeometry = () => {
+  try {
+    for (const key of Object.keys(localStorage)) {
+      if (!key.startsWith("overlayPositionAndSize") || !key.includes(`.v${STORAGE_VERSION}_`)) {
+        continue;
+      }
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      try {
+        const state = JSON.parse(raw);
+        if (
+          typeof state?.width === "number" &&
+          typeof state?.height === "number" &&
+          state.width <= CORRUPT_MAX_WIDTH &&
+          state.height <= CORRUPT_MAX_HEIGHT
+        ) {
+          localStorage.removeItem(key);
+        }
+      } catch {
+        // Corrupted JSON — drop it so a clean state is written next save.
+        localStorage.removeItem(key);
+      }
+    }
+  } catch {
+    // localStorage can throw in private mode / quota exhaustion — ignore.
+  }
+};
+
 // Looks up the canvas <main> element so fullscreen panels fill the canvas
 // region (not the viewport, which would overlap the page header).
 const getCanvasBounds = (): { width: number; height: number } => {
@@ -79,8 +117,10 @@ export interface ItemInitialState {
 }
 
 export const useItemStore = defineStore("itemStore", () => {
-  // Run-once cleanup of pre-v2 localStorage keys on first store instantiation.
+  // Run-once cleanup of pre-v2 localStorage keys on first store instantiation,
+  // then heal any panels a prior build collapsed to the floor constants.
   purgeLegacyKeys();
+  purgeCorruptedGeometry();
 
   const items = ref<Record<string, ItemLayout>>({});
   const initialItemStates = ref<Record<string, ItemInitialState>>({});

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/useDraggablePosition.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/useDraggablePosition.ts
@@ -1,0 +1,88 @@
+import { ref, type Ref } from "vue";
+
+import { POP_OUT_THRESHOLD_PX, type PanelDock, type RenderRect } from "./layoutGeometry";
+
+// Free panels keep the small jitter guard: a header dblclick (two mousedowns
+// + 1-2px cursor drift) must not register as a move.
+const FREE_DRAG_THRESHOLD_PX = 4;
+
+interface PositionOptions {
+  allowFreeMove: () => boolean;
+  gestureRect: Ref<RenderRect | null>;
+  getRect: () => RenderRect;
+  getDock: () => PanelDock;
+  onStart: () => void;
+  onCommit: (rect: RenderRect) => void;
+}
+
+// Header-drag gesture. Docked panels pop out only after a deliberate pull
+// (POP_OUT_THRESHOLD_PX); the commit handler decides whether the released
+// rect snaps back into a dock or becomes a free intent.
+export function useDraggablePosition(opts: PositionOptions) {
+  const isDragging = ref(false);
+  let dragActivated = false;
+  let startX = 0;
+  let startY = 0;
+  let anchorRect: RenderRect | null = null;
+  let anchorX = 0;
+  let anchorY = 0;
+
+  const startMove = (e: MouseEvent) => {
+    opts.onStart();
+    if (!opts.allowFreeMove()) return;
+    e.preventDefault();
+    const target = e.target as HTMLElement;
+    if (target.classList.contains("icon") || target.classList.contains("minimal-button")) {
+      return;
+    }
+    isDragging.value = true;
+    dragActivated = false;
+    startX = e.clientX;
+    startY = e.clientY;
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", stopMove);
+  };
+
+  const onMove = (e: MouseEvent) => {
+    if (!isDragging.value) return;
+    if (!dragActivated) {
+      const dx = Math.abs(e.clientX - startX);
+      const dy = Math.abs(e.clientY - startY);
+      const threshold = opts.getDock() !== "free" ? POP_OUT_THRESHOLD_PX : FREE_DRAG_THRESHOLD_PX;
+      if (dx < threshold && dy < threshold) return;
+      dragActivated = true;
+      // Anchor at activation so the panel doesn't jump by the threshold.
+      anchorRect = { ...opts.getRect() };
+      anchorX = e.clientX;
+      anchorY = e.clientY;
+      opts.gestureRect.value = { ...anchorRect };
+      return;
+    }
+    if (!anchorRect) return;
+    opts.gestureRect.value = {
+      ...anchorRect,
+      left: anchorRect.left + (e.clientX - anchorX),
+      top: anchorRect.top + (e.clientY - anchorY),
+    };
+  };
+
+  const stopMove = () => {
+    if (!isDragging.value) return;
+    isDragging.value = false;
+    document.removeEventListener("mousemove", onMove);
+    document.removeEventListener("mouseup", stopMove);
+    if (!dragActivated) return; // under-threshold: nothing changed
+    dragActivated = false;
+    anchorRect = null;
+    const rect = opts.gestureRect.value;
+    if (rect) opts.onCommit(rect);
+    opts.gestureRect.value = null;
+  };
+
+  const teardown = () => {
+    document.removeEventListener("mousemove", onMove);
+    document.removeEventListener("mouseup", stopMove);
+  };
+
+  return { isDragging, startMove, teardown };
+}

--- a/flowfile_frontend/src/renderer/app/components/common/DraggableItem/useDraggableResize.ts
+++ b/flowfile_frontend/src/renderer/app/components/common/DraggableItem/useDraggableResize.ts
@@ -1,0 +1,142 @@
+import { ref, type Ref } from "vue";
+
+import { MIN_PANEL_H, MIN_PANEL_W, type Bounds, type RenderRect } from "./layoutGeometry";
+
+export type ResizeEdge = "top" | "bottom" | "left" | "right";
+
+interface ResizeOptions {
+  gestureRect: Ref<RenderRect | null>;
+  getRect: () => RenderRect;
+  getBounds: () => Bounds;
+  // Gate: e.g. a fullscreen panel must not be resizable — its derived rect is
+  // view state, and committing it would overwrite the remembered layout.
+  isEnabled: () => boolean;
+  // Shared cross-panel flag: entering another panel's resize bar while a
+  // resize is in flight hands the gesture over (resizeOnEnter).
+  setSharedResizing: (value: boolean) => void;
+  isSharedResizing: () => boolean;
+  onStart: () => void;
+  onCommit: (rect: RenderRect) => void;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.max(min, Math.min(value, max));
+
+// Per-edge resize gestures. The gesture mutates only the shared gestureRect
+// (render-side override); intent is committed once, at mouseup.
+export function useDraggableResize(opts: ResizeOptions) {
+  const isResizing = ref(false);
+  const edge = ref<ResizeEdge | null>(null);
+  const activeLine = ref<HTMLElement | null>(null);
+  let start = { x: 0, y: 0, rect: { left: 0, top: 0, width: 0, height: 0 } as RenderRect };
+  let bounds: Bounds = { width: 0, height: 0 };
+  let hoverDelay: ReturnType<typeof setTimeout> | null = null;
+  let moved = false;
+
+  const beginResize = (e: MouseEvent, which: ResizeEdge) => {
+    opts.onStart();
+    if (!opts.isEnabled()) return;
+    e.preventDefault();
+    moved = false;
+    activeLine.value = e.target as HTMLElement;
+    activeLine.value.classList.add("resizing-highlight-line");
+    isResizing.value = true;
+    opts.setSharedResizing(true);
+    edge.value = which;
+    // Container can't change mid-drag; reading it per-mousemove would reflow.
+    bounds = opts.getBounds();
+    start = { x: e.clientX, y: e.clientY, rect: { ...opts.getRect() } };
+    opts.gestureRect.value = { ...start.rect };
+    document.addEventListener("mousemove", onResizeMove);
+    document.addEventListener("mouseup", stopResize);
+  };
+
+  const onResizeMove = (e: MouseEvent) => {
+    if (!isResizing.value) return;
+    const dx = e.clientX - start.x;
+    const dy = e.clientY - start.y;
+    const rect = { ...start.rect };
+    switch (edge.value) {
+      case "right":
+        rect.width = clamp(
+          start.rect.width + dx,
+          MIN_PANEL_W,
+          Math.max(MIN_PANEL_W, bounds.width - start.rect.left),
+        );
+        break;
+      case "bottom":
+        rect.height = clamp(
+          start.rect.height + dy,
+          MIN_PANEL_H,
+          Math.max(MIN_PANEL_H, bounds.height - start.rect.top),
+        );
+        break;
+      case "left": {
+        // Keep the right edge fixed.
+        const rightEdge = start.rect.left + start.rect.width;
+        rect.width = clamp(start.rect.width - dx, MIN_PANEL_W, Math.max(MIN_PANEL_W, rightEdge));
+        rect.left = rightEdge - rect.width;
+        break;
+      }
+      case "top": {
+        // Keep the bottom edge fixed.
+        const bottomEdge = start.rect.top + start.rect.height;
+        rect.height = clamp(start.rect.height - dy, MIN_PANEL_H, Math.max(MIN_PANEL_H, bottomEdge));
+        rect.top = bottomEdge - rect.height;
+        break;
+      }
+    }
+    if (
+      rect.left !== start.rect.left ||
+      rect.top !== start.rect.top ||
+      rect.width !== start.rect.width ||
+      rect.height !== start.rect.height
+    ) {
+      moved = true;
+    }
+    opts.gestureRect.value = rect;
+  };
+
+  const stopResize = () => {
+    if (!isResizing.value) return;
+    isResizing.value = false;
+    edge.value = null;
+    activeLine.value?.classList.remove("resizing-highlight-line");
+    activeLine.value = null;
+    opts.setSharedResizing(false);
+    document.removeEventListener("mousemove", onResizeMove);
+    document.removeEventListener("mouseup", stopResize);
+    const rect = opts.gestureRect.value;
+    opts.gestureRect.value = null;
+    // A zero-move click is not a gesture: committing it would freeze derived
+    // defaults into explicit intent (and break dblclick-fullscreen, whose two
+    // clicks would each commit the fullscreen rect as layout).
+    if (rect && moved) opts.onCommit(rect);
+    moved = false;
+  };
+
+  const resizeOnEnter = (e: MouseEvent, which: ResizeEdge) => {
+    if (hoverDelay) clearTimeout(hoverDelay);
+    hoverDelay = setTimeout(() => {
+      if (opts.isSharedResizing() && !isResizing.value) {
+        beginResize(e, which);
+      }
+    }, 200);
+  };
+
+  const teardown = () => {
+    if (hoverDelay) clearTimeout(hoverDelay);
+    // Unmount mid-gesture: the store-wide flag outlives this component and
+    // would otherwise arm phantom hover-started resizes on other panels.
+    if (isResizing.value) {
+      isResizing.value = false;
+      activeLine.value?.classList.remove("resizing-highlight-line");
+      activeLine.value = null;
+      opts.setSharedResizing(false);
+    }
+    document.removeEventListener("mousemove", onResizeMove);
+    document.removeEventListener("mouseup", stopResize);
+  };
+
+  return { isResizing, beginResize, resizeOnEnter, stopResize, teardown };
+}

--- a/flowfile_frontend/src/renderer/app/types/drawer.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/drawer.types.ts
@@ -1,5 +1,5 @@
 import type { Component } from "vue";
-import type { AxisBehaviour } from "../components/common/DraggableItem/stateStore";
+import type { AxisBehaviour } from "../components/common/DraggableItem/layoutGeometry";
 import type { useEditorStore } from "../stores/editor-store";
 import type { useNodeStore } from "../stores/column-store";
 import type { useFlowStore } from "../stores/flow-store";
@@ -12,12 +12,6 @@ export interface DrawerCtx {
   node: ReturnType<typeof useNodeStore>;
   flow: ReturnType<typeof useFlowStore>;
   drawer: ReturnType<typeof useDrawerStore>;
-}
-
-// The minimal {id,label} shape DraggableItem renders in its header strip.
-export interface DrawerTab {
-  id: string;
-  label: string;
 }
 
 export interface DrawerTabDef {
@@ -35,10 +29,9 @@ export interface DrawerTabDef {
 export interface DrawerDef {
   id: string; // DraggableItem id + localStorage + bringToFront key
   side: "right" | "bottom";
+  // Default sizes/offsets beyond the width come from Canvas overrides (height
+  // tiling, palette-adjacent left), so only the width is registry data.
   initialWidth?: number;
-  initialHeight?: number;
-  initialLeft?: number;
-  initialTop?: number;
   widthBehaviour?: AxisBehaviour;
   heightBehaviour?: AxisBehaviour;
   allowFullScreen?: boolean;

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
@@ -95,10 +95,10 @@ interface FlowNodeData {
 }
 
 const itemStore = useItemStore();
-// Tracks the live height of the canvas <main> element. Driven by ResizeObserver
-// in onMounted so derived heights (table preview, node settings) stay in sync
-// with the actual canvas region instead of a stale window.innerHeight snapshot.
-const availableHeight = ref(window.innerHeight - 50);
+// Live height of the canvas <main> element, from the store's shared container
+// measurement (registered in onMounted). Falls back to the window while the
+// container is unmeasured (first frame).
+const availableHeight = computed(() => itemStore.containerBounds.height || window.innerHeight - 50);
 const nodeStore = useNodeStore();
 const editorStore = useEditorStore();
 const flowStore = useFlowStore();
@@ -256,16 +256,26 @@ const {
 } = useDragAndDrop();
 const { groupSelectedNodes, removeSelectedFromGroup, persistDrag } = useNodeGroups();
 // Default drawer sizing. The bottom dock takes ~25% of the canvas height; the
-// right-side drawers fill from their top gap (def.initialTop) down to just above
-// the dock, so the two tile the right column without overlap. DraggableItem
-// reads these once on mount (and on Reset Layout); the user resizes from there.
+// right-side drawers span from the canvas top down to the dock, so the two
+// tile the right column without overlap. These are reactive DEFAULTS — they
+// apply until the user commits an explicit size (then intent wins).
 const tablePreviewHeight = computed(() => Math.max(120, Math.floor(availableHeight.value * 0.25)));
 const drawerHeightOverride = (d: DrawerDef): number | undefined => {
   if (d.id === "bottomDock") return tablePreviewHeight.value;
   if (d.side === "right")
-    return Math.max(200, availableHeight.value - tablePreviewHeight.value - (d.initialTop ?? 0));
+    return Math.max(200, availableHeight.value - tablePreviewHeight.value);
   return undefined;
 };
+const DATA_ACTIONS_WIDTH = 230;
+// The bottom dock starts right next to the docked palette, tracking its live
+// width (only while the user hasn't chosen an explicit dock offset).
+const dataActionsWidth = computed(() => {
+  const intent = itemStore.items["dataActions"];
+  if (!intent || intent.dock !== "left") return 0;
+  return intent.h.size ?? DATA_ACTIONS_WIDTH;
+});
+const drawerLeftOverride = (d: DrawerDef): number | undefined =>
+  d.id === "bottomDock" ? dataActionsWidth.value : undefined;
 const showContextMenu = ref(false);
 const clickedPosition = ref<CursorPosition>({ x: 0, y: 0 });
 const contextMenuTarget = ref({ type: "pane", id: "" });
@@ -1190,19 +1200,14 @@ const handleMoveEnd = () => {
   saveViewportToSession();
 };
 
-let mainResizeObserver: ResizeObserver | null = null;
+let unregisterContainer: (() => void) | null = null;
 let unlistenViewZoom: (() => void) | null = null;
 
 onMounted(async () => {
   if (mainContainerRef.value) {
-    availableHeight.value = mainContainerRef.value.clientHeight;
-    mainResizeObserver = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (entry) {
-        availableHeight.value = entry.contentRect.height;
-      }
-    });
-    mainResizeObserver.observe(mainContainerRef.value);
+    // Single shared container measurement for every overlay panel (and the
+    // derived drawer heights above).
+    unregisterContainer = itemStore.registerContainer(mainContainerRef.value);
   }
   window.addEventListener("keydown", handleKeyDown);
   document.addEventListener("copy", handleCopyEvent);
@@ -1317,8 +1322,8 @@ onUnmounted(() => {
   document.removeEventListener("paste", handlePasteEvent);
   unlistenViewZoom?.();
   unlistenViewZoom = null;
-  mainResizeObserver?.disconnect();
-  mainResizeObserver = null;
+  unregisterContainer?.();
+  unregisterContainer = null;
   cancelEdgeLeave();
 });
 
@@ -1387,7 +1392,7 @@ defineExpose({
       <draggable-item
         id="dataActions"
         :show-left="true"
-        :initial-width="230"
+        :initial-width="DATA_ACTIONS_WIDTH"
         initial-position="left"
         height-behaviour="scale"
         title="Data actions"
@@ -1400,6 +1405,7 @@ defineExpose({
         :key="d.id"
         :def="d"
         :height-override="drawerHeightOverride(d)"
+        :left-override="drawerLeftOverride(d)"
       />
       <AiCommandPalette />
       <layoutControls @reset-layout-graph="handleResetLayoutGraph" />

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/TabbedDrawer.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/TabbedDrawer.vue
@@ -11,6 +11,7 @@ import type { DrawerDef, DrawerCtx } from "../../types/drawer.types";
 const props = defineProps<{
   def: DrawerDef;
   heightOverride?: number;
+  leftOverride?: number;
 }>();
 
 const itemStore = useItemStore();
@@ -80,9 +81,8 @@ const onMinimize = () => props.def.onMinimize?.(ctx);
     :show-bottom="def.side === 'bottom'"
     :initial-position="def.side"
     :initial-width="def.initialWidth"
-    :initial-height="heightOverride ?? def.initialHeight"
-    :initial-left="def.initialLeft"
-    :initial-top="def.initialTop"
+    :initial-height="heightOverride"
+    :initial-left="leftOverride"
     :width-behaviour="def.widthBehaviour"
     :height-behaviour="def.heightBehaviour"
     :allow-full-screen="def.allowFullScreen ?? true"

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/designerHelp.ts
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/designerHelp.ts
@@ -13,17 +13,20 @@ export const designerHelp: PageHelpContent = {
         {
           icon: "fa-solid fa-plus-circle",
           title: "Add Nodes",
-          description: "Right-click the canvas or drag from the node panel to add transformation steps",
+          description:
+            "Right-click the canvas or drag from the node panel to add transformation steps",
         },
         {
           icon: "fa-solid fa-link",
           title: "Connect Nodes",
-          description: "Drag from an output handle to an input handle to define data flow between steps",
+          description:
+            "Drag from an output handle to an input handle to define data flow between steps",
         },
         {
           icon: "fa-solid fa-play",
           title: "Run Flows",
-          description: "Execute the entire flow or run individual nodes to preview intermediate results",
+          description:
+            "Execute the entire flow or run individual nodes to preview intermediate results",
         },
         {
           icon: "fa-solid fa-floppy-disk",
@@ -50,7 +53,8 @@ export const designerHelp: PageHelpContent = {
         {
           type: "warning",
           title: "Connect nodes before running",
-          description: "Unconnected nodes won't receive data. Make sure your pipeline is fully wired.",
+          description:
+            "Unconnected nodes won't receive data. Make sure your pipeline is fully wired.",
         },
       ],
     },

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/drawerRegistry.ts
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/drawerRegistry.ts
@@ -14,10 +14,9 @@ export const drawers: DrawerDef[] = [
     id: "rightDrawer",
     side: "right",
     initialWidth: 600,
-    // Small top gap so the drawer starts near the top (not the generic 100px
-    // free-panel default); Canvas derives its default height from this.
-    initialTop: 8,
     // Fixed width; height tracks the canvas (keeps its gap) instead of filling.
+    // Flush to the canvas top; Canvas derives its default height so the bottom
+    // edge meets the bottom dock.
     heightBehaviour: "scale",
     allowFullScreen: true,
     // Opens for settings / results / code; Code is then always a tab (its own
@@ -64,7 +63,6 @@ export const drawers: DrawerDef[] = [
     id: "aiDrawer",
     side: "right",
     initialWidth: 600,
-    initialTop: 8,
     heightBehaviour: "scale",
     allowFullScreen: true,
     onMinimize: ({ editor }) => editor.closeAiDrawer(),
@@ -80,8 +78,9 @@ export const drawers: DrawerDef[] = [
   {
     id: "bottomDock",
     side: "bottom",
-    initialLeft: 180,
-    // Width tracks the canvas (keeps its gap); height stays fixed px.
+    // Width tracks the canvas (keeps its gap); height stays fixed px. The
+    // left default comes from Canvas (the live width of the docked palette),
+    // so the dock starts right next to Data actions.
     widthBehaviour: "scale",
     allowFullScreen: true,
     // Opens for a data preview or logs; Data is a permanent home tab (placeholder).

--- a/flowfile_frontend/tests/canvas-overlays.spec.ts
+++ b/flowfile_frontend/tests/canvas-overlays.spec.ts
@@ -9,7 +9,10 @@ import { test, expect, APIRequestContext } from "@playwright/test";
  *  - Double-click on a panel's resize bar toggles fullscreen.
  *  - Double-click on the empty canvas pane hides all right-side and bottom
  *    panels (left palette stays visible).
- *  - localStorage uses the v3 storage key prefix.
+ *  - localStorage stores v4 intent records (user gestures only); legacy v3
+ *    geometry records are migrated or healed at panel registration.
+ *  - Docked panels resize via their splitter edges and only undock through a
+ *    deliberate pop-out drag; releasing near an edge snaps back into the dock.
  *
  * Prerequisites (web mode):
  *   1. Backend: `poetry run flowfile_core` (port 63578)
@@ -33,20 +36,49 @@ async function authPost(request: APIRequestContext, url: string, token: string) 
   return request.post(url, { headers: { Authorization: `Bearer ${token}` } });
 }
 
-// Inject auth into localStorage before navigating so the SPA boots authed.
-async function navigateWithAuth(page: any, token: string, targetUrl: string) {
+// Inject auth (and optional seeded localStorage entries, e.g. legacy panel
+// geometry) before navigating so the SPA boots against them.
+async function navigateWithAuth(
+  page: any,
+  token: string,
+  targetUrl: string,
+  seed: Record<string, string> = {},
+) {
   await page.goto(targetUrl);
   await page.waitForLoadState("networkidle");
   const expirationTime = Date.now() + 60 * 60 * 1000;
   await page.evaluate(
-    ({ token, expiration }: { token: string; expiration: number }) => {
+    ({
+      token,
+      expiration,
+      seed,
+    }: {
+      token: string;
+      expiration: number;
+      seed: Record<string, string>;
+    }) => {
       localStorage.setItem("auth_token", token);
       localStorage.setItem("auth_token_expiration", expiration.toString());
+      for (const [key, value] of Object.entries(seed)) {
+        localStorage.setItem(key, value);
+      }
     },
-    { token, expiration: expirationTime },
+    { token, expiration: expirationTime, seed },
   );
   await page.reload();
   await page.waitForLoadState("networkidle");
+}
+
+// Drag from the center of a locator by (dx, dy) with real mouse events.
+async function dragBy(page: any, locator: any, dx: number, dy: number) {
+  const box = await locator.boundingBox();
+  if (!box) throw new Error("dragBy: element has no bounding box");
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x + dx, y + dy, { steps: 12 });
+  await page.mouse.up();
 }
 
 test.describe("Canvas Overlay Behaviour", () => {
@@ -101,16 +133,18 @@ test.describe("Canvas Overlay Behaviour", () => {
     }
   });
 
-  test("storage uses v3 key prefix and purges legacy keys", async ({ page }) => {
+  test("storage uses v4 key prefix and purges legacy keys", async ({ page }) => {
     await navigateWithAuth(page, authToken, BASE_URL);
     await page.waitForSelector("main", { timeout: 10000 });
 
-    // The store purges older-version keys at init. Every panel-position key the
-    // app writes must carry the current `.v3_` infix — no legacy underscore keys
-    // and no stale `.v2_` keys remain.
+    // The store purges pre-v3 keys (and all group keys) at init; v3 records
+    // are only kept for the one-time migration at panel registration. Any
+    // panel-position key must therefore carry the `.v4_` or `.v3_` infix.
     const staleKeys = await page.evaluate(() => {
       return Object.keys(localStorage).filter(
-        (k) => k.startsWith("overlayPositionAndSize") && !k.includes(".v3_"),
+        (k) =>
+          (k.startsWith("overlayPositionAndSize") && !k.includes(".v4_") && !k.includes(".v3_")) ||
+          k.startsWith("overlayGroups"),
       );
     });
     expect(staleKeys).toEqual([]);
@@ -140,20 +174,15 @@ test.describe("Canvas Overlay Behaviour", () => {
     expect(cssPosition).toBe("absolute");
   });
 
-  test("floating panel does not persist a collapsed size when the canvas transiently shrinks", async ({
+  test("container changes never write storage and panels recover from a transient shrink", async ({
     page,
     request,
   }) => {
-    // Regression guard for the panel-collapse bug: geometry recompute
-    // (applyStickyPosition / clampStateToViewport) used to run against a
-    // transiently-tiny container — as happens during a route unmount/remount or
-    // any brief canvas shrink — and PERSIST the collapse to the floor constants
-    // (width 150 / height 100), so panels stayed shrunken after the canvas grew
-    // back. A viewport shrink is the deterministic form of that transient: it
-    // drives <main> below the usable threshold, then restores it. With the fix
-    // the recompute bails on the unusable container and the panel keeps its
-    // size; without it, dataActions' fixed-width axis collapses and never
-    // recovers.
+    // The structural invariant of the intent/derived split: persisted state
+    // only changes on user gestures. A transient container collapse (route
+    // remount, window-state restore, viewport shrink) may briefly clamp the
+    // RENDERED rect but must leave localStorage untouched, and the panel must
+    // return to its exact geometry once the container recovers.
     const flowName = `Overlay_Transient_Shrink_${Date.now()}`;
     const createResponse = await authPost(
       request,
@@ -171,41 +200,294 @@ test.describe("Canvas Overlay Behaviour", () => {
       await flowTab.first().waitFor({ state: "visible", timeout: 10000 });
       await flowTab.first().click();
 
-      // dataActions is the always-rendered left palette; its width is fixed
-      // (initialWidth 230), so a collapse to the ~150 floor cannot recover once
-      // the canvas grows back — a clean, stable signal.
+      // dataActions is the always-rendered left palette (fixed width 230).
       await page.waitForSelector("#dataActions", { timeout: 10000 });
 
-      // Read the stored geometry off the inline style (itemState.width/height) —
-      // that is what the user saw collapse, not the CSS-capped offsetWidth.
       const readWidth = () =>
         page.evaluate(() => {
           const el = document.getElementById("dataActions");
           return el ? parseFloat(el.style.width) : NaN;
         });
+      const readStored = () =>
+        page.evaluate(() =>
+          Object.keys(localStorage)
+            .filter((k) => k.startsWith("overlayPositionAndSize"))
+            .sort()
+            .map((k) => `${k}=${localStorage.getItem(k)}`)
+            .join("|"),
+        );
 
-      // Settle at the real (non-collapsed) width before shrinking.
       await expect.poll(readWidth, { timeout: 10000 }).toBeGreaterThanOrEqual(200);
-      const before = await readWidth();
+      const widthBefore = await readWidth();
+      const storedBefore = await readStored();
 
-      // Collapse the canvas well below the usable threshold, let the resize
-      // handlers run + debounced persist flush, then restore it.
+      // Collapse the canvas well below the usable threshold, then restore it.
       await page.setViewportSize({ width: 150, height: 120 });
       await page.waitForTimeout(600);
       await page.setViewportSize({ width: 1280, height: 800 });
       await page.waitForTimeout(600);
 
-      const after = await readWidth();
-      // Width must survive the transient (fixed axis never recovers if collapsed).
-      expect(after).toBeGreaterThanOrEqual(before - 20);
+      // Exact recovery — derived geometry, nothing accumulated.
+      expect(await readWidth()).toBe(widthBefore);
+      // Byte-identical storage — container changes are not gestures.
+      expect(await readStored()).toBe(storedBefore);
+    } finally {
+      await authPost(request, `${API_URL}/editor/close_flow/?flow_id=${flowId}`, authToken);
+    }
+  });
 
-      // And the persisted geometry must not carry the collapse fingerprint.
-      const persisted = await page.evaluate(() => {
-        const raw = localStorage.getItem("overlayPositionAndSize.v3_dataActions");
+  test("a corrupted legacy v3 record heals to defaults at panel registration", async ({
+    page,
+    request,
+  }) => {
+    // Users who hit the historical collapse bug have records like
+    // {width:150,height:100,top:0,left:464} in localStorage. Migration must
+    // reject the fingerprint, drop the v3 key, and render the panel at its
+    // default geometry.
+    const flowName = `Overlay_Self_Heal_${Date.now()}`;
+    const createResponse = await authPost(
+      request,
+      `${API_URL}/editor/create_flow/?name=${flowName}`,
+      authToken,
+    );
+    expect(createResponse.ok()).toBe(true);
+    const flowId = await createResponse.json();
+
+    try {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await navigateWithAuth(page, authToken, `${BASE_URL}/#/designer/${flowId}`, {
+        "overlayPositionAndSize.v3_dataActions": JSON.stringify({
+          width: 150,
+          height: 100,
+          left: 464,
+          top: 0,
+          stickynessPosition: "free",
+          fullWidth: false,
+          fullHeight: false,
+          zIndex: 105,
+          fullScreen: false,
+          clicked: false,
+        }),
+      });
+      await page.waitForSelector("main", { timeout: 10000 });
+      const flowTab = page.getByText(flowName, { exact: true });
+      await flowTab.first().waitFor({ state: "visible", timeout: 10000 });
+      await flowTab.first().click();
+      await page.waitForSelector("#dataActions", { timeout: 10000 });
+
+      // Healed: default docked-left geometry, not the seeded 150x100 float.
+      const readRect = () =>
+        page.evaluate(() => {
+          const el = document.getElementById("dataActions");
+          return el ? { left: parseFloat(el.style.left), width: parseFloat(el.style.width) } : null;
+        });
+      await expect
+        .poll(async () => (await readRect())?.width ?? NaN, { timeout: 10000 })
+        .toBeGreaterThanOrEqual(200);
+      expect((await readRect())?.left).toBe(0);
+
+      const keys = await page.evaluate(() => ({
+        v3: localStorage.getItem("overlayPositionAndSize.v3_dataActions"),
+        v4: localStorage.getItem("overlayPositionAndSize.v4_dataActions"),
+      }));
+      expect(keys.v3).toBeNull();
+      // Rejected records fall back to defaults without writing a v4 record.
+      expect(keys.v4).toBeNull();
+    } finally {
+      await authPost(request, `${API_URL}/editor/close_flow/?flow_id=${flowId}`, authToken);
+    }
+  });
+
+  test("splitter resize persists intent and survives a reload", async ({ page, request }) => {
+    const flowName = `Overlay_Resize_Persist_${Date.now()}`;
+    const createResponse = await authPost(
+      request,
+      `${API_URL}/editor/create_flow/?name=${flowName}`,
+      authToken,
+    );
+    expect(createResponse.ok()).toBe(true);
+    const flowId = await createResponse.json();
+
+    try {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await navigateWithAuth(page, authToken, `${BASE_URL}/#/designer/${flowId}`);
+      await page.waitForSelector("main", { timeout: 10000 });
+      const flowTab = page.getByText(flowName, { exact: true });
+      await flowTab.first().waitFor({ state: "visible", timeout: 10000 });
+      await flowTab.first().click();
+      await page.waitForSelector("#dataActions", { timeout: 10000 });
+
+      const readWidth = () =>
+        page.evaluate(() => {
+          const el = document.getElementById("dataActions");
+          return el ? parseFloat(el.style.width) : NaN;
+        });
+      await expect.poll(readWidth, { timeout: 10000 }).toBeGreaterThanOrEqual(200);
+      const widthBefore = await readWidth();
+
+      // Drag the palette's right splitter 60px outward.
+      await dragBy(page, page.locator("#dataActions .draggable-line.right-vertical"), 60, 0);
+
+      await expect.poll(readWidth).toBeGreaterThanOrEqual(widthBefore + 50);
+      const widthAfter = await readWidth();
+
+      const intent = await page.evaluate(() => {
+        const raw = localStorage.getItem("overlayPositionAndSize.v4_dataActions");
         return raw ? JSON.parse(raw) : null;
       });
-      expect(persisted).not.toBeNull();
-      expect(persisted.width > 150 || persisted.height > 100).toBe(true);
+      expect(intent).not.toBeNull();
+      expect(intent.dock).toBe("left");
+      expect(Math.abs(intent.h.size - widthAfter)).toBeLessThanOrEqual(2);
+
+      // The committed intent must survive a full reload.
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+      await page.waitForSelector("main", { timeout: 10000 });
+      const flowTabAfter = page.getByText(flowName, { exact: true });
+      await flowTabAfter.first().waitFor({ state: "visible", timeout: 10000 });
+      await flowTabAfter.first().click();
+      await page.waitForSelector("#dataActions", { timeout: 10000 });
+      await expect.poll(readWidth, { timeout: 10000 }).toBe(widthAfter);
+    } finally {
+      await authPost(request, `${API_URL}/editor/close_flow/?flow_id=${flowId}`, authToken);
+    }
+  });
+
+  test("docked panels pop out only deliberately and snap back into the dock", async ({
+    page,
+    request,
+  }) => {
+    const flowName = `Overlay_Dock_Policy_${Date.now()}`;
+    const createResponse = await authPost(
+      request,
+      `${API_URL}/editor/create_flow/?name=${flowName}`,
+      authToken,
+    );
+    expect(createResponse.ok()).toBe(true);
+    const flowId = await createResponse.json();
+
+    try {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await navigateWithAuth(page, authToken, `${BASE_URL}/#/designer/${flowId}`);
+      await page.waitForSelector("main", { timeout: 10000 });
+      const flowTab = page.getByText(flowName, { exact: true });
+      await flowTab.first().waitFor({ state: "visible", timeout: 10000 });
+      await flowTab.first().click();
+      await page.waitForSelector("#dataActions", { timeout: 10000 });
+
+      const readState = () =>
+        page.evaluate(() => {
+          const el = document.getElementById("dataActions");
+          const raw = localStorage.getItem("overlayPositionAndSize.v4_dataActions");
+          return {
+            left: el ? parseFloat(el.style.left) : NaN,
+            dock: raw ? JSON.parse(raw).dock : null,
+          };
+        });
+      const title = page.locator("#dataActions .dragitem-tab--static");
+
+      // A sub-threshold header drag (20px < 48px pop-out) must be a no-op:
+      // the panel stays docked and nothing is persisted.
+      await dragBy(page, title, 20, 20);
+      let state = await readState();
+      expect(state.left).toBe(0);
+      expect(state.dock).toBeNull();
+
+      // A deliberate pull past the threshold pops the panel out to free mode.
+      await dragBy(page, title, 300, 150);
+      await expect.poll(async () => (await readState()).dock).toBe("free");
+      state = await readState();
+      expect(state.left).toBeGreaterThan(40);
+
+      // Releasing with the panel edge inside the snap zone re-docks it.
+      const currentLeft = state.left;
+      await dragBy(page, title, -(currentLeft - 10), 0);
+      await expect.poll(async () => (await readState()).dock).toBe("left");
+      expect((await readState()).left).toBe(0);
+    } finally {
+      await authPost(request, `${API_URL}/editor/close_flow/?flow_id=${flowId}`, authToken);
+    }
+  });
+
+  test("fullscreen round-trips without disturbing panel geometry", async ({ page, request }) => {
+    const flowName = `Overlay_Fullscreen_${Date.now()}`;
+    const createResponse = await authPost(
+      request,
+      `${API_URL}/editor/create_flow/?name=${flowName}`,
+      authToken,
+    );
+    expect(createResponse.ok()).toBe(true);
+    const flowId = await createResponse.json();
+
+    try {
+      const addNodeResponse = await authPost(
+        request,
+        `${API_URL}/editor/add_node/?flow_id=${flowId}&node_id=1&node_type=python_script&pos_x=600&pos_y=300`,
+        authToken,
+      );
+      expect(addNodeResponse.ok()).toBe(true);
+
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await navigateWithAuth(page, authToken, `${BASE_URL}/#/designer/${flowId}`);
+      await page.waitForSelector("main", { timeout: 10000 });
+      const flowTab = page.getByText(flowName, { exact: true });
+      await flowTab.first().waitFor({ state: "visible", timeout: 10000 });
+      await flowTab.first().click();
+
+      const node = page.locator('.vue-flow__node[data-id="1"]');
+      await node.waitFor({ state: "visible", timeout: 10000 });
+      await node.dblclick();
+      await page.waitForSelector("#rightDrawer", { timeout: 10000 });
+
+      const readRect = () =>
+        page.evaluate(() => {
+          const el = document.getElementById("rightDrawer");
+          return el
+            ? {
+                left: parseFloat(el.style.left),
+                top: parseFloat(el.style.top),
+                width: parseFloat(el.style.width),
+                height: parseFloat(el.style.height),
+              }
+            : null;
+        });
+      await expect
+        .poll(async () => (await readRect())?.width ?? NaN, { timeout: 10000 })
+        .toBeGreaterThanOrEqual(300);
+      const rectBefore = await readRect();
+
+      const mainSize = await page.evaluate(() => {
+        const main = document.querySelector("main");
+        return main ? { width: main.clientWidth, height: main.clientHeight } : null;
+      });
+
+      // Header dblclick toggles fullscreen: the drawer fills the canvas <main>.
+      const header = page.locator("#rightDrawer .header");
+      await header.dblclick();
+      await expect
+        .poll(async () => (await readRect())?.width ?? NaN, { timeout: 5000 })
+        .toBe(mainSize!.width);
+      expect((await readRect())?.height).toBe(mainSize!.height);
+
+      // And back out — the exact pre-fullscreen rect returns (intent untouched).
+      await header.dblclick();
+      await expect
+        .poll(async () => (await readRect())?.width ?? NaN, { timeout: 5000 })
+        .toBe(rectBefore!.width);
+      expect(await readRect()).toEqual(rectBefore);
+
+      // Resize-bar dblclick must round-trip too: its zero-move clicks commit
+      // nothing, so exiting restores the same rect instead of a canvas-wide one.
+      const bar = page.locator("#rightDrawer .draggable-line.left-vertical");
+      await bar.dblclick();
+      await expect
+        .poll(async () => (await readRect())?.width ?? NaN, { timeout: 5000 })
+        .toBe(mainSize!.width);
+      await bar.dblclick();
+      await expect
+        .poll(async () => (await readRect())?.width ?? NaN, { timeout: 5000 })
+        .toBe(rectBefore!.width);
+      expect(await readRect()).toEqual(rectBefore);
     } finally {
       await authPost(request, `${API_URL}/editor/close_flow/?flow_id=${flowId}`, authToken);
     }

--- a/flowfile_frontend/tests/canvas-overlays.spec.ts
+++ b/flowfile_frontend/tests/canvas-overlays.spec.ts
@@ -140,6 +140,77 @@ test.describe("Canvas Overlay Behaviour", () => {
     expect(cssPosition).toBe("absolute");
   });
 
+  test("floating panel does not persist a collapsed size when the canvas transiently shrinks", async ({
+    page,
+    request,
+  }) => {
+    // Regression guard for the panel-collapse bug: geometry recompute
+    // (applyStickyPosition / clampStateToViewport) used to run against a
+    // transiently-tiny container — as happens during a route unmount/remount or
+    // any brief canvas shrink — and PERSIST the collapse to the floor constants
+    // (width 150 / height 100), so panels stayed shrunken after the canvas grew
+    // back. A viewport shrink is the deterministic form of that transient: it
+    // drives <main> below the usable threshold, then restores it. With the fix
+    // the recompute bails on the unusable container and the panel keeps its
+    // size; without it, dataActions' fixed-width axis collapses and never
+    // recovers.
+    const flowName = `Overlay_Transient_Shrink_${Date.now()}`;
+    const createResponse = await authPost(
+      request,
+      `${API_URL}/editor/create_flow/?name=${flowName}`,
+      authToken,
+    );
+    expect(createResponse.ok()).toBe(true);
+    const flowId = await createResponse.json();
+
+    try {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await navigateWithAuth(page, authToken, `${BASE_URL}/#/designer/${flowId}`);
+      await page.waitForSelector("main", { timeout: 10000 });
+      const flowTab = page.getByText(flowName, { exact: true });
+      await flowTab.first().waitFor({ state: "visible", timeout: 10000 });
+      await flowTab.first().click();
+
+      // dataActions is the always-rendered left palette; its width is fixed
+      // (initialWidth 230), so a collapse to the ~150 floor cannot recover once
+      // the canvas grows back — a clean, stable signal.
+      await page.waitForSelector("#dataActions", { timeout: 10000 });
+
+      // Read the stored geometry off the inline style (itemState.width/height) —
+      // that is what the user saw collapse, not the CSS-capped offsetWidth.
+      const readWidth = () =>
+        page.evaluate(() => {
+          const el = document.getElementById("dataActions");
+          return el ? parseFloat(el.style.width) : NaN;
+        });
+
+      // Settle at the real (non-collapsed) width before shrinking.
+      await expect.poll(readWidth, { timeout: 10000 }).toBeGreaterThanOrEqual(200);
+      const before = await readWidth();
+
+      // Collapse the canvas well below the usable threshold, let the resize
+      // handlers run + debounced persist flush, then restore it.
+      await page.setViewportSize({ width: 150, height: 120 });
+      await page.waitForTimeout(600);
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.waitForTimeout(600);
+
+      const after = await readWidth();
+      // Width must survive the transient (fixed axis never recovers if collapsed).
+      expect(after).toBeGreaterThanOrEqual(before - 20);
+
+      // And the persisted geometry must not carry the collapse fingerprint.
+      const persisted = await page.evaluate(() => {
+        const raw = localStorage.getItem("overlayPositionAndSize.v3_dataActions");
+        return raw ? JSON.parse(raw) : null;
+      });
+      expect(persisted).not.toBeNull();
+      expect(persisted.width > 150 || persisted.height > 100).toBe(true);
+    } finally {
+      await authPost(request, `${API_URL}/editor/close_flow/?flow_id=${flowId}`, authToken);
+    }
+  });
+
   test("python script expanded editor dialog teleports to body and covers the viewport", async ({
     page,
     request,


### PR DESCRIPTION
This pull request introduces a pure, deterministic geometry system for canvas overlay panels, ensuring that only user intent is persisted and all on-screen panel layouts are derived from this intent and the current container size. This prevents historical bugs caused by persisting derived geometry and enables robust, predictable panel behavior. The changes include a new pure TypeScript module for panel layout logic, comprehensive tests, and updated documentation.

**Panel overlay system improvements:**

* Added a new pure geometry module `layoutGeometry.ts` that computes panel positions and sizes from user intent and container bounds, never persisting derived geometry. This fixes historical state corruption issues and ensures robust recovery from container mis-measurements.
* Documented the new overlay panel contract and behavior in `CLAUDE.md`, clarifying the separation between user intent and derived geometry.

**Testing and validation:**

* Added a comprehensive test suite `layoutGeometry.test.ts` covering all panel docking modes, edge cases, round-trip intent/layout conversions, and geometry clamping logic to guarantee correctness and guard against regressions.