### PR TITLE
Hide the header for graphic walker in dashboard mode

### DIFF
--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/exploreData/vueGraphicWalker/VueGraphicWalker.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/exploreData/vueGraphicWalker/VueGraphicWalker.vue
@@ -21,6 +21,8 @@ interface VueGWProps {
   defaultTab?: "data" | "vis";
   /** Server-side compute callback; when set, GW aggregates through this instead of in-browser `data`. */
   computation?: (payload: any) => Promise<IRow[]>;
+  /** Hide GW's chart-tab bar so the surface is a single chart. */
+  hideChartNav?: boolean;
 }
 
 const props = defineProps<VueGWProps>();
@@ -56,6 +58,7 @@ const getReactProps = () => {
     storeRef: internalStoreRef.value,
     hideProfiling: true,
     ...(chartSpecArray.length > 0 && { chart: chartSpecArray }),
+    ...(props.hideChartNav && { hideChartNav: true }),
   };
 
   if (usingComputation) {

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/VisualizationEditor.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/VisualizationEditor.vue
@@ -48,6 +48,7 @@
           :fields="plainFields"
           :spec-list="plainInitialSpecList"
           :appearance="appearance"
+          :hide-chart-nav="true"
         />
       </template>
     </div>

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/VisualizationViewer.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/VisualizationViewer.vue
@@ -110,6 +110,7 @@
           :fields="plainFields"
           :spec-list="plainSpecList"
           :appearance="appearance"
+          :hide-chart-nav="true"
         />
       </template>
     </div>

--- a/flowfile_wasm/src/components/nodes/exploreData/VueGraphicWalker.vue
+++ b/flowfile_wasm/src/components/nodes/exploreData/VueGraphicWalker.vue
@@ -30,6 +30,7 @@ interface VueGWProps {
    * prop is here for API parity with flowfile_frontend.
    */
   computation?: (payload: any) => Promise<IRow[]>
+  hideChartNav?: boolean
 }
 
 const props = defineProps<VueGWProps>()
@@ -67,6 +68,7 @@ const getReactProps = () => {
     themeKey: props.themeKey,
     storeRef: internalStoreRef.value,
     ...(chartSpecArray.length > 0 && { chart: chartSpecArray }),
+    ...(props.hideChartNav && { hideChartNav: true }),
   }
 
   if (usingComputation) {

--- a/flowfile_wasm/src/views/CatalogView/VisualizationEditor.vue
+++ b/flowfile_wasm/src/views/CatalogView/VisualizationEditor.vue
@@ -117,6 +117,7 @@ async function save() {
         :data="data"
         :fields="fields"
         :spec-list="initialSpecList"
+        :hide-chart-nav="true"
       />
     </div>
   </div>


### PR DESCRIPTION
This pull request introduces a new `hideChartNav` prop to the `VueGraphicWalker` component in both the frontend and WASM implementations. This prop allows the chart navigation bar to be hidden, presenting a cleaner, single-chart display in various visualization views. The prop is now used in all relevant visualization editor and viewer components.

**New Feature: Hide Chart Navigation Bar**

* Added `hideChartNav` prop to the `VueGWProps` interface in both `flowfile_frontend` and `flowfile_wasm` versions of `VueGraphicWalker`, allowing the chart navigation bar to be hidden. [[1]](diffhunk://#diff-914f53c3e45e008e296ae78dc4a9badd2fa605790912722ee8419648f5d48b92R24-R25) [[2]](diffhunk://#diff-698475536689c328c5f233f149599db9f6f99583c244f3cd8f9e8e74c917920aR33)
* Passed `hideChartNav` through to the underlying React props in both implementations, ensuring the prop is respected by the charting library. [[1]](diffhunk://#diff-914f53c3e45e008e296ae78dc4a9badd2fa605790912722ee8419648f5d48b92R61) [[2]](diffhunk://#diff-698475536689c328c5f233f149599db9f6f99583c244f3cd8f9e8e74c917920aR71)

**Usage in Visualization Views**

* Set `:hide-chart-nav="true"` in `VisualizationEditor.vue` and `VisualizationViewer.vue` for both frontend and WASM, ensuring the chart navigation bar is hidden in these contexts. [[1]](diffhunk://#diff-cdc4b3b83fad6af02d88c3162128aaca04dd01b2303c0d655c6a0ee9437700d0R51) [[2]](diffhunk://#diff-9353025cfd643819399a860cd0b8ad138cabffc2fa98aa01d12d19154751bc03R113) [[3]](diffhunk://#diff-927731302a6d743e75b4807e4870cb1877772a9f1cc8e8721b84b056d5c2d4d9R120)