### PR TITLE
feat: enhance CI pipeline for Docker image publishing with version gting and improved matrix computation

### DIFF
--- a/.claude/skills/flowfile-change-control/SKILL.md
+++ b/.claude/skills/flowfile-change-control/SKILL.md
@@ -130,7 +130,8 @@ The codebase has a set of intentional, by-design refusals — places where a fea
 4. Open a PR (branch protection blocks direct pushes to `main`), get it merged
 5. Tag the merge commit **lowercase** `vX.Y.Z` and push the tag
 6. This fires `pypi-release.yml`, `release.yaml`, **and** `docker-publish.yml` (app Docker images) simultaneously (§3b)
-7. **Manual, and historically never done:** assemble and attach `latest.json` to the release per the schema in `flowfile_frontend/src-tauri/SIGNING.md` (§3d)
+7. **First release on the tag-triggered path:** confirm `docker-publish.yml` actually fired on the tag (tag pushes ignore the `paths:` filter — documented GH behavior, but unexercised here). If it didn't, `workflow_dispatch` with `publish_app: true` publishes the app images at the manifest version — the intended escape hatch, safe because the new version's tags don't exist on Docker Hub yet.
+8. **Manual, and historically never done:** assemble and attach `latest.json` to the release per the schema in `flowfile_frontend/src-tauri/SIGNING.md` (§3d)
 
 ### 3b. One `v*` tag push → three workflows
 

--- a/.claude/skills/flowfile-change-control/SKILL.md
+++ b/.claude/skills/flowfile-change-control/SKILL.md
@@ -41,7 +41,7 @@ CI is 15 workflow files under `.github/workflows/` as of 2026-07-03 (v0.12.7) �
 
 ### 2a. Never force-push `main`
 
-`CONTRIBUTING.md`: "**Don't force-push to `main`.** Releases build from it." `docker-publish.yml` triggers on every push to `main` (paths-filtered) and rebuilds 6 Docker images; `test.yaml` runs full CI from `main`. Live branch protection additionally sets `allow_force_pushes: false`, and repo ruleset id `2660650` ("Only admin commits") adds `non_fast_forward` + `required_linear_history` blocks (verified live via `gh api repos/.../branches/main/protection` and `gh api repos/.../rulesets`). A force-push to `main` would desync in-flight release/Docker pipelines that key off a specific commit.
+`CONTRIBUTING.md`: "**Don't force-push to `main`.** Releases build from it." `docker-publish.yml` publishes kernel Docker images from `main` (kernel-path-filtered, only when the kernel version is unpublished; app images publish from `v*` tags); `test.yaml` runs full CI from `main`. Live branch protection additionally sets `allow_force_pushes: false`, and repo ruleset id `2660650` ("Only admin commits") adds `non_fast_forward` + `required_linear_history` blocks (verified live via `gh api repos/.../branches/main/protection` and `gh api repos/.../rulesets`). A force-push to `main` would desync in-flight release/Docker pipelines that key off a specific commit.
 
 ### 2b. Version bumps move in lockstep — never hand-edit a manifest
 
@@ -129,24 +129,24 @@ The codebase has a set of intentional, by-design refusals — places where a fea
 3. `make check-version` — must print "All versions in sync"
 4. Open a PR (branch protection blocks direct pushes to `main`), get it merged
 5. Tag the merge commit **lowercase** `vX.Y.Z` and push the tag
-6. This fires `pypi-release.yml` **and** `release.yaml` simultaneously (§3b)
-7. `release.yaml` publishing the GitHub Release fires `docker-publish.yml` again via its `release: published` trigger (§3c)
-8. **Manual, and historically never done:** assemble and attach `latest.json` to the release per the schema in `flowfile_frontend/src-tauri/SIGNING.md` (§3d)
+6. This fires `pypi-release.yml`, `release.yaml`, **and** `docker-publish.yml` (app Docker images) simultaneously (§3b)
+7. **Manual, and historically never done:** assemble and attach `latest.json` to the release per the schema in `flowfile_frontend/src-tauri/SIGNING.md` (§3d)
 
-### 3b. One `v*` tag push → two workflows
+### 3b. One `v*` tag push → three workflows
 
 | Workflow | What it does | Hard gate |
 |---|---|---|
 | `pypi-release.yml` | Builds web frontend into `flowfile/flowfile/web/static/`, `poetry build`, publishes to PyPI via **Trusted Publishing (OIDC)** — no API token | `python3 tools/check_version_sync.py --expect "${GITHUB_REF#refs/tags/v}"` — dies instantly if tag ≠ manifest version |
 | `release.yaml` | Builds Tauri desktop installers on a 4-platform matrix (macOS arm64/x86_64, Windows, Linux), signs/notarizes macOS, publishes the GitHub Release | Same `check_version_sync.py --expect` gate, run per-platform before the Rust/PyInstaller build starts |
