### PR TITLE
feat: implement default save-target namespace selection in catalog registration

### DIFF
--- a/flowfile_frontend/src/renderer/app/features/designer/components/CatalogNamespacePicker.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/components/CatalogNamespacePicker.vue
@@ -26,7 +26,11 @@
 import { ref, onMounted, watch } from "vue";
 import NamespaceTreeItem from "./NamespaceTreeItem.vue";
 import { CatalogApi } from "../../../api";
-import { filterSelectableNamespaces, findNamespacePath } from "../../../types";
+import {
+  filterSelectableNamespaces,
+  findDefaultSaveNamespace,
+  findNamespacePath,
+} from "../../../types";
 import type { NamespaceTree } from "../../../types";
 import { useWritableNamespaces } from "../../../composables/useWritableNamespaces";
 
@@ -67,7 +71,10 @@ const loadTree = async () => {
     tree.value = props.hideSystemNamespaces ? filterSelectableNamespaces(fetched) : fetched;
     // Auto-select the most appropriate "General" child when nothing is selected.
     if (selectedId.value === null) {
-      const defaultNs = findDefaultNamespace(tree.value);
+      const defaultNs = findDefaultSaveNamespace(
+        tree.value,
+        (c) => !props.writableOnly || isWritableNamespace(c),
+      );
       if (defaultNs) {
         selectedId.value = defaultNs.id;
         emit("update:modelValue", defaultNs.id);
@@ -80,25 +87,6 @@ const loadTree = async () => {
   } finally {
     loading.value = false;
   }
-};
-
-/**
- * Pick a sensible default namespace: prefer ``General > Local Flows``
- * (the home for disk-backed flows introduced alongside the save UX rework),
- * and fall back to ``General > default`` for older catalogs where the
- * Local Flows namespace hasn't been seeded yet.
- */
-const findDefaultNamespace = (nodes: NamespaceTree[]): NamespaceTree | null => {
-  const selectable = (c: NamespaceTree) => !props.writableOnly || isWritableNamespace(c);
-  for (const node of nodes) {
-    if (node.name === "General" && node.parent_id === null) {
-      const local = node.children.find((c) => c.name === "Local Flows");
-      if (local && selectable(local)) return local;
-      const defaultChild = node.children.find((c) => c.name === "default");
-      if (defaultChild && selectable(defaultChild)) return defaultChild;
-    }
-  }
-  return null;
 };
 
 const handleSelect = (namespaceId: number) => {

--- a/flowfile_frontend/src/renderer/app/features/designer/components/CatalogRegisterRow.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/components/CatalogRegisterRow.vue
@@ -1,0 +1,200 @@
+<template>
+  <div class="register-row">
+    <el-checkbox
+      v-model="registered"
+      title="Registered flows show up in the catalog and keep run history"
+    >
+      Also register in catalog
+    </el-checkbox>
+    <template v-if="registered">
+      <span class="register-in">in</span>
+      <el-popover ref="popoverRef" trigger="click" placement="top-start" :width="340">
+        <template #reference>
+          <button type="button" class="ns-chip" title="Change the catalog namespace">
+            <i class="fa-solid fa-layer-group ns-chip-icon"></i>
+            <span class="ns-chip-label">{{ chipLabel }}</span>
+            <i class="fa-solid fa-chevron-down ns-chip-caret"></i>
+          </button>
+        </template>
+        <div class="ns-popover-body">
+          <div v-if="loading" class="ns-status">Loading namespaces...</div>
+          <div v-else-if="error" class="ns-status ns-status-error">{{ error }}</div>
+          <div v-else class="ns-tree">
+            <namespace-tree-item
+              v-for="node in tree"
+              :key="node.id"
+              :node="node"
+              :selected-id="namespaceId"
+              :initially-expanded="true"
+              :writable-only="true"
+              @select="handleSelect"
+            />
+          </div>
+        </div>
+      </el-popover>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * One-line "Also register in catalog" option for the Save/Create dialogs'
+ * File System tab: a checkbox plus a compact chip showing the target
+ * namespace at a glance, with the full namespace tree tucked into a popover
+ * instead of permanently occupying the dialog.
+ */
+import { computed, onMounted, ref } from "vue";
+import NamespaceTreeItem from "./NamespaceTreeItem.vue";
+import { CatalogApi } from "../../../api";
+import {
+  filterSelectableNamespaces,
+  findDefaultSaveNamespace,
+  findNamespacePath,
+} from "../../../types";
+import type { NamespaceTree } from "../../../types";
+import { useWritableNamespaces } from "../../../composables/useWritableNamespaces";
+
+const props = defineProps<{
+  modelValue: boolean;
+  namespaceId: number | null;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+  (e: "update:namespaceId", value: number | null): void;
+}>();
+
+const { isWritableNamespace } = useWritableNamespaces();
+
+const registered = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit("update:modelValue", value),
+});
+
+const tree = ref<NamespaceTree[]>([]);
+const loading = ref(false);
+const error = ref<string | null>(null);
+const popoverRef = ref<{ hide: () => void } | null>(null);
+
+const loadTree = async () => {
+  loading.value = true;
+  error.value = null;
+  try {
+    tree.value = filterSelectableNamespaces(await CatalogApi.getNamespaceTree());
+    if (props.namespaceId === null) {
+      const defaultNs = findDefaultSaveNamespace(tree.value, isWritableNamespace);
+      if (defaultNs) emit("update:namespaceId", defaultNs.id);
+    }
+  } catch (err) {
+    console.error("Failed to load namespace tree", err);
+    error.value = "Failed to load namespaces";
+  } finally {
+    loading.value = false;
+  }
+};
+
+const chipLabel = computed(() => {
+  if (props.namespaceId !== null) {
+    const path = findNamespacePath(tree.value, props.namespaceId);
+    if (path.length) return path.join(" / ");
+  }
+  return loading.value ? "Loading..." : "Choose namespace";
+});
+
+const handleSelect = (namespaceId: number) => {
+  emit("update:namespaceId", namespaceId);
+  popoverRef.value?.hide();
+};
+
+// Dotted ancestry label (e.g. "General.default") — same contract as
+// CatalogNamespacePicker so callers can build catalog refs from either picker.
+const getNamespacePath = (id: number | null): string | null => {
+  if (id === null) return null;
+  const path = findNamespacePath(tree.value, id);
+  return path.length ? path.join(".") : null;
+};
+
+onMounted(loadTree);
+
+defineExpose({ reload: loadTree, getNamespacePath });
+</script>
+
+<style scoped>
+.register-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-3);
+  min-height: 28px;
+}
+
+.register-in {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.ns-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  max-width: 320px;
+  padding: 3px var(--spacing-3);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--border-radius-md);
+  background-color: var(--color-background-tertiary);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.ns-chip:hover {
+  border-color: var(--color-accent, #1976d2);
+  color: var(--color-accent, #1976d2);
+}
+
+.ns-chip-icon {
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.ns-chip:hover .ns-chip-icon {
+  color: var(--color-accent, #1976d2);
+}
+
+.ns-chip-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ns-chip-caret {
+  font-size: 9px;
+  color: var(--color-text-muted);
+}
+
+.ns-popover-body {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.ns-status {
+  padding: var(--spacing-3);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.ns-status-error {
+  color: var(--color-danger, #e53935);
+}
+
+.ns-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+</style>

--- a/flowfile_frontend/src/renderer/app/features/designer/components/CreateDialog.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/components/CreateDialog.vue
@@ -40,18 +40,11 @@
             @create-file="handleCreateAtPath"
             @overwrite-file="handleCreateAtPath"
           />
-          <div class="catalog-options">
-            <el-checkbox v-model="registerInCatalog"> Also register in catalog </el-checkbox>
-            <div v-if="registerInCatalog" class="namespace-section">
-              <label class="namespace-label">Namespace</label>
-              <catalog-namespace-picker
-                ref="filePicker"
-                v-model="selectedNamespaceId"
-                :hide-system-namespaces="true"
-                :writable-only="true"
-              />
-            </div>
-          </div>
+          <catalog-register-row
+            ref="filePicker"
+            v-model="registerInCatalog"
+            v-model:namespace-id="selectedNamespaceId"
+          />
         </div>
 
         <!-- Catalog tab -->
@@ -106,6 +99,7 @@ import { getCatalogFlowsDirectory } from "../../../api/file.api";
 import { ALLOWED_SAVE_EXTENSIONS } from "../../../components/common/FileBrowser/constants";
 import { basenameNoExt } from "../../../composables/useRecentFlows";
 import CatalogNamespacePicker from "./CatalogNamespacePicker.vue";
+import CatalogRegisterRow from "./CatalogRegisterRow.vue";
 
 const props = defineProps({
   visible: {
@@ -125,7 +119,7 @@ const registerInCatalog = ref(true);
 const selectedNamespaceId = ref<number | null>(null);
 const catalogFlowName = ref("");
 const catalogFlowsDir = ref("");
-const filePicker = ref<InstanceType<typeof CatalogNamespacePicker> | null>(null);
+const filePicker = ref<InstanceType<typeof CatalogRegisterRow> | null>(null);
 const catalogPicker = ref<InstanceType<typeof CatalogNamespacePicker> | null>(null);
 
 // Dotted catalog reference ("General.default.my_flow") for the recents list;
@@ -302,32 +296,10 @@ defineExpose({
   gap: var(--spacing-4);
 }
 
-/* Cap the browser (default 70vh) so the register/namespace section below it
-   stays visible without scrolling the dialog. */
+/* Cap the browser (default 70vh) so the one-line register row below it stays
+   visible without scrolling the dialog. */
 .create-panel :deep(.file-browser) {
-  height: 46vh;
-}
-
-.catalog-options {
-  padding: var(--spacing-3);
-  border: 1px solid var(--color-border-light);
-  border-radius: var(--border-radius-md);
-  background-color: var(--color-background-muted, #f9f9fb);
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-}
-
-.namespace-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
-}
-
-.namespace-label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-primary);
+  height: 52vh;
 }
 
 .catalog-create-form {

--- a/flowfile_frontend/src/renderer/app/features/designer/components/SaveDialog.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/components/SaveDialog.vue
@@ -1,11 +1,7 @@
 <template>
   <!-- TODO(ux): move the file-browser Save trigger into the dialog footer
        too, so both tabs share a single primary-action location. Requires
-       changing the file-browser to a pure-selection mode.
-       TODO(ux): surface the catalog-registration namespace more prominently
-       on re-save — keep the default-on behavior (users get free run history
-       that way), but make the target namespace visible at a glance so users
-       understand where their flow is being tracked. -->
+       changing the file-browser to a pure-selection mode. -->
   <el-dialog
     v-model="isVisible"
     title="Save Flow"
@@ -49,17 +45,10 @@
             @create-file="handleSaveFlow"
             @overwrite-file="handleSaveFlow"
           />
-          <div class="catalog-options">
-            <el-checkbox v-model="registerInCatalog"> Also register in catalog </el-checkbox>
-            <div v-if="registerInCatalog" class="namespace-section">
-              <label class="namespace-label">Namespace</label>
-              <catalog-namespace-picker
-                v-model="selectedNamespaceId"
-                :hide-system-namespaces="true"
-                :writable-only="true"
-              />
-            </div>
-          </div>
+          <catalog-register-row
+            v-model="registerInCatalog"
+            v-model:namespace-id="selectedNamespaceId"
+          />
         </div>
 
         <!-- Catalog tab -->
@@ -142,7 +131,7 @@ import {
 import { getCatalogFlowsDirectory } from "../../../api/file.api";
 import { getFlowSettings } from "../../../components/nodes/nodeLogic";
 import { ALLOWED_SAVE_EXTENSIONS } from "../../../components/common/FileBrowser/constants";
-import CatalogNamespacePicker from "./CatalogNamespacePicker.vue";
+import CatalogRegisterRow from "./CatalogRegisterRow.vue";
 import CatalogFlowPicker from "./CatalogFlowPicker.vue";
 import { useTutorialStore } from "../../../stores/tutorial-store";
 import type { FlowRegistration } from "../../../types";
@@ -283,7 +272,10 @@ const updateInitialPath = async () => {
       if (isInternalFlowfilePath(settings.path)) {
         stem = stem.replace(/^\d+_/, "");
       }
-      catalogFlowName.value = settings.display_name?.trim() || stem;
+      // display_name is the catalog registration's name; an unregistered flow
+      // that was renamed only carries the rename in the session name, so fall
+      // back to it before the (possibly machine-generated) file stem.
+      catalogFlowName.value = settings.display_name?.trim() || settings.name?.trim() || stem;
 
       // Only seed the file-browser initial path from the current flow path
       // when that path lives in a real user directory.  Quick-created flows
@@ -525,32 +517,10 @@ defineExpose({
   gap: var(--spacing-4);
 }
 
-/* Cap the browser (default 70vh) so the register/namespace section below it
-   stays visible without scrolling the dialog. */
+/* Cap the browser (default 70vh) so the one-line register row below it stays
+   visible without scrolling the dialog. */
 .save-panel :deep(.file-browser) {
-  height: 46vh;
-}
-
-.catalog-options {
-  padding: var(--spacing-3);
-  border: 1px solid var(--color-border-light);
-  border-radius: var(--border-radius-md);
-  background-color: var(--color-background-muted, #f9f9fb);
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-3);
-}
-
-.namespace-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-2);
-}
-
-.namespace-label {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-primary);
+  height: 52vh;
 }
 
 .catalog-save-form {

--- a/flowfile_frontend/src/renderer/app/types/catalog.types.test.ts
+++ b/flowfile_frontend/src/renderer/app/types/catalog.types.test.ts
@@ -1,8 +1,9 @@
 // Guards the namespace ancestry lookup used to build catalog references
-// ("General.default.my_flow") for the welcome screen's recent flows.
+// ("General.default.my_flow") for the welcome screen's recent flows, and the
+// default save-target selection shared by the save/create namespace pickers.
 
 import { describe, it, expect } from "vitest";
-import { findNamespacePath, type NamespaceTree } from "./catalog.types";
+import { findDefaultSaveNamespace, findNamespacePath, type NamespaceTree } from "./catalog.types";
 
 const ns = (id: number, name: string, children: NamespaceTree[] = []): NamespaceTree =>
   ({
@@ -39,5 +40,22 @@ describe("findNamespacePath", () => {
 
   it("returns [] for an unknown id", () => {
     expect(findNamespacePath(tree, 99)).toEqual([]);
+  });
+});
+
+describe("findDefaultSaveNamespace", () => {
+  it("prefers General > Local Flows when present", () => {
+    expect(findDefaultSaveNamespace(tree)?.id).toBe(3);
+  });
+
+  it("falls back to General > default when Local Flows is absent or unselectable", () => {
+    const withoutLocal = [ns(1, "General", [ns(2, "default")]), ns(4, "Marketing")];
+    expect(findDefaultSaveNamespace(withoutLocal)?.id).toBe(2);
+    expect(findDefaultSaveNamespace(tree, (n) => n.name !== "Local Flows")?.id).toBe(2);
+  });
+
+  it("returns null when nothing under General is selectable", () => {
+    expect(findDefaultSaveNamespace(tree, () => false)).toBeNull();
+    expect(findDefaultSaveNamespace([ns(4, "Marketing", [ns(5, "campaigns")])])).toBeNull();
   });
 });

--- a/flowfile_frontend/src/renderer/app/types/catalog.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/catalog.types.ts
@@ -63,6 +63,29 @@ export function findNamespacePath(nodes: NamespaceTree[], id: number): string[] 
   return [];
 }
 
+/**
+ * Default save-target namespace for catalog registration pickers: prefer
+ * ``General > Local Flows`` (the home for disk-backed flows), falling back to
+ * ``General > default``. Note that trees passed through
+ * ``filterSelectableNamespaces`` no longer contain "Local Flows", so those
+ * callers land on "default". ``isSelectable`` lets save-target pickers skip
+ * read-only namespaces.
+ */
+export function findDefaultSaveNamespace(
+  nodes: NamespaceTree[],
+  isSelectable: (node: NamespaceTree) => boolean = () => true,
+): NamespaceTree | null {
+  for (const node of nodes) {
+    if (node.name === "General" && node.parent_id === null) {
+      const local = node.children.find((c) => c.name === "Local Flows");
+      if (local && isSelectable(local)) return local;
+      const fallback = node.children.find((c) => c.name === "default");
+      if (fallback && isSelectable(fallback)) return fallback;
+    }
+  }
+  return null;
+}
+
 export interface NamespaceCreate {
   name: string;
   parent_id?: number | null;


### PR DESCRIPTION
This pull request refactors and improves the catalog registration UX in the Save and Create dialogs. It introduces a new, more compact `CatalogRegisterRow` component to replace the previous multi-row catalog registration section, consolidates namespace selection logic, and improves the default namespace selection for catalog registration. The changes also include code cleanup and improved test coverage for the namespace selection logic.

**UI/UX Improvements:**

* Introduced a new `CatalogRegisterRow.vue` component, providing a one-line "Also register in catalog" option with an integrated namespace picker popover, replacing the previous multi-row section in both Save and Create dialogs.
* Updated `SaveDialog.vue` and `CreateDialog.vue` to use `CatalogRegisterRow` instead of the old checkbox and namespace picker, streamlining the dialog layouts. [[1]](diffhunk://#diff-cdf0bba7aa94c19b353d9406b909a406365afdaf298bfd5cba3758ac18d9fb24L52-L63) [[2]](diffhunk://#diff-e3268c8a8ddd8ee21d1a96a7fb27f9f8a8c68ca791fab3e81a60cfa75b0b1a00L43-L55)

**Namespace Selection Logic:**

* Added a new utility function `findDefaultSaveNamespace` in `catalog.types.ts` to consistently select the default save-target namespace, preferring "General > Local Flows" and falling back to "General > default", with support for filtering by writability.
* Refactored dialogs and pickers to use `findDefaultSaveNamespace` for initial namespace selection, ensuring consistent behavior and correct handling of writable-only namespaces. [[1]](diffhunk://#diff-9485fd948ce07bc35a4146f10dff2dc9e7a2b8c8a2086a17fe9f03c409abeac8L70-R77) [[2]](diffhunk://#diff-9485fd948ce07bc35a4146f10dff2dc9e7a2b8c8a2086a17fe9f03c409abeac8L29-R33)

**Testing and Code Cleanup:**

* Added comprehensive tests for `findDefaultSaveNamespace` to cover all fallback and edge cases in `catalog.types.test.ts`.
* Removed the now-obsolete `findDefaultNamespace` function from `CatalogNamespacePicker.vue` and updated imports accordingly.

**Minor Enhancements:**

* Improved the logic for determining the catalog flow name in `SaveDialog.vue` to better handle renamed flows.
* Adjusted dialog and file browser heights for better visual integration with the new register row. [[1]](diffhunk://#diff-cdf0bba7aa94c19b353d9406b909a406365afdaf298bfd5cba3758ac18d9fb24L528-R523) [[2]](diffhunk://#diff-e3268c8a8ddd8ee21d1a96a7fb27f9f8a8c68ca791fab3e81a60cfa75b0b1a00L305-R302)