### PR TITLE
set time out to 24 hours for kernel

### DIFF
--- a/flowfile_core/flowfile_core/kernel/manager.py
+++ b/flowfile_core/flowfile_core/kernel/manager.py
@@ -46,6 +46,8 @@ _KERNEL_DOWN_MSG = (
     "core restart). Run the cell again to restart it."
 )
 
+_CELL_EXECUTION_TIMEOUT = 86_400.0
+
 
 def _envvar_or_default(name: str, default: str) -> str:
     """Read an env var, treating unset OR empty/whitespace as 'use default'.
@@ -1820,7 +1822,7 @@ class KernelManager:
 
             if cancel_event is None:
                 # Simple blocking call (no cancellation support)
-                with httpx.Client(timeout=httpx.Timeout(300.0)) as client:
+                with httpx.Client(timeout=httpx.Timeout(_CELL_EXECUTION_TIMEOUT)) as client:
                     response = client.post(url, json=request.model_dump())
                     response.raise_for_status()
                     return ExecuteResult(**response.json())
@@ -1831,7 +1833,7 @@ class KernelManager:
 
             def _post() -> None:
                 try:
-                    with httpx.Client(timeout=httpx.Timeout(300.0)) as client:
+                    with httpx.Client(timeout=httpx.Timeout(_CELL_EXECUTION_TIMEOUT)) as client:
                         resp = client.post(url, json=request.model_dump())
                         resp.raise_for_status()
                         result_holder[0] = ExecuteResult(**resp.json())
@@ -1879,7 +1881,10 @@ class KernelManager:
                 self.interrupt_execution_sync(kernel_id)
                 return ExecuteResult(
                     success=False,
-                    error="Cell exceeded the 300s execution limit and was interrupted.",
+                    error=(
+                        f"Cell exceeded the {_CELL_EXECUTION_TIMEOUT:.0f}s execution limit and was interrupted. "
+                        "The kernel stopped responding — check whether its container is healthy."
+                    ),
                 )
             raise
         finally:

--- a/flowfile_core/tests/test_kernel_start_race.py
+++ b/flowfile_core/tests/test_kernel_start_race.py
@@ -571,7 +571,7 @@ class TestExecuteSerialization:
 
         result = mgr.execute_sync("ml", _request())
         assert result.success is False
-        assert "300s" in (result.error or "")
+        assert f"{kernel_manager._CELL_EXECUTION_TIMEOUT:.0f}s" in (result.error or "")
         mgr.interrupt_execution_sync.assert_called_once_with("ml")
 
         follow_up = mgr.execute_sync("ml", _request())

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/ColumnSelector.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/ColumnSelector.vue
@@ -61,11 +61,16 @@ const filteredColumns = computed(() => {
   }
 
   if (Array.isArray(dataTypes)) {
-    // A data_types entry is a specific polars type ("Int64") or a group ("Numeric"),
-    // so a column matches on either its concrete dtype or its data_type_group.
+    // A data_types entry is a specific polars type ("Int64") or a group ("Numeric"), so a column
+    // matches on its concrete dtype or its data_type_group. Parameterized dtypes arrive stringified
+    // with their inner type ("Array(Float32, shape=(384,))", "Datetime(time_unit='us')"), so they
+    // also match on the base token — mirroring get_readable_datatype_group() in core.
+    const baseType = (dtype: string) => (dtype ?? "").split("(")[0];
     return props.incomingColumns.filter(
       (column) =>
-        dataTypes.includes(column.data_type) || dataTypes.includes(column.data_type_group),
+        dataTypes.includes(column.data_type) ||
+        dataTypes.includes(baseType(column.data_type)) ||
+        dataTypes.includes(column.data_type_group),
     );
   }
 

--- a/shared/delta_utils.py
+++ b/shared/delta_utils.py
@@ -135,6 +135,27 @@ def _validate_partition_columns(df: pl.LazyFrame | pl.DataFrame, partition_by: l
         raise ValueError(f"partition_by columns not present in data: {missing}")
 
 
+def _lists_from_fixed_size_arrays(df: pl.LazyFrame | pl.DataFrame) -> pl.LazyFrame | pl.DataFrame:
+    """Cast top-level fixed-size ``Array`` columns to ``List`` before a Delta write.
+
+    Delta has no fixed-size-array type, so an ``Array(inner, N)`` column is recorded in the log
+    as a plain list while the Parquet files keep the fixed-size layout. ``scan_delta`` then plans
+    against the log's ``List`` and collects an ``Array``, so the mismatch surfaces as a dtype
+    error on every later read instead of at write time. Normalising on the way in keeps the log
+    and the data agreeing.
+
+    Only top-level columns are rewritten: an ``Array`` nested inside a ``Struct`` or a ``List``
+    still round-trips inconsistently.
+    """
+    import polars as pl_
+
+    schema = df.collect_schema() if isinstance(df, pl_.LazyFrame) else df.schema
+    casts = [
+        pl_.col(name).cast(pl_.List(dtype.inner)) for name, dtype in schema.items() if isinstance(dtype, pl_.Array)
+    ]
+    return df.with_columns(casts) if casts else df
+
+
 def _quote_ident(name: str) -> str:
     """Quote *name* as a SQL identifier for a DataFusion merge clause.
 