+| `docker-publish.yml` | Publishes app Docker images (`flowfile-core`/`-worker`/`-frontend`) as `:<version>` + `:latest` (no `latest` for `-`-suffixed prerelease tags); self-heals any unpublished kernel image version in the same run | Same `check_version_sync.py --expect` gate, plus `tools/check_kernel_version_sync.py` (manager.py kernel pins must match `kernel_runtime/pyproject.toml`) |
 
-Both gates mean: **tag before bumping = both release pipelines fail fast**, which is the intended failure mode (better than shipping a mismatched artifact).
+The shared gate means: **tag before bumping = all release pipelines fail fast**, which is the intended failure mode (better than shipping a mismatched artifact).
 
 `wasm-v*` tags separately fire `npm-publish-wasm.yml` (publishes `flowfile-editor` to npm with provenance). As of 2026-07-03 no `wasm-v*` tag has ever been pushed to this repo — all historical runs of that workflow were manual `workflow_dispatch`, and most failed. Treat the npm publish channel as stalled/experimental, not a proven path.
 
-### 3c. `docker-publish.yml` fires twice per release cycle
+### 3c. `docker-publish.yml` fires once per release, plus kernel-only runs from `main`
 
-Once on the `main`-push that merges the version-bump PR (paths-filtered on backend/frontend/worker/kernel dirs), and again on the `release: published` event once `release.yaml` cuts the GitHub Release. Docker image tags come from `poetry version -s` (root and `kernel_runtime/`) — **from the manifest, not from the git tag** — so this is consistent as long as §2b held.
+App images publish once per release, from the `v*` tag (the old `release: published` re-fire and per-main-push publishing were removed — the `GH_TOKEN` PAT on `release.yaml`'s release step no longer serves that re-fire purpose). Kernel images (`flowfile-kernel-base/ml/lite`) publish from `main` pushes touching kernel paths, and **only when `flowfile-kernel-*:<kernel_version>` is absent from Docker Hub** (`tools/docker_publish_matrix.py` checks; `workflow_dispatch` `force_kernel` overrides, `publish_app` republishes app images at the manifest version). Published version tags are therefore immutable in practice. Versions come from the manifests (root and `kernel_runtime/` `pyproject.toml`), with the `--expect` gate tying app tags to the git tag per §2b.
 
 ### 3d. The auto-updater gap (verified live, still true)
 
@@ -267,7 +267,7 @@ git tag | grep -viE "^v?[0-9]"                                    # expect stray
 
 # v*/wasm-v* release triggers
 grep -n "check_version_sync" .github/workflows/pypi-release.yml .github/workflows/release.yaml
-grep -n "on:" -A6 .github/workflows/docker-publish.yml            # confirm push(paths) + release:published + dispatch
+grep -n "on:" -A24 .github/workflows/docker-publish.yml           # confirm push(main kernel paths + v* tags) + dispatch(publish_app/force_kernel)
 git tag | grep -i "^wasm-v"                                       # expect empty (no wasm-v* tag ever pushed)
 
 # latest.json auto-updater gap

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -125,6 +125,7 @@ jobs:
   merge:
     name: Create multi-arch manifest for ${{ matrix.image }}
     runs-on: ubuntu-latest
+    # No has_work guard needed: when build is skipped, the skip cascades through needs.
     needs: [prepare, build]
     strategy:
       matrix: ${{ fromJSON(needs.prepare.outputs.merge_matrix) }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,160 +3,84 @@ name: Build and Push Docker Images to Docker Hub
 permissions:
   contents: read
 
+# App images (core/frontend/worker) publish on v* tag pushes, gated on the tag
+# matching the manifests. Kernel images publish from main only when
+# flowfile-kernel-*:<kernel_version> is not on Docker Hub yet, so published
+# version tags stay immutable and a missed publish self-heals.
 on:
   push:
     branches:
       - main
+    # Path filters are not evaluated for tag pushes, so v* tags always fire;
+    # branch pushes fire only for kernel-publishing paths.
     paths:
-      - 'flowfile_core/**'
-      - 'flowfile_frontend/**'
-      - 'flowfile_worker/**'
       - 'kernel_runtime/**'
-      - 'shared/**'
-      - 'tools/**'
-      - 'pyproject.toml'
-      - 'docker-compose.yml'
+      - 'flowfile_core/flowfile_core/kernel/manager.py'
+      - 'tools/check_kernel_version_sync.py'
+      - 'tools/docker_publish_matrix.py'
       - '.github/workflows/docker-publish.yml'
-  release:
-    types: [published]
+    tags:
+      - 'v*'
   workflow_dispatch:
+    inputs:
+      publish_app:
+        description: 'Publish app images (core/worker/frontend) at the manifest version'
+        type: boolean
+        default: false
+      force_kernel:
+        description: 'Republish kernel images even if the version tag exists on Docker Hub'
+        type: boolean
+        default: false
+
+# Per-ref on purpose: a queued main run may be superseded by a newer main push,
+# but a queued tag (release) run must never be cancelled by one.
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   prepare:
-    name: Extract Versions
+    name: Gates and publish matrix
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
-      kernel_version: ${{ steps.kernel_version.outputs.kernel_version }}
+      app_version: ${{ steps.matrix.outputs.app_version }}
+      kernel_version: ${{ steps.matrix.outputs.kernel_version }}
+      # Matrices carry bare image names: GitHub drops job outputs containing a
+      # secret value (DOCKERHUB_USERNAME), so the org is applied in steps.
+      build_matrix: ${{ steps.matrix.outputs.build_matrix }}
+      merge_matrix: ${{ steps.matrix.outputs.merge_matrix }}
+      has_work: ${{ steps.matrix.outputs.has_work }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install Poetry
+      - name: Version gates
         run: |
-          curl -sSL https://install.python-poetry.org | python -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            python3 tools/check_version_sync.py --expect "${GITHUB_REF#refs/tags/v}"
+          else
+            python3 tools/check_version_sync.py
+          fi
+          python3 tools/check_kernel_version_sync.py
 
-      - name: Extract root version from Poetry
-        id: version
-        run: |
-          VERSION=$(poetry version -s)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Root version: $VERSION"
-
-      - name: Extract kernel version from Poetry
-        id: kernel_version
-        working-directory: kernel_runtime
-        run: |
-          VERSION=$(poetry version -s)
-          echo "kernel_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Kernel version: $VERSION"
+      - name: Compute publish matrix
+        id: matrix
+        env:
+          DOCKERHUB_ORG: ${{ secrets.DOCKERHUB_USERNAME }}
+          PUBLISH_APP: ${{ github.ref_type == 'tag' || (github.event_name == 'workflow_dispatch' && inputs.publish_app == true) }}
+          FORCE_KERNEL: ${{ github.event_name == 'workflow_dispatch' && inputs.force_kernel == true }}
+        run: python3 tools/docker_publish_matrix.py
 
   build:
     name: Build ${{ matrix.image }} for ${{ matrix.platform }}
     needs: prepare
+    # Load-bearing: an empty include matrix is a workflow error, not a skip.
+    if: needs.prepare.outputs.has_work == 'true'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # AMD64 builds — application images
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            image: flowfile-core
-            dockerfile: ./flowfile_core/Dockerfile
-            context: .
-            extras: ""
-            version: ${{ needs.prepare.outputs.version }}
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            image: flowfile-frontend
-            dockerfile: ./flowfile_frontend/Dockerfile
-            context: .
-            extras: ""
-            version: ${{ needs.prepare.outputs.version }}
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            image: flowfile-worker
-            dockerfile: ./flowfile_worker/Dockerfile
-            context: .
-            extras: ""
-            version: ${{ needs.prepare.outputs.version }}
-          # AMD64 builds — kernel images
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            image: flowfile-kernel-base
-            dockerfile: ./kernel_runtime/Dockerfile
-            context: ./kernel_runtime
-            extras: ""
-            version: ${{ needs.prepare.outputs.kernel_version }}
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            image: flowfile-kernel-ml
-            dockerfile: ./kernel_runtime/Dockerfile
-            context: ./kernel_runtime
-            extras: "ml"
-            version: ${{ needs.prepare.outputs.kernel_version }}
-          - platform: linux/amd64
-            runner: ubuntu-latest
-            image: flowfile-kernel-lite
-            dockerfile: ./kernel_runtime/Dockerfile
-            context: ./kernel_runtime
-            extras: ""
-            slim_constraints: "true"
-            version: ${{ needs.prepare.outputs.kernel_version }}
-          # ARM64 builds — application images (native!)
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            image: flowfile-core
-            dockerfile: ./flowfile_core/Dockerfile
-            context: .
-            extras: ""
-            version: ${{ needs.prepare.outputs.version }}
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            image: flowfile-frontend
-            dockerfile: ./flowfile_frontend/Dockerfile
-            context: .
-            extras: ""
-            version: ${{ needs.prepare.outputs.version }}
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            image: flowfile-worker
-            dockerfile: ./flowfile_worker/Dockerfile
-            context: .
-            extras: ""
-            version: ${{ needs.prepare.outputs.version }}
-          # ARM64 builds — kernel images (native!)
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            image: flowfile-kernel-base
-            dockerfile: ./kernel_runtime/Dockerfile
-            context: ./kernel_runtime
-            extras: ""
-            version: ${{ needs.prepare.outputs.kernel_version }}
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            image: flowfile-kernel-ml
-            dockerfile: ./kernel_runtime/Dockerfile
-            context: ./kernel_runtime
-            extras: "ml"
-            version: ${{ needs.prepare.outputs.kernel_version }}
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
-            image: flowfile-kernel-lite
-            dockerfile: ./kernel_runtime/Dockerfile
-            context: ./kernel_runtime
-            extras: ""
-            slim_constraints: "true"
-            version: ${{ needs.prepare.outputs.kernel_version }}
-
+      matrix: ${{ fromJSON(needs.prepare.outputs.build_matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -170,17 +94,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ matrix.version }}
-            type=raw,value=test,enable=${{ github.ref != 'refs/heads/main' }}
-            type=sha,prefix=sha-
-
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v5
@@ -190,7 +103,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             EXTRAS=${{ matrix.extras }}
-            SLIM_CONSTRAINTS=${{ matrix.slim_constraints || 'false' }}
+            SLIM_CONSTRAINTS=${{ matrix.slim_constraints }}
           outputs: type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.platform }}
@@ -204,7 +117,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: digests-${{ matrix.image }}-${{ matrix.arch }}
           path: /tmp/digests/${{ matrix.image }}/*
           if-no-files-found: error
           retention-days: 1
@@ -214,20 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, build]
     strategy:
-      matrix:
-        include:
-          - image: flowfile-core
-            version: ${{ needs.prepare.outputs.version }}
-          - image: flowfile-frontend
-            version: ${{ needs.prepare.outputs.version }}
-          - image: flowfile-worker
-            version: ${{ needs.prepare.outputs.version }}
-          - image: flowfile-kernel-base
-            version: ${{ needs.prepare.outputs.kernel_version }}
-          - image: flowfile-kernel-ml
-            version: ${{ needs.prepare.outputs.kernel_version }}
-          - image: flowfile-kernel-lite
-            version: ${{ needs.prepare.outputs.kernel_version }}
+      matrix: ${{ fromJSON(needs.prepare.outputs.merge_matrix) }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -245,57 +145,53 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ matrix.version }}
-            type=raw,value=test,enable=${{ github.ref != 'refs/heads/main' }}
-            type=sha,prefix=sha-
-
       - name: Create manifest list and push
         working-directory: /tmp/digests/${{ matrix.image }}
+        env:
+          ORG: ${{ secrets.DOCKERHUB_USERNAME }}
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}@sha256:%s ' *)
+          tag_args=""
+          for tag in ${{ matrix.tags }}; do
+            tag_args="$tag_args -t $ORG/${{ matrix.image }}:$tag"
+          done
+          docker buildx imagetools create $tag_args \
+            $(printf "$ORG/${{ matrix.image }}@sha256:%s " *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:${{ matrix.version }}
 
   summary:
-    name: Build Summary
+    name: Publish Summary
     runs-on: ubuntu-latest
-    needs: [prepare, merge]
+    needs: [prepare, build, merge]
     if: always()
     steps:
       - name: Create summary
+        env:
+          ORG: ${{ secrets.DOCKERHUB_USERNAME }}
+          MERGE_MATRIX: ${{ needs.prepare.outputs.merge_matrix }}
         run: |
-          APP_VERSION="${{ needs.prepare.outputs.version }}"
-          KERNEL_VERSION="${{ needs.prepare.outputs.kernel_version }}"
-          USER="${{ secrets.DOCKERHUB_USERNAME }}"
           {
-            echo "## Docker Images Published 🚀"
-            echo ""
-            echo "Application version: **$APP_VERSION**"
-            echo "Kernel version: **$KERNEL_VERSION**"
-            echo ""
-            echo "### Application images:"
-            echo "- \`$USER/flowfile-core:$APP_VERSION\`, \`$USER/flowfile-core:latest\`"
-            echo "- \`$USER/flowfile-frontend:$APP_VERSION\`, \`$USER/flowfile-frontend:latest\`"
-            echo "- \`$USER/flowfile-worker:$APP_VERSION\`, \`$USER/flowfile-worker:latest\`"
-            echo ""
-            echo "### Kernel images:"
-            echo "- \`$USER/flowfile-kernel-base:$KERNEL_VERSION\`, \`$USER/flowfile-kernel-base:latest\`"
-            echo "- \`$USER/flowfile-kernel-ml:$KERNEL_VERSION\`, \`$USER/flowfile-kernel-ml:latest\`"
-            echo "- \`$USER/flowfile-kernel-lite:$KERNEL_VERSION\`, \`$USER/flowfile-kernel-lite:latest\`"
-            echo ""
-            echo "### Platforms:"
-            echo "- linux/amd64 (native)"
-            echo "- linux/arm64 (native)"
-            echo ""
-            echo "Built in parallel on native runners — no QEMU emulation! ⚡"
+            if [ "${{ needs.prepare.result }}" != "success" ]; then
+              echo "## Docker publish failed at the gates ❌"
+              echo ""
+              echo "Version gates or matrix computation failed — nothing was published."
+            elif [ "${{ needs.prepare.outputs.has_work }}" != "true" ]; then
+              echo "## Nothing to publish"
+              echo ""
+              echo "Kernel ${{ needs.prepare.outputs.kernel_version }} is already on Docker Hub (bump \`kernel_runtime/pyproject.toml\` to release a kernel change); app images publish on \`v*\` tag pushes."
+            elif [ "${{ needs.merge.result }}" = "success" ]; then
+              echo "## Docker Images Published 🚀"
+              echo ""
+              jq -r --arg org "$ORG" \
+                '.include[] | . as $i | "- " + ($i.tags | split(" ") | map("`\($org)/\($i.image):\(.)`") | join(", "))' \
+                <<< "$MERGE_MATRIX"
+              echo ""
+              echo "Platforms: linux/amd64 + linux/arm64 (native runners, no QEMU)."
+            else
+              echo "## Docker publish incomplete ⚠️"
+              echo ""
+              echo "Build or merge failed — tags were NOT moved for images whose merge did not complete. Use 'Re-run failed jobs'."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,7 +341,7 @@ npm run lint          # eslint --fix ./src/**/*.{ts,vue} (renderer TS/Vue only)
 | `test-kernel-integration.yml` | Push/PR to `main` (kernel_runtime, kernel/artifacts code + tests) | Kernel integration tests |
 | `test-kafka-integration.yml` | Push/PR to `main` (kafka code + tests) | Kafka integration tests |
 | `flowfile-wasm-build.yml` | Push/PR to `main` (`flowfile_wasm/**`) | Build WASM version and run its test suite |
-| `docker-publish.yml` | Push to `main` (backend/frontend/worker/kernel/shared/tools paths), `release` published | Multi-arch Docker builds (amd64/arm64) → Docker Hub |
+| `docker-publish.yml` | Git tags `v*` (app images, version-gated) + push to `main` touching kernel paths (kernel images, only unpublished versions) + dispatch (`publish_app`/`force_kernel`) | Multi-arch Docker builds (amd64/arm64) → Docker Hub |
 | `documentation.yml` | Push/PR to `main` (`docs/**`, `mkdocs.yml`, `flowfile_frame/**/*.py`) | Build and deploy MkDocs site |
 | `pypi-release.yml` | Git tags `v*` | Build frontend into static, Poetry build, publish to PyPI |
 | `release.yaml` | Git tags `v*` | Build & sign Tauri desktop installers (macOS arm64/intel, Windows, Linux), publish GitHub release |
@@ -350,7 +350,7 @@ npm run lint          # eslint --fix ./src/**/*.{ts,vue} (renderer TS/Vue only)
 | `claude-pr-review.yml` | PR opened/synchronize/ready/reopened (skips drafts) | Automated Claude PR review |
 | `codeql.yaml` | Weekly cron + manual | Legacy advanced CodeQL scan (broken config reference — see note above) |
 
-> Release tags: pushing a `v*` tag fires **both** `pypi-release.yml` (PyPI) and `release.yaml` (desktop installers); a `wasm-v*` tag fires the npm WASM publish.
+> Release tags: pushing a `v*` tag fires `pypi-release.yml` (PyPI), `release.yaml` (desktop installers), **and** `docker-publish.yml` (app Docker images); a `wasm-v*` tag fires the npm WASM publish.
 
 ## Environment Variables
 
@@ -467,4 +467,4 @@ that's what you're debugging). Both flags default off; production runs stay sile
 - Tests and test_utils are excluded from Ruff linting (except specific per-file rules)
 - The `kernel`, `docker_integration`, and `kafka` pytest markers all require Docker
 - Do not "fix" the SHA-256 API-key hash (`flowfile_core/auth/api_key.py`) — it is deliberate for 256-bit tokens; the CodeQL weak-hash alert is a false positive
-- Never force-push to `main`; CI builds Docker images from it (`docker-publish.yml` on push) and the test pipeline runs from it. PyPI/desktop releases run from `v*` tags
+- Never force-push to `main`; CI publishes kernel Docker images from it (`docker-publish.yml` on kernel-path pushes) and the test pipeline runs from it. PyPI/desktop/app-Docker releases run from `v*` tags

--- a/docs/for-developers/kernel-architecture.md
+++ b/docs/for-developers/kernel-architecture.md
@@ -77,14 +77,14 @@ Flowfile does **not** define compatibility *ranges* between app and kernel versi
 | Version | Where | Role |
 |---------|-------|------|
 | App / root | root `pyproject.toml` `version` | The Flowfile release |
-| Kernel **image** tag | `flowfile_core/flowfile_core/kernel/manager.py` (`_KERNEL_IMAGE_{BASE,ML,LITE}_DEFAULT`, `0.5.0` as of 2026-07) | The image the app pulls / runs |
+| Kernel **image** tag | `flowfile_core/flowfile_core/kernel/manager.py` (`_KERNEL_IMAGE_{BASE,ML,LITE}_DEFAULT` — read the current value there) | The image the app pulls / runs |
 | Kernel **runtime API** | `kernel_runtime/__init__.py` (`__version__`) | The kernel's HTTP API version, reported by `/health` |
 
 Read each value from its source rather than assuming a number — the three are decoupled. They evolve **independently**: bumping the app does not require bumping the kernel image, and vice versa.
 
 ### How the pin works
 
-- Each Flowfile version hardcodes **one exact kernel tag per flavour** (e.g. `edwardvaneechoud/flowfile-kernel-ml:0.5.1`) in `manager.py`. That single tag — not a `>=x,<y` range — is the version the app is built and tested against.
+- Each Flowfile version hardcodes **one exact kernel tag per flavour** (e.g. `edwardvaneechoud/flowfile-kernel-ml:<version>`) in `manager.py`. That single tag — not a `>=x,<y` range — is the version the app is built and tested against.
 - Core reads the running kernel's runtime version from `/health` into `KernelInfo.kernel_version` **for display only** (the "Kernel runtime" line in the Kernel Manager). There is no min/max gate and nothing that rejects or warns about an "out-of-range" kernel.
 - The only **hard** coupling is **polars**: `kernel_runtime` pins a polars (and the `polars-ds` plugin) compatible with the app's `polars >=1.8.2,<1.40`. These must be bumped together, but that compatibility is guaranteed at *image-build time* via the pinned tag — not by a runtime check.
 
@@ -95,8 +95,8 @@ So the practical contract is "use the pinned tag." An older kernel image is **no
 Because the app only re-pulls a kernel tag it doesn't already have locally (`images.get(tag)` pulls only on a miss), a fix to `kernel_runtime/` reaches users only when the image **tag changes**:
 
 1. Bump `version` in `kernel_runtime/pyproject.toml` (CI tags the published images from it).
-2. Bump the three `_KERNEL_IMAGE_{BASE,ML,LITE}_DEFAULT` tags in `manager.py` to match.
-3. Merge — CI (`docker-publish.yml`) builds and pushes `flowfile-kernel-{base,ml,lite}:<new>`. On the next kernel start the app requests the new tag, misses locally, and pulls it.
+2. Bump the three `_KERNEL_IMAGE_{BASE,ML,LITE}_DEFAULT` tags in `manager.py` to match. CI enforces this pairing: `tools/check_kernel_version_sync.py` hard-fails the publish run when the pins and the kernel version drift.
+3. Merge — CI (`docker-publish.yml`) checks Docker Hub and builds/pushes `flowfile-kernel-{base,ml,lite}:<new>` only if that tag is absent, so published version tags stay immutable and a missed publish self-heals on the next kernel-path push. (A `workflow_dispatch` with `force_kernel` republishes an existing tag.) On the next kernel start the app requests the new tag, misses locally, and pulls it.
 
 For local development, build the image yourself (`docker build -t flowfile-kernel-base:local kernel_runtime/`); the `:local` tag is preferred by the resolver when the pinned registry tag isn't present, and is excluded from the version comparison (so it shows as a **local** build, not "up to date" or "update available").
 

--- a/docs/users/deployment/docker.md
+++ b/docs/users/deployment/docker.md
@@ -49,7 +49,7 @@ python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().d
 | `edwardvaneechoud/flowfile-kernel-ml` | Python-script kernel with sklearn / xgboost / lightgbm / statsmodels |
 | `edwardvaneechoud/flowfile-kernel-lite` | Slimmed Python-script kernel for constrained hosts |
 
-The application images (`flowfile-frontend`, `flowfile-core`, `flowfile-worker`) share the project version (tagged `latest`, the release version, and `sha-...`). The kernel images carry their own version so the kernel runtime can evolve independently of the rest of the application; the tag core pulls by default is set in `flowfile_core/flowfile_core/kernel/manager.py` (`_KERNEL_IMAGE_*_DEFAULT`).
+The application images (`flowfile-frontend`, `flowfile-core`, `flowfile-worker`) share the project version and are published once per release: each `v*` tag pushes `:<version>`, and stable releases also move `:latest` (prerelease tags with a `-` suffix, e.g. `-rc.1`, don't). The kernel images carry their own version so the kernel runtime can evolve independently of the rest of the application; they are published only when that version is new, and the tag core pulls by default is set in `flowfile_core/flowfile_core/kernel/manager.py` (`_KERNEL_IMAGE_*_DEFAULT`).
 
 ## docker-compose.yml
 

--- a/tools/check_kernel_version_sync.py
+++ b/tools/check_kernel_version_sync.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fail if flowfile_core's kernel image pins drift from the kernel_runtime version (CI guard).
+
+kernel_runtime/pyproject.toml carries the kernel image version that CI publishes;
+flowfile_core/kernel/manager.py hardcodes the exact registry tags core pulls at
+runtime. The two must move together — see docs/for-developers/kernel-architecture.md,
+"Shipping a kernel change".
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+KERNEL_PYPROJECT = ROOT / "kernel_runtime/pyproject.toml"
+MANAGER = ROOT / "flowfile_core/flowfile_core/kernel/manager.py"
+
+
+def _section_version(path: Path, section: str) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    pattern = r"^\[" + re.escape(section) + r"\][^\n]*\n(.*?)(?=^\[|\Z)"
+    section_match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+    if not section_match:
+        return None
+    version_match = re.search(r"""^\s*version\s*=\s*["']([^"']+)["']""", section_match.group(1), re.MULTILINE)
+    return version_match.group(1) if version_match else None
+
+
+def main() -> int:
+    kernel_version = _section_version(KERNEL_PYPROJECT, "tool.poetry")
+    if not kernel_version:
+        print(f"Could not read the kernel version from {KERNEL_PYPROJECT}.", file=sys.stderr)
+        return 1
+
+    pins = re.findall(r'_KERNEL_IMAGE_(BASE|ML|LITE)_DEFAULT\s*=\s*"([^"]+)"', MANAGER.read_text(encoding="utf-8"))
+    if len(pins) < 3:
+        print(f"Expected 3 _KERNEL_IMAGE_*_DEFAULT pins in {MANAGER}, found {len(pins)}.", file=sys.stderr)
+        return 1
+
+    print(f"  kernel_runtime/pyproject.toml   {kernel_version}")
+    drifted = False
+    for flavour, ref in pins:
+        tag = ref.rsplit(":", 1)[-1]
+        print(f"  manager.py {flavour:<4} pin             {ref}")
+        if tag != kernel_version:
+            drifted = True
+
+    if drifted:
+        print(
+            f"\nKernel image pin drift: manager.py pins do not match kernel_runtime/pyproject.toml "
+            f"({kernel_version!r}). Bump the three _KERNEL_IMAGE_*_DEFAULT pins together with the "
+            'kernel version (docs/for-developers/kernel-architecture.md, "Shipping a kernel change").',
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\nKernel image pins in sync: {kernel_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/docker_publish_matrix.py
+++ b/tools/docker_publish_matrix.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Compute the docker-publish build/merge matrices (CI helper for docker-publish.yml).
+
+Writes app_version / kernel_version / build_matrix / merge_matrix / has_work to
+$GITHUB_OUTPUT. App images are included when PUBLISH_APP is true (v* tag runs and
+the publish_app dispatch input); kernel images only when Docker Hub is missing
+flowfile-kernel-<flavour>:<kernel_version> — or FORCE_KERNEL is true — so
+published kernel version tags stay immutable and a missed publish self-heals on
+the next qualifying run.
+
+The matrices deliberately carry bare image names: DOCKERHUB_ORG comes from a
+repository secret, and GitHub silently drops job outputs containing a secret
+value. The org is applied inside workflow steps instead.
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PLATFORMS = [
+    ("linux/amd64", "ubuntu-latest", "amd64"),
+    ("linux/arm64", "ubuntu-24.04-arm", "arm64"),
+]
+APP_IMAGES = [
+    ("flowfile-core", "./flowfile_core/Dockerfile"),
+    ("flowfile-frontend", "./flowfile_frontend/Dockerfile"),
+    ("flowfile-worker", "./flowfile_worker/Dockerfile"),
+]
+KERNEL_IMAGES = [
+    ("flowfile-kernel-base", "", "false"),
+    ("flowfile-kernel-ml", "ml", "false"),
+    ("flowfile-kernel-lite", "", "true"),
+]
+
+
+def _section_version(path: Path, section: str) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    pattern = r"^\[" + re.escape(section) + r"\][^\n]*\n(.*?)(?=^\[|\Z)"
+    section_match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
+    if not section_match:
+        return None
+    version_match = re.search(r"""^\s*version\s*=\s*["']([^"']+)["']""", section_match.group(1), re.MULTILINE)
+    return version_match.group(1) if version_match else None
+
+
+def _tags_for(version: str) -> list[str]:
+    return [version] if "-" in version else [version, "latest"]
+
+
+def _tag_exists(org: str, image: str, tag: str) -> bool:
+    """True if the tag exists on Docker Hub, False on 404, hard-fail otherwise.
+
+    Never guesses: an unexpected status or an unreachable Hub aborts the run
+    instead of risking a republish over an existing tag.
+    """
+    url = f"https://hub.docker.com/v2/repositories/{org}/{image}/tags/{tag}"
+    last_error: Exception | None = None
+    for attempt in range(3):
+        if attempt:
+            time.sleep(2**attempt)
+        try:
+            with urllib.request.urlopen(url, timeout=15):
+                return True
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return False
+            last_error = exc
+        except urllib.error.URLError as exc:
+            last_error = exc
+    raise SystemExit(f"Could not determine whether {image}:{tag} exists on Docker Hub ({last_error}); aborting.")
+
+
+def main() -> int:
+    org = os.environ["DOCKERHUB_ORG"].strip()
+    publish_app = os.environ.get("PUBLISH_APP", "").strip().lower() == "true"
+    force_kernel = os.environ.get("FORCE_KERNEL", "").strip().lower() == "true"
+
+    app_version = _section_version(ROOT / "pyproject.toml", "tool.poetry")
+    kernel_version = _section_version(ROOT / "kernel_runtime/pyproject.toml", "tool.poetry")
+    if not app_version or not kernel_version:
+        print("Could not read versions from the pyproject manifests.", file=sys.stderr)
+        return 1
+
+    build_cells: list[dict[str, str]] = []
+    merge_cells: list[dict[str, str]] = []
+
+    def add_image(image: str, dockerfile: str, context: str, extras: str, slim: str, version: str) -> None:
+        for platform, runner, arch in PLATFORMS:
+            build_cells.append(
+                {
+                    "image": image,
+                    "dockerfile": dockerfile,
+                    "context": context,
+                    "extras": extras,
+                    "slim_constraints": slim,
+                    "version": version,
+                    "platform": platform,
+                    "runner": runner,
+                    "arch": arch,
+                }
+            )
+        merge_cells.append({"image": image, "version": version, "tags": " ".join(_tags_for(version))})
+
+    if publish_app:
+        for image, dockerfile in APP_IMAGES:
+            add_image(image, dockerfile, ".", "", "false", app_version)
+
+    for image, extras, slim in KERNEL_IMAGES:
+        if force_kernel or not _tag_exists(org, image, kernel_version):
+            add_image(image, "./kernel_runtime/Dockerfile", "./kernel_runtime", extras, slim, kernel_version)
+        else:
+            print(f"::notice::{image}:{kernel_version} already exists on Docker Hub — skipped.")
+
+    for cell in merge_cells:
+        print(f"Will publish {cell['image']} tags: {cell['tags']}")
+    if not build_cells:
+        message = (
+            f"Nothing to publish. Kernel {kernel_version} is already on Docker Hub (bump "
+            "kernel_runtime/pyproject.toml to release a kernel change); app images publish on "
+            "v* tag pushes (or a dispatch with publish_app)."
+        )
+        print(message)
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(f"## Docker publish\n\n{message}\n")
+
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+        fh.write(f"app_version={app_version}\n")
+        fh.write(f"kernel_version={kernel_version}\n")
+        fh.write(f"build_matrix={json.dumps({'include': build_cells})}\n")
+        fh.write(f"merge_matrix={json.dumps({'include': merge_cells})}\n")
+        fh.write(f"has_work={'true' if build_cells else 'false'}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION

This pull request significantly refactors the Docker image publishing workflow to make image publishing more robust, predictable, and maintainable. The main improvements are: app images now publish only on `v*` tag pushes (not on every `main` push or GitHub Release), kernel images publish from `main` only when a new version is detected, and the workflow dynamically computes which images need to be built and published. The workflow also now provides clearer summaries and error handling, and the documentation is updated to reflect these changes.

**Docker workflow refactor and improvements:**

* `.github/workflows/docker-publish.yml`:
  - Refactored triggers: app images (`flowfile-core`, `-worker`, `-frontend`) now publish only on `v*` tag pushes, kernel images publish from `main` when a new version is not yet on Docker Hub, and both can be manually triggered via workflow dispatch with new inputs (`publish_app`, `force_kernel`). Path filters for `main` pushes now only include kernel-relevant files.
  - Removed the `release: published` trigger, so app images are no longer republished on GitHub Release creation.
  - The build and merge matrices are now dynamically computed in Python (`tools/docker_publish_matrix.py`), removing the large static matrix and ensuring only necessary images are built and published.
  - Improved summary and error reporting: the workflow now provides clear output if nothing needs to be published, if gates fail, or if any build/merge fails.
  - Cleaned up and simplified Docker build/push steps, including tag handling and artifact naming. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L173-L183) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L207-R120)

**Documentation updates:**

* `.claude/skills/flowfile-change-control/SKILL.md`:
  - Updated all descriptions of the Docker publishing process to match the new workflow: clarified when and how app and kernel images are published, removed references to the old triggers, and explained the new self-healing and gating logic. [[1]](diffhunk://#diff-e1cf09febb15e87d2e09a088e81c5168014943679d236d5479dea83f4ee46326L44-R44) [[2]](diffhunk://#diff-e1cf09febb15e87d2e09a088e81c5168014943679d236d5479dea83f4ee46326L132-R149) [[3]](diffhunk://#diff-e1cf09febb15e87d2e09a088e81c5168014943679d236d5479dea83f4ee46326L270-R270)
* `CLAUDE.md`:
  - Updated the workflow summary table and release tag notes to accurately reflect the new triggers and behavior for `docker-publish.yml`. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L344-R344) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L353-R353)

These changes make Docker image publishing safer (no more accidental overwrites), more efficient (only builds what’s needed), and easier to understand and maintain.