### PR TITLE
docs: Remove "deliberately" from Emoji Generator tutorial intro

### DIFF
--- a/docs/users/visual-editor/custom-node-tutorial.md
+++ b/docs/users/visual-editor/custom-node-tutorial.md
@@ -2,7 +2,7 @@
 
 This tutorial builds one custom node end to end, entirely in the **[Node Designer](node-designer.md)** — the visual tool for making your own nodes. No file to write by hand, no terminal: you lay out the settings form, write one small transform, test it, and save. The node then appears in the palette next to the built-in ones.
 
-The example is an **Emoji Generator** that maps a numeric column to mood-based emojis. It is deliberately small, and it exercises everything real nodes use: a multi-section settings form, a type-filtered column picker, and a `process` method that transforms the incoming data.
+The example is an **Emoji Generator** that maps a numeric column to mood-based emojis. It is small, and it exercises everything real nodes use: a multi-section settings form, a type-filtered column picker, and a `process` method that transforms the incoming data.
 
 !!! info "What you'll build"
     An "Emoji Generator" node that:


### PR DESCRIPTION
## Summary
Minor documentation refinement to the custom node tutorial introduction.

## Changes
- Removed the word "deliberately" from the opening description of the Emoji Generator example in the custom node tutorial
- The sentence now reads: "It is small, and it exercises everything real nodes use..." instead of "It is deliberately small, and it exercises..."

## Rationale
This is a stylistic improvement that makes the documentation more concise while maintaining the same meaning. The word "deliberately" is implied by the context and removing it creates a cleaner, more direct statement about the example's scope.

https://claude.ai/code/session_011do2oLSsoCb71oSrtjj22j