@@ -170,6 +191,8 @@ def write_delta(
     import os
 
     import polars as pl_
+
+    df = _lists_from_fixed_size_arrays(df)
 
     if storage_options is None:
         os.makedirs(output_path, exist_ok=True)
@@ -227,6 +250,8 @@ def merge_into_delta(
     import os
 
     from deltalake import DeltaTable
+
+    df = _lists_from_fixed_size_arrays(df)
 
     # Open the target once (re-used below) rather than probing then re-opening.
     dt = _open_delta_or_none(output_path, storage_options)
@@ -495,6 +520,8 @@ def scd2_into_delta(
         ValueError: The batch or the target is unusable, or *valid_from_iso* is not strictly newer
             than every instant already recorded in the table.
     """
+    df = _lists_from_fixed_size_arrays(df)
+
     last_error: Exception | None = None
     for attempt in range(max_commit_attempts):
         try:

--- a/shared/tests/test_delta_utils.py
+++ b/shared/tests/test_delta_utils.py
@@ -6,6 +6,7 @@ Covers:
 - get_delta_partition_columns
 - vacuum_delta (dry_run, <168h retention guard)
 - optimize_delta (compact + z_order)
+- fixed-size Array -> List normalization on the way into a Delta write
 """
 
 import polars as pl
@@ -78,6 +79,92 @@ class TestMergePartitioning:
             partition_by=["v"],
         )
         assert get_delta_partition_columns(p) == ["v"]
+
+
+class TestFixedSizeArrayNormalization:
+    """A fixed-size ``Array`` column must survive a write/read round-trip as a ``List``.
+
+    Delta has no fixed-size-array type, so writing an ``Array(inner, N)`` unnormalized records a
+    list in the log while the Parquet files keep the fixed-size layout; ``scan_delta`` then plans
+    ``List`` and collects ``Array``, raising a dtype mismatch on every later read.
+    """
+
+    @staticmethod
+    def _embeddings(ids: list[int], vectors: list[list[float]], width: int = 3) -> pl.DataFrame:
+        return pl.DataFrame(
+            {"id": ids, "emb": vectors},
+            schema={"id": pl.Int64, "emb": pl.Array(pl.Float32, width)},
+        )
+
+    def test_array_column_reads_back_as_list(self, tmp_path):
+        p = tmp_path / "t"
+        df = self._embeddings([1, 2], [[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]])
+        assert df.schema["emb"] == pl.Array(pl.Float32, 3)
+
+        write_delta(df, str(p), mode="overwrite")
+
+        lf = pl.scan_delta(str(p))
+        assert lf.collect_schema()["emb"] == pl.List(pl.Float32)
+        out = lf.collect().sort("id")  # no dtype-mismatch SchemaError
+        assert out.schema["emb"] == pl.List(pl.Float32)
+        assert out["emb"].to_list() == [[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]]
+
+    def test_lazyframe_array_column_reads_back_as_list(self, tmp_path):
+        p = tmp_path / "t"
+        df = self._embeddings([1, 2], [[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]])
+
+        write_delta(df.lazy(), str(p), mode="overwrite")
+
+        out = pl.scan_delta(str(p)).collect().sort("id")  # sink_delta does not preserve row order
+        assert out.schema["emb"] == pl.List(pl.Float32)
+        assert out["emb"].to_list() == [[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]]
+
+    def test_append_array_column(self, tmp_path):
+        p = tmp_path / "t"
+        write_delta(self._embeddings([1], [[0.5, 1.5, 2.5]]), str(p), mode="overwrite")
+        write_delta(self._embeddings([2], [[3.5, 4.5, 5.5]]), str(p), mode="append")
+
+        out = pl.scan_delta(str(p)).collect().sort("id")
+        assert out.schema["emb"] == pl.List(pl.Float32)
+        assert out["emb"].to_list() == [[0.5, 1.5, 2.5], [3.5, 4.5, 5.5]]
+
+    def test_merge_array_column(self, tmp_path):
+        p = tmp_path / "t"
+        merge_into_delta(self._embeddings([1], [[0.5, 1.5, 2.5]]), str(p), merge_mode="upsert", merge_keys=["id"])
+        # The create branch is the guard here: a later merge rewrites the files and would mask it.
+        assert pl.scan_delta(str(p)).collect().schema["emb"] == pl.List(pl.Float32)
+
+        merge_into_delta(
+            self._embeddings([1, 2], [[9.5, 9.5, 9.5], [3.5, 4.5, 5.5]]),
+            str(p),
+            merge_mode="upsert",
+            merge_keys=["id"],
+        )
+
+        out = pl.scan_delta(str(p)).collect().sort("id")
+        assert out.schema["emb"] == pl.List(pl.Float32)
+        assert out["emb"].to_list() == [[9.5, 9.5, 9.5], [3.5, 4.5, 5.5]]
+
+    def test_non_array_columns_untouched(self, tmp_path):
+        p = tmp_path / "t"
+        df = pl.DataFrame(
+            {"id": [1], "name": ["x"], "tags": [["a", "b"]], "emb": [[0.5, 1.5]]},
+            schema={
+                "id": pl.Int64,
+                "name": pl.Utf8,
+                "tags": pl.List(pl.Utf8),
+                "emb": pl.Array(pl.Float32, 2),
+            },
+        )
+        write_delta(df, str(p), mode="overwrite")
+
+        out = pl.scan_delta(str(p)).collect()
+        assert out.schema == {
+            "id": pl.Int64,
+            "name": pl.Utf8,
+            "tags": pl.List(pl.Utf8),
+            "emb": pl.List(pl.Float32),
+        }
 
 
 class TestGetDeltaPartitionColumns:


### PR DESCRIPTION
This pull request increases the cell execution timeout in the kernel manager from 300 seconds (5 minutes) to 86,400 seconds (24 hours), ensuring long-running cells are supported. It also updates error messaging to reflect the new timeout and provide clearer guidance when a kernel becomes unresponsive.

**Cell execution timeout changes:**

* Introduced a new constant `_CELL_EXECUTION_TIMEOUT` set to 86,400 seconds (24 hours) in `manager.py`.
* Updated all usages of the previous 300-second timeout in HTTP client calls to use `_CELL_EXECUTION_TIMEOUT`, allowing cells to run for up to 24 hours. [[1]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdL1823-R1825) [[2]](diffhunk://#diff-e3d103334bb1e4fa15c875691ecbad3d59eca7d79bcf595cadfe38d1d71076bdL1834-R1836)

**Error handling improvements:**

* Updated the error message when a cell exceeds the execution limit to reference the new 24-hour timeout and to suggest checking the kernel container’s health.