### PR TITLE
fix layout sort

### DIFF
--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/sort/Sort.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/sort/Sort.vue
@@ -51,25 +51,23 @@
               </tr>
             </thead>
             <tbody>
-              <div v-if="nodeSort">
-                <tr
-                  v-for="(item, index) in nodeSort.sort_input"
-                  :key="index"
-                  @contextmenu.prevent="openRowContextMenu($event, index)"
-                >
-                  <td>{{ item.column }}</td>
-                  <td>
-                    <el-select v-model="item.how" size="small">
-                      <el-option
-                        v-for="aggOption in sortOptions"
-                        :key="aggOption"
-                        :label="aggOption"
-                        :value="aggOption"
-                      />
-                    </el-select>
-                  </td>
-                </tr>
-              </div>
+              <tr
+                v-for="(item, index) in nodeSort.sort_input"
+                :key="index"
+                @contextmenu.prevent="openRowContextMenu($event, index)"
+              >
+                <td>{{ item.column }}</td>
+                <td>
+                  <el-select v-model="item.how" size="small">
+                    <el-option
+                      v-for="aggOption in sortOptions"
+                      :key="aggOption"
+                      :label="aggOption"
+                      :value="aggOption"
+                    />
+                  </el-select>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
This pull request makes a small change to the `Sort.vue` component, removing an unnecessary `div` wrapper from inside the `<tbody>`. This improves the HTML structure and ensures valid markup.