### PR TITLE
feat: enhance custom nodes search functionality with additional metadata and improved UI

### DIFF
--- a/flowfile_core/flowfile_core/routes/custom_node_mounts.py
+++ b/flowfile_core/flowfile_core/routes/custom_node_mounts.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from flowfile_core.auth.jwt import get_current_active_user
 from flowfile_core.configs import logger
 from flowfile_core.fileExplorer import validate_path_under_cwd
+from flowfile_core.flowfile.community_nodes.receipts import community_icon_override
 from flowfile_core.flowfile.user_defined.mounts import (
     MountValidationError,
     add_mount,
@@ -53,6 +54,10 @@ class CatalogCustomNode(BaseModel):
     node_name: str
     node_category: str = ""
     file_name: str
+    title: str = ""
+    intro: str = ""
+    tags: list[str] = []
+    node_icon: str = "user-defined-icon.png"
     environment: Literal["local", "kernel"] = "local"
     error: str | None = None
     source: str = "default"  # "default" | absolute mount path
@@ -96,7 +101,13 @@ def _catalog_node_from_entry(entry: LoadedNode) -> CatalogCustomNode:
         if entry.manifest.node_name:
             row.node_name = entry.manifest.node_name
         row.node_category = entry.manifest.node_category
+        row.title = entry.manifest.title
+        row.intro = entry.manifest.intro
+        row.tags = list(entry.manifest.tags)
         row.environment = entry.manifest.environment.kind
+        # Installed community icons live namespaced on disk while node_icon keeps the original name.
+        icon_override = community_icon_override(Path(entry.file_name).stem)
+        row.node_icon = icon_override or entry.manifest.node_icon
     return row
 
 

--- a/flowfile_frontend/src/renderer/app/api/nodeDesigner.ts
+++ b/flowfile_frontend/src/renderer/app/api/nodeDesigner.ts
@@ -183,6 +183,10 @@ export interface CatalogCustomNode {
   node_name: string;
   node_category: string;
   file_name: string;
+  title: string;
+  intro: string;
+  tags: string[];
+  node_icon: string;
   environment: "local" | "kernel";
   error: string | null;
   source: string; // "default" | absolute mount path

--- a/flowfile_frontend/src/renderer/app/pages/NodeDesigner.vue
+++ b/flowfile_frontend/src/renderer/app/pages/NodeDesigner.vue
@@ -43,6 +43,8 @@
       :viewing-node-code="browser.viewingNodeCode.value"
       :viewing-node-name="browser.viewingNodeName.value"
       :read-only-extensions="autocompletion.readOnlyExtensions"
+      :current-file="store.sourceFile"
+      :community-nodes="browser.communityByFile.value"
       @close="browser.closeNodeBrowser()"
       @view-node="browser.viewCustomNode($event)"
       @back="browser.backToNodeList()"

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/NodeBrowserModal.vue
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/NodeBrowserModal.vue
@@ -1,16 +1,34 @@
 <template>
   <div v-if="show" class="modal-overlay" @click="emit('close')">
-    <div class="modal-container modal-large" @click.stop>
+    <div class="modal-container modal-xl" @click.stop>
       <div class="modal-header">
         <h3 class="modal-title">
           <i class="fa-solid fa-folder-open"></i>
           {{ viewingNodeCode ? viewingNodeName : "Browse Custom Nodes" }}
+          <span v-if="!viewingNodeCode && countLabel" class="modal-title-count">
+            {{ countLabel }}
+          </span>
         </h3>
         <button class="modal-close" @click="emit('close')">
           <i class="fa-solid fa-times"></i>
         </button>
       </div>
-      <div class="modal-content">
+
+      <!-- Sibling of .modal-content so the search box never scrolls away. -->
+      <div v-if="!viewingNodeCode && nodes.length" class="browser-toolbar">
+        <el-input
+          v-model="search"
+          placeholder="Search nodes"
+          clearable
+          size="small"
+          class="node-search"
+          data-testid="node-browser-search"
+        >
+          <template #prefix><i class="fa-solid fa-magnifying-glass" /></template>
+        </el-input>
+      </div>
+
+      <div class="modal-content" :class="{ 'modal-content--flush': !viewingNodeCode }">
         <template v-if="viewingNodeCode">
           <div class="node-code-view">
             <Codemirror
@@ -35,57 +53,35 @@
             title="No custom nodes found"
             description="Save a node to see it here."
           />
-          <div v-else class="nodes-grid">
-            <div
-              v-for="node in nodes"
-              :key="node.file_name"
-              class="node-card"
-              :data-testid="`node-card-${node.file_name}`"
-            >
-              <div class="node-card-header">
-                <i class="fa-solid fa-puzzle-piece"></i>
-                <span class="node-name">{{ node.node_name || node.file_name }}</span>
-                <span v-if="node.error" class="node-broken" title="Failed to load">
-                  <i class="fa-solid fa-triangle-exclamation"></i>
-                </span>
+          <EmptyState
+            v-else-if="visibleNodes.length === 0"
+            icon="fa-solid fa-magnifying-glass"
+            title="No nodes match your search"
+            :description="`Nothing found for “${search.trim()}”.`"
+          >
+            <template #actions>
+              <button class="btn btn-secondary btn-sm" @click="search = ''">Clear search</button>
+            </template>
+          </EmptyState>
+          <template v-else>
+            <section v-for="group in groups" :key="group.key">
+              <div class="node-group__header">
+                <span>{{ group.label }}</span>
+                <span>{{ group.nodes.length }}</span>
               </div>
-              <div class="node-card-body">
-                <span class="node-category">{{ node.node_category }}</span>
-                <p class="node-description">{{ node.intro || "No description" }}</p>
-              </div>
-              <div class="node-card-actions">
-                <button
-                  class="btn btn-sm"
-                  title="Edit"
-                  :data-testid="`node-edit-${node.file_name}`"
-                  @click="emit('edit', node.file_name)"
-                >
-                  <i class="fa-solid fa-pen"></i> Edit
-                </button>
-                <button
-                  class="btn btn-sm"
-                  title="Duplicate"
-                  @click="emit('duplicate', node.file_name)"
-                >
-                  <i class="fa-solid fa-copy"></i> Duplicate
-                </button>
-                <button
-                  class="btn btn-sm"
-                  title="View code"
-                  @click="emit('viewNode', node.file_name)"
-                >
-                  <i class="fa-solid fa-code"></i> Code
-                </button>
-                <button
-                  class="btn btn-sm btn-icon btn-danger card-action-danger"
-                  title="Delete"
-                  @click="askDelete(node.file_name, node.node_name || node.file_name)"
-                >
-                  <i class="fa-solid fa-trash"></i>
-                </button>
-              </div>
-            </div>
-          </div>
+              <NodeBrowserRow
+                v-for="node in group.nodes"
+                :key="node.file_name"
+                :node="node"
+                :is-current="node.file_name === currentFile"
+                :community="communityNodes?.[node.file_name] ?? null"
+                @edit="emit('edit', $event)"
+                @duplicate="emit('duplicate', $event)"
+                @view="emit('viewNode', $event)"
+                @delete="askDelete(node.file_name, node.node_name || node.file_name)"
+              />
+            </section>
+          </template>
         </template>
       </div>
       <div class="modal-actions">
@@ -135,22 +131,28 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { Codemirror } from "vue-codemirror";
+import { ElInput } from "element-plus";
 import type { Extension } from "@codemirror/state";
+import type { InstallReceipt } from "../../api/communityNodes";
 import type { CustomNodeInfo } from "./types";
+import { filterNodes, groupByCategory } from "./customNodeFilter";
+import NodeBrowserRow from "./NodeBrowserRow.vue";
 import EmptyState from "../../components/common/EmptyState/EmptyState.vue";
 
 const router = useRouter();
 
-defineProps<{
+const props = defineProps<{
   show: boolean;
   nodes: CustomNodeInfo[];
   loading: boolean;
   viewingNodeCode: string;
   viewingNodeName: string;
   readOnlyExtensions: Extension[];
+  currentFile?: string | null;
+  communityNodes?: Record<string, InstallReceipt>;
 }>();
 
 const emit = defineEmits<{
@@ -161,6 +163,27 @@ const emit = defineEmits<{
   (e: "back"): void;
   (e: "delete", fileName: string): void;
 }>();
+
+const search = ref("");
+
+const visibleNodes = computed(() => filterNodes(props.nodes, search.value));
+const groups = computed(() => groupByCategory(visibleNodes.value));
+
+const countLabel = computed(() => {
+  const total = props.nodes.length;
+  if (!total) return "";
+  const shown = visibleNodes.value.length;
+  return shown === total ? `${total}` : `${shown} of ${total}`;
+});
+
+// The component never unmounts (v-if lives on the inner overlay), so a stale
+// query would silently hide nodes on the next visit.
+watch(
+  () => props.show,
+  (open) => {
+    if (open) search.value = "";
+  },
+);
 
 const pendingDelete = ref<{ fileName: string; name: string } | null>(null);
 
@@ -193,80 +216,27 @@ function browseCommunity() {
   font-size: 1.25rem;
 }
 
-.nodes-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 1rem;
+.modal-title-count {
+  margin-left: var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text-tertiary);
 }
 
-.node-card {
-  background: var(--color-background-primary);
-  border: 1px solid var(--color-border-primary);
-  border-radius: var(--border-radius-lg);
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.node-card-header {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  background: var(--color-background-secondary);
+.browser-toolbar {
+  flex-shrink: 0;
+  padding: var(--spacing-2) var(--spacing-4);
   border-bottom: 1px solid var(--color-border-primary);
 }
 
-.node-card-header i {
-  color: var(--color-accent);
+/* Not `.search-input` — _forms.css defines a global one whose own border and
+   background would double up on the el-input root. */
+.node-search {
+  max-width: 320px;
 }
 
-.node-broken {
-  margin-left: auto;
-  color: var(--color-warning);
-}
-
-.node-name {
-  font-weight: var(--font-weight-semibold);
-  font-size: var(--font-size-base);
-}
-
-.node-card-body {
-  padding: 0.75rem 1rem;
-  flex: 1;
-}
-
-.node-category {
-  display: inline-block;
-  font-size: var(--font-size-2xs);
-  font-weight: var(--font-weight-medium);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 0.125rem 0.5rem;
-  background: var(--color-accent-subtle);
-  color: var(--color-accent);
-  border-radius: var(--border-radius-full);
-  margin-bottom: 0.5rem;
-}
-
-.node-description {
-  margin: 0;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  line-height: 1.4;
-}
-
-.node-card-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  padding: 0.5rem 0.75rem;
-  border-top: 1px solid var(--color-border-primary);
-  background: var(--color-background-secondary);
-}
-
-.card-action-danger {
-  margin-left: auto;
+.modal-content--flush {
+  padding: 0;
 }
 
 .node-code-view {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/NodeBrowserRow.vue
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/NodeBrowserRow.vue
@@ -1,0 +1,87 @@
+<template>
+  <div
+    class="node-row"
+    :class="{ 'node-row--current': isCurrent }"
+    :data-testid="`node-card-${node.file_name}`"
+    @click="emit('edit', node.file_name)"
+  >
+    <img :src="iconUrl" alt="" class="node-row__icon" />
+    <span class="node-row__name">{{ node.node_name || node.file_name }}</span>
+
+    <span v-if="isCurrent" class="status-badge status-badge--info">Editing</span>
+    <span v-if="node.environment === 'kernel'" class="status-badge status-badge--warning">
+      Kernel
+    </span>
+    <el-tooltip
+      v-if="community"
+      :content="`Installed from the community registry · v${community.version}`"
+      placement="top"
+    >
+      <button class="status-badge status-badge--success community-chip" @click.stop="openSource">
+        Community <i class="fa-solid fa-arrow-up-right-from-square" />
+      </button>
+    </el-tooltip>
+    <span v-if="node.error" class="node-row__broken" title="Failed to load">
+      <i class="fa-solid fa-triangle-exclamation" />
+    </span>
+
+    <span class="node-row__intro">{{ node.intro || "No description" }}</span>
+
+    <div class="node-row__actions" @click.stop>
+      <button
+        class="btn btn-sm"
+        title="Edit"
+        :data-testid="`node-edit-${node.file_name}`"
+        @click="emit('edit', node.file_name)"
+      >
+        <i class="fa-solid fa-pen" /> Edit
+      </button>
+      <el-tooltip content="Duplicate" placement="top">
+        <button class="btn btn-sm btn-icon" @click="emit('duplicate', node.file_name)">
+          <i class="fa-solid fa-copy" />
+        </button>
+      </el-tooltip>
+      <el-tooltip content="View code" placement="top">
+        <button class="btn btn-sm btn-icon" @click="emit('view', node.file_name)">
+          <i class="fa-solid fa-code" />
+        </button>
+      </el-tooltip>
+      <el-tooltip content="Delete" placement="top">
+        <button class="btn btn-sm btn-icon btn-danger" @click="emit('delete', node.file_name)">
+          <i class="fa-solid fa-trash" />
+        </button>
+      </el-tooltip>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// One row of the custom-node browser. Its own component because useNodeIconUrl
+// is a watchEffect composable and cannot be called inside a v-for.
+import { ElTooltip } from "element-plus";
+import { useNodeIconUrl } from "../../composables/useCustomNodeIcon";
+import { communityNodeSourceUrl, type InstallReceipt } from "../../api/communityNodes";
+import { desktop } from "../../../lib/desktop";
+import type { CustomNodeInfo } from "./types";
+
+const props = defineProps<{
+  node: CustomNodeInfo;
+  isCurrent: boolean;
+  community?: InstallReceipt | null;
+}>();
+
+const emit = defineEmits<{
+  (e: "edit", fileName: string): void;
+  (e: "duplicate", fileName: string): void;
+  (e: "view", fileName: string): void;
+  (e: "delete", fileName: string): void;
+}>();
+
+const iconUrl = useNodeIconUrl(() => props.node.node_icon);
+
+function openSource() {
+  if (props.community) void desktop.openExternal(communityNodeSourceUrl(props.community.node_id));
+}
+</script>
+
+<!-- Row layout is shared with the catalog's Custom Nodes tab: styles/components/_node-rows.css -->

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/composables/useNodeBrowser.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/composables/useNodeBrowser.ts
@@ -4,12 +4,21 @@
  */
 import { ref } from "vue";
 import { getCustomNode, listCustomNodes } from "../../../api/nodeDesigner";
+import {
+  fetchInstalled,
+  type InstallReceipt,
+  type InstalledCommunityNode,
+} from "../../../api/communityNodes";
 import type { CustomNodeInfo } from "../types";
 
 export function useNodeBrowser() {
   const showNodeBrowser = ref(false);
   const customNodes = ref<CustomNodeInfo[]>([]);
   const loadingNodes = ref(false);
+  // Keyed by receipt.file_name: the receipt is the only marker that a local
+  // node came from the registry, and file_name is what both surfaces carry
+  // on disk (node_key can diverge from node_id).
+  const communityByFile = ref<Record<string, InstallReceipt>>({});
 
   const viewingNodeCode = ref("");
   const viewingNodeName = ref("");
@@ -18,10 +27,20 @@ export function useNodeBrowser() {
   async function fetchCustomNodes() {
     loadingNodes.value = true;
     try {
-      customNodes.value = (await listCustomNodes()) as unknown as CustomNodeInfo[];
+      // /community_nodes/installed is JWT-only and reads a local sidecar, so it
+      // works offline; a failure just means no Community chips.
+      const [nodes, installed] = await Promise.all([
+        listCustomNodes(),
+        fetchInstalled().catch(() => [] as InstalledCommunityNode[]),
+      ]);
+      customNodes.value = nodes as unknown as CustomNodeInfo[];
+      communityByFile.value = Object.fromEntries(
+        installed.map((entry) => [entry.receipt.file_name, entry.receipt]),
+      );
     } catch (error) {
       console.error("Failed to fetch custom nodes:", error);
       customNodes.value = [];
+      communityByFile.value = {};
     } finally {
       loadingNodes.value = false;
     }
@@ -59,6 +78,7 @@ export function useNodeBrowser() {
   return {
     showNodeBrowser,
     customNodes,
+    communityByFile,
     loadingNodes,
     viewingNodeCode,
     viewingNodeName,

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/customNodeFilter.test.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/customNodeFilter.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  UNCATEGORIZED,
+  filterNodes,
+  groupByCategory,
+  matchesTokens,
+  tokenize,
+} from "./customNodeFilter";
+import type { CustomNodeInfo } from "./types";
+
+function makeNode(overrides: Partial<CustomNodeInfo>): CustomNodeInfo {
+  return {
+    file_name: "node.py",
+    node_name: "Node",
+    node_category: "Tools",
+    title: "Node",
+    intro: "A node",
+    node_icon: "user-defined-icon.png",
+    ...overrides,
+  };
+}
+
+describe("tokenize", () => {
+  it("lowercases, splits on whitespace and drops empties", () => {
+    expect(tokenize("  Auto   ML ")).toEqual(["auto", "ml"]);
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize("   ")).toEqual([]);
+  });
+});
+
+describe("matchesTokens", () => {
+  it("returns true for every node when there are no tokens", () => {
+    expect(matchesTokens(makeNode({}), [])).toBe(true);
+  });
+
+  it("ANDs terms across different fields", () => {
+    const node = makeNode({ node_name: "Classifier", node_category: "AutoML" });
+    expect(matchesTokens(node, tokenize("automl classifier"))).toBe(true);
+    expect(matchesTokens(node, tokenize("automl regressor"))).toBe(false);
+  });
+
+  it("matches partial terms so 'auto class' finds 'Auto Classifier'", () => {
+    const node = makeNode({ node_name: "Auto Classifier" });
+    expect(matchesTokens(node, tokenize("auto class"))).toBe(true);
+  });
+
+  it("matches on file_name", () => {
+    const node = makeNode({ node_name: "Widget", file_name: "mood_emoji.py" });
+    expect(matchesTokens(node, tokenize("mood_emoji"))).toBe(true);
+  });
+
+  it("matches on tags", () => {
+    const node = makeNode({ node_name: "Widget", tags: ["sklearn", "ml"] });
+    expect(matchesTokens(node, tokenize("sklearn"))).toBe(true);
+  });
+
+  it("tolerates a node with no tags", () => {
+    const node = makeNode({ node_name: "Widget", tags: undefined });
+    expect(matchesTokens(node, tokenize("widget"))).toBe(true);
+    expect(matchesTokens(node, tokenize("sklearn"))).toBe(false);
+  });
+});
+
+describe("filterNodes", () => {
+  const nodes = [
+    makeNode({ file_name: "a.py", node_name: "Auto Classifier", node_category: "AutoML" }),
+    makeNode({ file_name: "b.py", node_name: "Date Parser", node_category: "Date & Time" }),
+  ];
+
+  it("returns everything for an empty or whitespace-only query", () => {
+    expect(filterNodes(nodes, "")).toEqual(nodes);
+    expect(filterNodes(nodes, "   ")).toEqual(nodes);
+  });
+
+  it("narrows to the matching nodes", () => {
+    expect(filterNodes(nodes, "automl").map((n) => n.file_name)).toEqual(["a.py"]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(filterNodes(nodes, "zzz")).toEqual([]);
+  });
+});
+
+describe("groupByCategory", () => {
+  it("sorts group labels alphabetically", () => {
+    const groups = groupByCategory([
+      makeNode({ file_name: "z.py", node_category: "Zoology" }),
+      makeNode({ file_name: "a.py", node_category: "AutoML" }),
+      makeNode({ file_name: "d.py", node_category: "Date & Time" }),
+    ]);
+    expect(groups.map((g) => g.label)).toEqual(["AutoML", "Date & Time", "Zoology"]);
+  });
+
+  it("keeps backend order inside a bucket", () => {
+    const groups = groupByCategory([
+      makeNode({ file_name: "second.py", node_category: "Tools" }),
+      makeNode({ file_name: "first.py", node_category: "Tools" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].nodes.map((n) => n.file_name)).toEqual(["second.py", "first.py"]);
+  });
+
+  it("buckets blank, whitespace and missing categories into Uncategorized, sorted last", () => {
+    const groups = groupByCategory([
+      makeNode({ file_name: "blank.py", node_category: "" }),
+      makeNode({ file_name: "space.py", node_category: "   " }),
+      makeNode({ file_name: "missing.py", node_category: undefined as unknown as string }),
+      makeNode({ file_name: "zoo.py", node_category: "Zoology" }),
+      makeNode({ file_name: "auto.py", node_category: "AutoML" }),
+    ]);
+    expect(groups.map((g) => g.key)).toEqual(["AutoML", "Zoology", UNCATEGORIZED]);
+    expect(groups[2].nodes.map((n) => n.file_name)).toEqual([
+      "blank.py",
+      "space.py",
+      "missing.py",
+    ]);
+  });
+
+  it("returns no groups for an empty node list", () => {
+    expect(groupByCategory([])).toEqual([]);
+  });
+});

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/customNodeFilter.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/customNodeFilter.ts
@@ -1,0 +1,63 @@
+// Search + category grouping for the custom-node lists (designer browser and
+// the catalog's Custom Nodes tab). Vue-free so the matching and bucketing rules
+// stay unit-testable, mirroring usePaletteGroups.ts. Generic over the row type
+// because the two surfaces carry different extra fields.
+export const UNCATEGORIZED = "Uncategorized";
+
+/** The fields both custom-node row shapes share, and all that search reads. */
+export interface SearchableNode {
+  file_name: string;
+  node_name?: string;
+  node_category?: string;
+  title?: string;
+  intro?: string;
+  tags?: string[];
+}
+
+export interface NodeGroup<T extends SearchableNode = SearchableNode> {
+  key: string;
+  label: string;
+  nodes: T[];
+}
+
+export function tokenize(raw: string): string[] {
+  return raw.toLowerCase().split(/\s+/).filter(Boolean);
+}
+
+function haystack(node: SearchableNode): string {
+  return [node.node_name, node.title, node.intro, node.node_category, node.file_name]
+    .concat(node.tags ?? [])
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+/** Every term must hit some field, so "auto class" finds "Auto Classifier". */
+export function matchesTokens(node: SearchableNode, tokens: string[]): boolean {
+  if (!tokens.length) return true;
+  const text = haystack(node);
+  return tokens.every((token) => text.includes(token));
+}
+
+export function filterNodes<T extends SearchableNode>(nodes: T[], query: string): T[] {
+  const tokens = tokenize(query);
+  return tokens.length ? nodes.filter((node) => matchesTokens(node, tokens)) : nodes;
+}
+
+/** Bucket by category: alphabetical, uncategorized last, backend order kept inside. */
+export function groupByCategory<T extends SearchableNode>(nodes: T[]): NodeGroup<T>[] {
+  const byKey = new Map<string, T[]>();
+  for (const node of nodes) {
+    const key = (node.node_category || "").trim() || UNCATEGORIZED;
+    const bucket = byKey.get(key);
+    if (bucket) bucket.push(node);
+    else byKey.set(key, [node]);
+  }
+  return [...byKey.entries()]
+    .map(([key, groupNodes]) => ({ key, label: key, nodes: groupNodes }))
+    .sort((a, b) => {
+      if (a.key === UNCATEGORIZED) return 1;
+      if (b.key === UNCATEGORIZED) return -1;
+      return a.label.localeCompare(b.label);
+    });
+}

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/types.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/types.ts
@@ -44,6 +44,7 @@ export interface CustomNodeInfo {
   node_key?: string;
   environment?: "local" | "kernel";
   source_hash?: string;
+  tags?: string[];
   error?: string | null;
 }
 

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CustomNodeRow.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CustomNodeRow.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="node-row" :data-testid="`catalog-node-${node.file_name}`" @click="emit('open')">
+    <img :src="iconUrl" alt="" class="node-row__icon" />
+    <span class="node-row__name">{{ node.node_name || node.file_name }}</span>
+
+    <span v-if="node.environment === 'kernel'" class="status-badge status-badge--warning">
+      Kernel
+    </span>
+    <el-tooltip
+      v-if="community"
+      :content="`Installed from the community registry · v${community.version}`"
+      placement="top"
+    >
+      <button class="status-badge status-badge--success community-chip" @click.stop="openSource">
+        Community <i class="fa-solid fa-arrow-up-right-from-square" />
+      </button>
+    </el-tooltip>
+    <el-tooltip v-if="node.source !== 'default'" :content="node.source" placement="top">
+      <span class="status-badge status-badge--info source-chip">
+        <i class="fa-solid fa-folder" /> {{ node.source_label }}
+      </span>
+    </el-tooltip>
+    <el-tooltip v-if="node.error" :content="node.error" placement="top">
+      <span class="node-row__broken"><i class="fa-solid fa-triangle-exclamation" /></span>
+    </el-tooltip>
+
+    <span class="node-row__intro">{{ node.intro || "No description" }}</span>
+
+    <div class="node-row__actions" @click.stop>
+      <button class="btn btn-sm" @click="emit('open')"><i class="fa-solid fa-pen" /> Open</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// One row of the catalog's Custom Nodes tab. Own component because
+// useNodeIconUrl is a watchEffect composable and cannot be called in a v-for.
+// Shares .node-row* styling with the designer browser (_node-rows.css).
+import { ElTooltip } from "element-plus";
+import { useNodeIconUrl } from "../../composables/useCustomNodeIcon";
+import { communityNodeSourceUrl, type InstallReceipt } from "../../api/communityNodes";
+import type { CatalogCustomNode } from "../../api/nodeDesigner";
+import { desktop } from "../../../lib/desktop";
+
+const props = defineProps<{
+  node: CatalogCustomNode;
+  community?: InstallReceipt | null;
+}>();
+
+const emit = defineEmits<{ (e: "open"): void }>();
+
+const iconUrl = useNodeIconUrl(() => props.node.node_icon);
+
+function openSource() {
+  if (props.community) void desktop.openExternal(communityNodeSourceUrl(props.community.node_id));
+}
+</script>
+
+<style scoped>
+.source-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: default;
+}
+</style>

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CustomNodesPanel.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CustomNodesPanel.vue
@@ -1,23 +1,40 @@
 <template>
   <div class="custom-nodes-panel">
-    <div class="panel-header">
-      <h2>Custom Nodes</h2>
-      <div class="header-actions">
-        <el-button size="small" type="primary" @click="openDesigner()">
-          <i class="fa-solid fa-plus" /> New node
-        </el-button>
-        <el-button size="small" @click="openManageFolders">
-          <i class="fa-solid fa-folder-tree" /> Manage folders
-        </el-button>
-        <el-button size="small" :loading="rescanning" @click="rescan">
-          <i class="fa-solid fa-arrows-rotate" /> Rescan
-        </el-button>
+    <div class="panel-top">
+      <div class="panel-header">
+        <h2>
+          Custom Nodes
+          <span v-if="countLabel" class="panel-count">{{ countLabel }}</span>
+        </h2>
+        <div class="header-actions">
+          <el-button size="small" type="primary" @click="openDesigner()">
+            <i class="fa-solid fa-plus" /> New node
+          </el-button>
+          <el-button size="small" @click="openManageFolders">
+            <i class="fa-solid fa-folder-tree" /> Manage folders
+          </el-button>
+          <el-button size="small" :loading="rescanning" @click="rescan">
+            <i class="fa-solid fa-arrows-rotate" /> Rescan
+          </el-button>
+        </div>
       </div>
+      <p class="panel-hint">
+        Custom nodes discovered in the default directory and any mounted folders. Broken files stay
+        listed with their error so nothing silently disappears.
+      </p>
+
+      <el-input
+        v-if="nodes.length"
+        v-model="search"
+        placeholder="Search nodes"
+        clearable
+        size="small"
+        class="node-search"
+        data-testid="catalog-node-search"
+      >
+        <template #prefix><i class="fa-solid fa-magnifying-glass" /></template>
+      </el-input>
     </div>
-    <p class="panel-hint">
-      Custom nodes discovered in the default directory and any mounted folders. Broken files stay
-      listed with their error so nothing silently disappears.
-    </p>
 
     <EmptyState
       v-if="!loading && nodes.length === 0"
@@ -35,53 +52,32 @@
       </template>
     </EmptyState>
 
-    <el-table v-else v-loading="loading" :data="nodes" size="small">
-      <el-table-column label="Name" min-width="180">
-        <template #default="{ row }">
-          <div class="node-name-cell">
-            <span class="node-name">{{ row.node_name || row.file_name }}</span>
-            <el-tooltip v-if="row.error" :content="row.error" placement="top">
-              <i class="fa-solid fa-triangle-exclamation node-error-icon" />
-            </el-tooltip>
-          </div>
-        </template>
-      </el-table-column>
-      <el-table-column label="Category" width="150">
-        <template #default="{ row }">
-          <span v-if="row.node_category" class="chip chip-category">{{ row.node_category }}</span>
-          <span v-else class="chip chip-muted">Custom</span>
-        </template>
-      </el-table-column>
-      <el-table-column label="Environment" width="130">
-        <template #default="{ row }">
-          <span :class="['chip', row.environment === 'kernel' ? 'chip-kernel' : 'chip-local']">
-            {{ row.environment === "kernel" ? "Kernel" : "Local" }}
-          </span>
-        </template>
-      </el-table-column>
-      <el-table-column label="Source" min-width="140">
-        <template #default="{ row }">
-          <el-tooltip
-            v-if="row.source !== 'default'"
-            :content="row.source"
-            placement="top"
-            :show-after="300"
-          >
-            <span class="chip chip-source"
-              ><i class="fa-solid fa-folder" /> {{ row.source_label }}</span
-            >
-          </el-tooltip>
-          <span v-else class="chip chip-muted">Default</span>
-        </template>
-      </el-table-column>
-      <el-table-column width="120" align="right">
-        <template #default="{ row }">
-          <el-button size="small" text type="primary" @click="openDesigner(row.file_name)">
-            Open
-          </el-button>
-        </template>
-      </el-table-column>
-    </el-table>
+    <EmptyState
+      v-else-if="!loading && visibleNodes.length === 0"
+      icon="fa-solid fa-magnifying-glass"
+      title="No nodes match your search"
+      :description="`Nothing found for “${search.trim()}”.`"
+    >
+      <template #actions>
+        <el-button size="small" @click="search = ''">Clear search</el-button>
+      </template>
+    </EmptyState>
+
+    <div v-else v-loading="loading" class="nodes-list">
+      <section v-for="group in groups" :key="group.key">
+        <div class="node-group__header">
+          <span>{{ group.label }}</span>
+          <span>{{ group.nodes.length }}</span>
+        </div>
+        <CustomNodeRow
+          v-for="node in group.nodes"
+          :key="node.file_name"
+          :node="node"
+          :community="communityByFile[node.file_name] ?? null"
+          @open="openDesigner(node.file_name)"
+        />
+      </section>
+    </div>
 
     <!-- Manage folders dialog -->
     <el-dialog v-model="foldersOpen" title="Custom-node folders" width="620px" align-center>
@@ -178,7 +174,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import { ElMessage } from "element-plus";
 import {
@@ -190,14 +186,35 @@ import {
   type CatalogCustomNode,
   type MountInfo,
 } from "../../api/nodeDesigner";
+import {
+  fetchInstalled,
+  type InstalledCommunityNode,
+  type InstallReceipt,
+} from "../../api/communityNodes";
+import { filterNodes, groupByCategory } from "../../pages/nodeDesigner/customNodeFilter";
 import { EmptyState } from "../../components/common";
 import FileBrowser from "../../components/common/FileBrowser/fileBrowser.vue";
+import CustomNodeRow from "./CustomNodeRow.vue";
 
 const router = useRouter();
 
 const nodes = ref<CatalogCustomNode[]>([]);
 const loading = ref(false);
 const rescanning = ref(false);
+const search = ref("");
+// Keyed by receipt.file_name: the receipt is the only marker that a local node
+// came from the registry, and file_name is what both surfaces carry on disk.
+const communityByFile = ref<Record<string, InstallReceipt>>({});
+
+const visibleNodes = computed(() => filterNodes(nodes.value, search.value));
+const groups = computed(() => groupByCategory(visibleNodes.value));
+
+const countLabel = computed(() => {
+  const total = nodes.value.length;
+  if (!total) return "";
+  const shown = visibleNodes.value.length;
+  return shown === total ? `${total}` : `${shown} of ${total}`;
+});
 
 const foldersOpen = ref(false);
 const browseOpen = ref(false);
@@ -210,7 +227,16 @@ const mountError = ref<string | null>(null);
 async function loadNodes() {
   loading.value = true;
   try {
-    nodes.value = await listCatalogCustomNodes();
+    // /community_nodes/installed is JWT-only and reads a local sidecar, so it
+    // works offline; a failure just means no Community chips.
+    const [rows, installed] = await Promise.all([
+      listCatalogCustomNodes(),
+      fetchInstalled().catch(() => [] as InstalledCommunityNode[]),
+    ]);
+    nodes.value = rows;
+    communityByFile.value = Object.fromEntries(
+      installed.map((entry) => [entry.receipt.file_name, entry.receipt]),
+    );
   } catch {
     ElMessage.error("Failed to load custom nodes");
   } finally {
@@ -307,8 +333,17 @@ onMounted(loadNodes);
 </script>
 
 <style scoped>
+/* Fills .catalog-detail so the list is the only scroll surface and the header
+   + search stay put; sticky group headers then pin at the list's own top. */
 .custom-nodes-panel {
-  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.panel-top {
+  flex-shrink: 0;
+  padding: 16px 16px 12px;
 }
 .panel-header {
   display: flex;
@@ -318,6 +353,12 @@ onMounted(loadNodes);
 .panel-header h2 {
   font-size: 18px;
   margin: 0;
+}
+.panel-count {
+  margin-left: var(--spacing-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-normal);
+  color: var(--color-text-tertiary);
 }
 .header-actions {
   display: flex;
@@ -329,18 +370,18 @@ onMounted(loadNodes);
 .panel-hint {
   font-size: 13px;
   color: var(--color-text-secondary);
-  margin: 4px 0 16px;
+  margin: 4px 0 12px;
 }
-.node-name-cell {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+/* Not `.search-input` — _forms.css defines a global one whose own border and
+   background would double up on the el-input root. */
+.node-search {
+  max-width: 320px;
 }
-.node-name {
-  font-weight: 500;
-}
-.node-error-icon {
-  color: var(--color-danger, #e53e3e);
+.nodes-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  border-top: 1px solid var(--color-border-light);
 }
 .chip {
   display: inline-flex;
@@ -350,24 +391,6 @@ onMounted(loadNodes);
   padding: 1px 8px;
   border-radius: 10px;
   background-color: var(--color-background-secondary);
-  color: var(--color-text-secondary);
-}
-.chip-category {
-  background-color: var(--color-primary-bg, #ebf3fe);
-  color: var(--color-primary, #3b6fd4);
-}
-.chip-kernel {
-  background-color: var(--color-warning-bg, #fdf0e6);
-  color: var(--color-warning, #b7791f);
-}
-.chip-local {
-  background-color: var(--color-success-bg, #e6f4ea);
-  color: var(--color-success, #1e7e34);
-}
-.chip-source {
-  cursor: default;
-}
-.chip-muted {
   color: var(--color-text-secondary);
 }
 .chip-missing {

--- a/flowfile_frontend/src/renderer/styles/components/_node-rows.css
+++ b/flowfile_frontend/src/renderer/styles/components/_node-rows.css
@@ -1,0 +1,91 @@
+/* styles/components/_node-rows.css - Custom-node list rows (designer browser + catalog tab) */
+
+.node-row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2) var(--spacing-3);
+  border-bottom: 1px solid var(--color-border-light);
+  border-left: 2px solid transparent;
+  cursor: pointer;
+  /* Keeps a scrollIntoView'd row clear of the sticky group header. */
+  scroll-margin-top: 40px;
+}
+
+.node-row:hover {
+  background: var(--color-background-secondary);
+}
+
+.node-row--current {
+  border-left-color: var(--color-accent);
+}
+
+.node-row__icon {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.node-row__name {
+  flex-shrink: 0;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+/* min-width:0 is load-bearing — without it the flex item refuses to shrink
+   below its content width and the ellipsis never appears. */
+.node-row__intro {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.node-row__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  flex-shrink: 0;
+}
+
+.node-row__broken {
+  color: var(--color-warning);
+}
+
+/* Offset lets a host with its own sticky toolbar push headers below it. */
+.node-group__header {
+  position: sticky;
+  top: var(--node-group-sticky-top, 0);
+  z-index: 1;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: var(--spacing-2) var(--spacing-3);
+  background: var(--color-background-secondary);
+  border-bottom: 1px solid var(--color-border-primary);
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-tertiary);
+}
+
+/* Chips that link out (community source) still read as badges, not buttons. */
+.node-row .community-chip {
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.node-row .community-chip i {
+  font-size: var(--font-size-2xs);
+}

--- a/flowfile_frontend/src/renderer/styles/main.css
+++ b/flowfile_frontend/src/renderer/styles/main.css
@@ -12,6 +12,7 @@
 @import './components/_modals.css';
 @import './components/_context-menu.css';
 @import './components/_status-badges.css';
+@import './components/_node-rows.css';
 @import './components/_detail-panels.css';
 @import './components/_popovers.css';
 @import './utils/_spacing.css';


### PR DESCRIPTION
This pull request significantly improves the custom node browser in both backend and frontend, focusing on enhanced search/filtering, better UX for browsing nodes, and clearer display of community-installed nodes. It introduces search and grouping features, richer node metadata, and a new row-based layout for the browser. The backend and API types are updated to support these frontend improvements.

**Custom Node Browser Improvements**

- **Search and Filtering**
  - Added a search box to the custom node browser, supporting case-insensitive, multi-field search (name, category, tags, file name) with live filtering and clearable input. [[1]](diffhunk://#diff-446d95705dfb34915fdeaedd7ed75b88f0fdb628895beaba957c5fa301dea7eaL3-R31) [[2]](diffhunk://#diff-446d95705dfb34915fdeaedd7ed75b88f0fdb628895beaba957c5fa301dea7eaL38-R84) [[3]](diffhunk://#diff-446d95705dfb34915fdeaedd7ed75b88f0fdb628895beaba957c5fa301dea7eaR167-R187) [[4]](diffhunk://#diff-3d510b85567539ffa5852dd5b4b9f74f320b5e1c16c3137c691638f588dc4228R1-R122)
  - Nodes are grouped by category, sorted alphabetically, with uncategorized nodes bucketed at the end. [[1]](diffhunk://#diff-446d95705dfb34915fdeaedd7ed75b88f0fdb628895beaba957c5fa301dea7eaL38-R84) [[2]](diffhunk://#diff-3d510b85567539ffa5852dd5b4b9f74f320b5e1c16c3137c691638f588dc4228R1-R122)

- **Layout and UX Enhancements**
  - Switched from a card grid to a new row-based layout for custom nodes, improving readability and action accessibility. [[1]](diffhunk://#diff-446d95705dfb34915fdeaedd7ed75b88f0fdb628895beaba957c5fa301dea7eaL38-R84) [[2]](diffhunk://#diff-5b997a2c7b7a8881afbff815bc93eb40ab2148e34f1734e4082ef1bd7af8cfeeR1-R87)
  - The modal now shows a count of nodes and retains search state only while open. [[1]](diffhunk://#diff-446d95705dfb34915fdeaedd7ed75b88f0fdb628895beaba957c5fa301dea7eaL3-R31) [[2]](diffhunk://#diff-446d95705dfb34915fdeaedd7ed75b88f0fdb628895beaba957c5fa301dea7eaR167-R187)
  - Improved empty/search-not-found states with clearer messaging and actions.

**Community Node Integration**

- Community-installed nodes are now clearly marked with a "Community" badge, including version info and a link to the registry. [[1]](diffhunk://#diff-f1d2279bb0a42cede8a340081a9e1522d9d27b143dc6d3188db57758a10a3a3bR7-R21) [[2]](diffhunk://#diff-f1d2279bb0a42cede8a340081a9e1522d9d27b143dc6d3188db57758a10a3a3bL21-R43) [[3]](diffhunk://#diff-f1d2279bb0a42cede8a340081a9e1522d9d27b143dc6d3188db57758a10a3a3bR81) [[4]](diffhunk://#diff-5b997a2c7b7a8881afbff815bc93eb40ab2148e34f1734e4082ef1bd7af8cfeeR1-R87) [[5]](diffhunk://#diff-480a19b5d908a2f34a46224e1125055a93ee39e587f9780931a2a7cc5f631344R46-R47)
- Backend and API updated to support and expose community node metadata. [[1]](diffhunk://#diff-7a73df9b8851fd5bb0508f307f0cb344f1ce353e693d0317c747c7f8a34c51b4R17) [[2]](diffhunk://#diff-7a73df9b8851fd5bb0508f307f0cb344f1ce353e693d0317c747c7f8a34c51b4R104-R110) [[3]](diffhunk://#diff-18cd0c5fb9931e3d4435f8533f9a0eb421e896e05bffa6f09a9f041382c559e2R186-R189)

**Node Metadata and API Changes**

- The `CatalogCustomNode` model and corresponding frontend types now include `title`, `intro`, `tags`, and `node_icon` fields for richer display and filtering. [[1]](diffhunk://#diff-7a73df9b8851fd5bb0508f307f0cb344f1ce353e693d0317c747c7f8a34c51b4R57-R60) [[2]](diffhunk://#diff-7a73df9b8851fd5bb0508f307f0cb344f1ce353e693d0317c747c7f8a34c51b4R104-R110) [[3]](diffhunk://#diff-18cd0c5fb9931e3d4435f8533f9a0eb421e896e05bffa6f09a9f041382c559e2R186-R189)
- Backend logic ensures node icons are correctly namespaced for community nodes.

**Testing and Code Quality**

- Added comprehensive unit tests for search tokenization, filtering, and grouping logic in the browser.

These changes collectively make the custom node browser much more user-friendly, especially for users with many nodes or those using community-contributed nodes.…