### PR TITLE
Fix stale catalog read links surviving flow saves

### DIFF
--- a/flowfile_core/flowfile_core/catalog/repository.py
+++ b/flowfile_core/flowfile_core/catalog/repository.py
@@ -6,6 +6,7 @@ Defines a ``CatalogRepository`` :pep:`544` Protocol and provides a concrete
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from datetime import datetime, timedelta
 from typing import Protocol, runtime_checkable
 
@@ -233,7 +234,7 @@ class CatalogRepository(Protocol):
 
     def bulk_get_tables_for_flows(self, flow_ids: list[int]) -> dict[int, list[CatalogTable]]: ...
 
-    def upsert_read_link(self, table_id: int, registration_id: int) -> None: ...
+    def replace_read_links(self, registration_id: int, table_ids: Collection[int]) -> None: ...
 
     def list_readers_for_table(self, table_id: int) -> list[FlowRegistration]: ...
 
@@ -465,6 +466,9 @@ class SQLAlchemyCatalogRepository:
     def delete_flow(self, registration_id: int) -> None:
         self._db.query(FlowFavorite).filter_by(registration_id=registration_id).delete()
         self._db.query(FlowFollow).filter_by(registration_id=registration_id).delete()
+        # Read-lineage links don't cascade either; a stale one would attribute this
+        # flow's reads to whichever future registration reuses the SQLite rowid.
+        self._db.query(CatalogTableReadLink).filter_by(registration_id=registration_id).delete()
         # Schedules don't FK-cascade; a flow can't have schedules without the flow, so drop them
         # (and their trigger-table links) — otherwise they'd be orphaned on the flow's deletion.
         schedule_ids = [
@@ -994,13 +998,23 @@ class SQLAlchemyCatalogRepository:
             result.setdefault(table.source_registration_id, []).append(table)
         return result
 
-    def upsert_read_link(self, table_id: int, registration_id: int) -> None:
-        """Record that a flow reads from a catalog table (idempotent)."""
-        existing = (
-            self._db.query(CatalogTableReadLink).filter_by(table_id=table_id, registration_id=registration_id).first()
-        )
-        if not existing:
+    def replace_read_links(self, registration_id: int, table_ids: Collection[int]) -> None:
+        """Make a flow's read links exactly ``table_ids``.
+
+        Prunes links to tables the flow no longer reads and inserts the missing
+        ones, so a removed catalog_reader stops showing up as read lineage. An
+        empty collection drops every link for the registration.
+        """
+        wanted = set(table_ids)
+        links = self._db.query(CatalogTableReadLink).filter(CatalogTableReadLink.registration_id == registration_id)
+        existing = {link.table_id for link in links.all()}
+        stale = existing - wanted
+        missing = wanted - existing
+        if stale:
+            links.filter(CatalogTableReadLink.table_id.in_(stale)).delete(synchronize_session=False)
+        for table_id in missing:
             self._db.add(CatalogTableReadLink(table_id=table_id, registration_id=registration_id))
+        if stale or missing:
             self._db.commit()
 
     def list_readers_for_table(self, table_id: int) -> list[FlowRegistration]:

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -6290,35 +6290,55 @@ class FlowGraph:
         # Record the current state as the clean baseline for dirty tracking
         self.mark_as_saved()
 
+    def _owns_registration(self, repo: SQLAlchemyCatalogRepository, registration_id: int) -> bool:
+        """Whether ``registration_id`` really points at this flow's own file.
+
+        Registration ids are machine-local and can alias another flow: SQLite reuses
+        rowids after a registration is deleted, and a copied YAML carries the original's
+        id. Since the read-link sync prunes, syncing under an aliased id would wipe the
+        other flow's lineage. Renames never move ``flow_path``, so path identity is the
+        authoritative check.
+        """
+        registration = repo.get_flow(registration_id)
+        own_path = self._flow_settings.path or self._flow_settings.save_location
+        if registration is None or not registration.flow_path or not own_path:
+            return False
+        return os.path.realpath(registration.flow_path) == os.path.realpath(own_path)
+
     def _sync_catalog_read_links(self):
         """Record which catalog tables this flow reads from.
 
-        Scans all nodes for catalog_reader types and upserts read links
-        in the catalog database.  Runs at save time so that
-        source_registration_id is guaranteed to be set.
+        Scans all nodes for catalog_reader types and replaces the flow's read
+        links with exactly that set, so removing a reader drops its link. Runs
+        at save time so that source_registration_id is guaranteed to be set.
         """
         registration_id = self._flow_settings.source_registration_id
         logger.debug("Found registration_id %s", registration_id)
         if not registration_id:
             return
 
-        table_ids = []
+        table_ids = set()
         for node in self.nodes:
             if node.node_type != "catalog_reader":
                 continue
             setting = node.setting_input
             table_id = getattr(setting, "catalog_table_id", None)
             if table_id:
-                table_ids.append(table_id)
-
-        if not table_ids:
-            return
+                table_ids.add(table_id)
 
         try:
             with get_db_context() as db:
                 repo = SQLAlchemyCatalogRepository(db)
-                for table_id in table_ids:
-                    repo.upsert_read_link(table_id, registration_id)
+                if not self._owns_registration(repo, registration_id):
+                    logger.warning(
+                        "Registration %s does not belong to flow '%s' (reused id or copied flow file); "
+                        "clearing it and skipping the catalog read-link sync",
+                        registration_id,
+                        self._flow_settings.path or self._flow_settings.save_location,
+                    )
+                    self._flow_settings.source_registration_id = None
+                    return
+                repo.replace_read_links(registration_id, table_ids)
         except Exception:
             logger.warning(
                 "Failed to record catalog read links for tables %s",

--- a/flowfile_core/flowfile_core/flowfile/flow_graph.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_graph.py
@@ -6257,6 +6257,7 @@ class FlowGraph:
         new_flow_name = path.name.replace(suffix, "")
         self._handle_flow_renaming(new_flow_name, path)
         self.flow_settings.modified_on = datetime.datetime.now().timestamp()
+        self._validate_registration_ownership(flow_path)
         try:
             if suffix == ".flowfile":
                 raise DeprecationWarning(
@@ -6290,8 +6291,8 @@ class FlowGraph:
         # Record the current state as the clean baseline for dirty tracking
         self.mark_as_saved()
 
-    def _owns_registration(self, repo: SQLAlchemyCatalogRepository, registration_id: int) -> bool:
-        """Whether ``registration_id`` really points at this flow's own file.
+    def _owns_registration(self, repo: SQLAlchemyCatalogRepository, registration_id: int, own_path: str | None) -> bool:
+        """Whether ``registration_id`` really points at ``own_path``, this flow's file.
 
         Registration ids are machine-local and can alias another flow: SQLite reuses
         rowids after a registration is deleted, and a copied YAML carries the original's
@@ -6300,10 +6301,36 @@ class FlowGraph:
         authoritative check.
         """
         registration = repo.get_flow(registration_id)
-        own_path = self._flow_settings.path or self._flow_settings.save_location
         if registration is None or not registration.flow_path or not own_path:
             return False
         return os.path.realpath(registration.flow_path) == os.path.realpath(own_path)
+
+    def _validate_registration_ownership(self, flow_path: str) -> None:
+        """Re-point (or drop) a ``source_registration_id`` that isn't this file's own.
+
+        Runs before the save serializes settings, so the corrected id is what lands in the
+        file. Clearing it after the write would be resurrected on the next open —
+        ``resolve_source_registration_id`` keeps any non-None stored id — leaving the flow's
+        read-link sync permanently wedged. A transient DB failure never drops the id.
+        """
+        registration_id = getattr(self._flow_settings, "source_registration_id", None)
+        if not registration_id:
+            return
+        try:
+            with get_db_context() as db:
+                repo = SQLAlchemyCatalogRepository(db)
+                if self._owns_registration(repo, registration_id, flow_path):
+                    return
+                own_id = CatalogService(repo).resolve_registration_id(flow_path)
+            logger.warning(
+                "Registration %s does not belong to flow '%s' (reused id or copied flow file); re-resolved to %s",
+                registration_id,
+                flow_path,
+                own_id,
+            )
+            self._flow_settings.source_registration_id = own_id
+        except Exception:
+            logger.warning("Could not validate the catalog registration of flow '%s'", flow_path, exc_info=True)
 
     def _sync_catalog_read_links(self):
         """Record which catalog tables this flow reads from.
@@ -6329,12 +6356,14 @@ class FlowGraph:
         try:
             with get_db_context() as db:
                 repo = SQLAlchemyCatalogRepository(db)
-                if not self._owns_registration(repo, registration_id):
+                own_path = self._flow_settings.path or self._flow_settings.save_location
+                if not self._owns_registration(repo, registration_id, own_path):
+                    # Backstop for callers that set the id without going through save_flow.
                     logger.warning(
                         "Registration %s does not belong to flow '%s' (reused id or copied flow file); "
                         "clearing it and skipping the catalog read-link sync",
                         registration_id,
-                        self._flow_settings.path or self._flow_settings.save_location,
+                        own_path,
                     )
                     self._flow_settings.source_registration_id = None
                     return

--- a/flowfile_core/flowfile_core/flowfile/handler.py
+++ b/flowfile_core/flowfile_core/flowfile/handler.py
@@ -87,6 +87,13 @@ class FlowfileHandler:
         imported_flow = open_flow(flow_path, user_id=user_id)
         self._flows[imported_flow.flow_id] = imported_flow
         imported_flow.flow_settings = self.get_flow_info(imported_flow.flow_id)
+        # The stored id is machine-local and a copied file carries the original's; callers
+        # re-resolve it from the path (same reasoning as save_as_flow and project normalize).
+        try:
+            imported_flow.flow_settings.source_registration_id = None
+        except (AttributeError, ValueError):
+            # Legacy .flowfile pickles unpickle a FlowSettings class without the field.
+            object.__setattr__(imported_flow.flow_settings, "source_registration_id", None)
         imported_flow.flow_settings.is_running = False
         if register_session:
             self._register_user_session(user_id, imported_flow.flow_id)

--- a/flowfile_core/tests/flowfile/test_catalog_flow_graph.py
+++ b/flowfile_core/tests/flowfile/test_catalog_flow_graph.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import polars as pl
 import pytest
+import yaml
 
 from flowfile_core.catalog import CatalogService
 from flowfile_core.catalog.repository import SQLAlchemyCatalogRepository
@@ -521,6 +522,12 @@ class TestSyncCatalogReadLinks:
         with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
             return f.name
 
+    @staticmethod
+    def _persisted_registration_id(flow_path: str):
+        """The source_registration_id actually written into the flow file."""
+        with open(flow_path, encoding="utf-8") as f:
+            return yaml.safe_load(f)["flowfile_settings"]["source_registration_id"]
+
     def test_save_flow_prunes_removed_reader(self):
         """Removing one of two catalog_reader nodes drops only that reader's link."""
         ns_id = _create_namespace()
@@ -643,6 +650,7 @@ class TestSyncCatalogReadLinks:
         graph_a.save_flow(path_a)
         assert self._linked_table_ids(reg_b) == {table_b}
         assert graph_a.flow_settings.source_registration_id is None
+        assert self._persisted_registration_id(path_a) is None
 
         os.unlink(path_a)
         os.unlink(path_b)
@@ -664,9 +672,69 @@ class TestSyncCatalogReadLinks:
         copy_graph.save_flow(copy_path)
         assert self._linked_table_ids(reg_id) == {table_id}
         assert copy_graph.flow_settings.source_registration_id is None
+        # Persisted too: a stale id left in the file would be resurrected on reopen.
+        assert self._persisted_registration_id(copy_path) is None
 
         os.unlink(original_path)
         os.unlink(copy_path)
+
+    def test_save_flow_reresolves_foreign_registration_id_to_own_in_one_save(self):
+        """A flow whose own path IS registered self-heals: the correct id is persisted and
+        its links sync in the same save, leaving the foreign registration untouched."""
+        ns_id = _create_namespace()
+        foreign_path = self._temp_flow_path()
+        own_path = self._temp_flow_path()
+        foreign_table = self._register_table(ns_id, "heal_foreign_table")
+        own_table = self._register_table(ns_id, "heal_own_table")
+
+        foreign_reg = _create_flow_registration(ns_id, name="foreign_flow", path=foreign_path)
+        foreign_graph = _create_graph(flow_id=1, source_registration_id=foreign_reg)
+        self._add_reader(foreign_graph, 1, foreign_table)
+        foreign_graph.save_flow(foreign_path)
+        assert self._linked_table_ids(foreign_reg) == {foreign_table}
+
+        own_reg = _create_flow_registration(ns_id, name="own_flow", path=own_path)
+        graph = _create_graph(flow_id=2, source_registration_id=foreign_reg)
+        self._add_reader(graph, 1, own_table)
+        graph.save_flow(own_path)
+
+        assert graph.flow_settings.source_registration_id == own_reg
+        assert self._persisted_registration_id(own_path) == own_reg
+        assert self._linked_table_ids(own_reg) == {own_table}
+        assert self._linked_table_ids(foreign_reg) == {foreign_table}
+
+        os.unlink(foreign_path)
+        os.unlink(own_path)
+
+    def test_reopened_flow_no_longer_resurrects_a_stale_registration_id(self):
+        """The persisted None breaks the resurrection loop: reopening re-resolves by path."""
+        from flowfile_core.flowfile.catalog_helpers import resolve_source_registration_id
+        from flowfile_core.flowfile.manage.io_flowfile import open_flow
+
+        ns_id = _create_namespace()
+        foreign_path = self._temp_flow_path()
+        own_path = self._temp_flow_path()
+        table_id = self._register_table(ns_id, "loop_breaker_table")
+
+        foreign_reg = _create_flow_registration(ns_id, name="loop_foreign", path=foreign_path)
+        graph = _create_graph(source_registration_id=foreign_reg)
+        self._add_reader(graph, 1, table_id)
+        graph.save_flow(own_path)  # own_path has no registration yet -> unresolvable, cleared
+
+        reopened = open_flow(Path(own_path))
+        assert reopened.flow_settings.source_registration_id is None
+
+        # open_flow stamps the resolved path; the by-path resolver matches on the exact string.
+        own_reg = _create_flow_registration(ns_id, name="loop_own", path=os.path.realpath(own_path))
+        resolve_source_registration_id(reopened)
+        assert reopened.flow_settings.source_registration_id == own_reg
+
+        reopened.save_flow(own_path)
+        assert self._linked_table_ids(own_reg) == {table_id}
+        assert self._linked_table_ids(foreign_reg) == set()
+
+        os.unlink(foreign_path)
+        os.unlink(own_path)
 
     def test_import_flow_strips_foreign_registration_id(self):
         """Opening/copying a YAML must not adopt the id baked into it."""

--- a/flowfile_core/tests/flowfile/test_catalog_flow_graph.py
+++ b/flowfile_core/tests/flowfile/test_catalog_flow_graph.py
@@ -10,6 +10,7 @@ Covers:
 import io as _io
 import json
 import os
+import shutil
 import tempfile
 import time
 from pathlib import Path
@@ -486,10 +487,244 @@ class TestCatalogReader:
 class TestSyncCatalogReadLinks:
     """Test that save_flow records read links for catalog_reader nodes."""
 
-    def test_save_flow_records_read_links(self):
-        """Saving a flow with catalog_reader nodes should upsert read links."""
+    @staticmethod
+    def _register_table(ns_id: int, name: str) -> int:
+        """Register a parquet-backed catalog table and return its id."""
+        df = pl.DataFrame(SAMPLE_DATA)
+        tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+        df.write_parquet(tmp.name)
+        tmp.close()
+
+        with get_db_context() as db:
+            svc = CatalogService(SQLAlchemyCatalogRepository(db))
+            table_out = svc.register_table(name=name, file_path=tmp.name, owner_id=1, namespace_id=ns_id)
+        return table_out.id
+
+    @staticmethod
+    def _add_reader(graph, node_id: int, table_id: int) -> None:
+        graph.add_node_promise(
+            input_schema.NodePromise(flow_id=graph.flow_id, node_id=node_id, node_type="catalog_reader")
+        )
+        graph.add_catalog_reader(
+            input_schema.NodeCatalogReader(flow_id=graph.flow_id, node_id=node_id, catalog_table_id=table_id)
+        )
+
+    @staticmethod
+    def _linked_table_ids(reg_id: int) -> set[int]:
+        with get_db_context() as db:
+            rows = db.query(CatalogTableReadLink.table_id).filter_by(registration_id=reg_id).all()
+        return {row[0] for row in rows}
+
+    @staticmethod
+    def _temp_flow_path() -> str:
+        """A save path the flow's registration can be registered at (they must match)."""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            return f.name
+
+    def test_save_flow_prunes_removed_reader(self):
+        """Removing one of two catalog_reader nodes drops only that reader's link."""
         ns_id = _create_namespace()
-        reg_id = _create_flow_registration(ns_id, name="reader_flow", path="/tmp/reader_flow.yaml")
+        save_path = self._temp_flow_path()
+        reg_id = _create_flow_registration(ns_id, name="two_readers", path=save_path)
+        table_a = self._register_table(ns_id, "prune_table_a")
+        table_b = self._register_table(ns_id, "prune_table_b")
+
+        graph = _create_graph(source_registration_id=reg_id)
+        self._add_reader(graph, 1, table_a)
+        self._add_reader(graph, 2, table_b)
+
+        graph.save_flow(save_path)
+        assert self._linked_table_ids(reg_id) == {table_a, table_b}
+
+        graph.delete_node(2)
+        graph.save_flow(save_path)
+        assert self._linked_table_ids(reg_id) == {table_a}
+
+        os.unlink(save_path)
+
+    def test_save_flow_prunes_last_reader(self):
+        """Removing the last catalog_reader leaves the flow with no read links."""
+        ns_id = _create_namespace()
+        save_path = self._temp_flow_path()
+        reg_id = _create_flow_registration(ns_id, name="last_reader", path=save_path)
+        table_id = self._register_table(ns_id, "last_reader_table")
+
+        graph = _create_graph(source_registration_id=reg_id)
+        self._add_reader(graph, 1, table_id)
+
+        graph.save_flow(save_path)
+        assert self._linked_table_ids(reg_id) == {table_id}
+
+        graph.delete_node(1)
+        graph.save_flow(save_path)
+        assert self._linked_table_ids(reg_id) == set()
+
+        os.unlink(save_path)
+
+    def test_save_flow_restores_readded_reader(self):
+        """A reader added back after a prune gets its link recreated."""
+        ns_id = _create_namespace()
+        save_path = self._temp_flow_path()
+        reg_id = _create_flow_registration(ns_id, name="readded_reader", path=save_path)
+        table_id = self._register_table(ns_id, "readd_table")
+
+        graph = _create_graph(source_registration_id=reg_id)
+        self._add_reader(graph, 1, table_id)
+
+        graph.save_flow(save_path)
+        graph.delete_node(1)
+        graph.save_flow(save_path)
+        assert self._linked_table_ids(reg_id) == set()
+
+        self._add_reader(graph, 1, table_id)
+        graph.save_flow(save_path)
+        assert self._linked_table_ids(reg_id) == {table_id}
+
+        os.unlink(save_path)
+
+    def test_save_flow_leaves_other_flows_links_intact(self):
+        """Pruning one flow's links must not touch another flow reading the same table."""
+        ns_id = _create_namespace()
+        path_a = self._temp_flow_path()
+        path_b = self._temp_flow_path()
+        reg_a = _create_flow_registration(ns_id, name="flow_a", path=path_a)
+        reg_b = _create_flow_registration(ns_id, name="flow_b", path=path_b)
+        table_id = self._register_table(ns_id, "shared_read_table")
+
+        graph_a = _create_graph(flow_id=1, source_registration_id=reg_a)
+        self._add_reader(graph_a, 1, table_id)
+        graph_b = _create_graph(flow_id=2, source_registration_id=reg_b)
+        self._add_reader(graph_b, 1, table_id)
+
+        graph_a.save_flow(path_a)
+        graph_b.save_flow(path_b)
+        assert self._linked_table_ids(reg_a) == {table_id}
+        assert self._linked_table_ids(reg_b) == {table_id}
+
+        graph_a.delete_node(1)
+        graph_a.save_flow(path_a)
+        assert self._linked_table_ids(reg_a) == set()
+        assert self._linked_table_ids(reg_b) == {table_id}
+
+        os.unlink(path_a)
+        os.unlink(path_b)
+
+    def test_save_flow_ignores_registration_id_reused_by_another_flow(self):
+        """A stale id that SQLite handed to another flow must not prune that flow's links.
+
+        Registration ids are bare rowids, so deleting a registration frees the id for
+        the next insert while an open FlowGraph (and its YAML) still carries it.
+        """
+        ns_id = _create_namespace()
+        path_a = self._temp_flow_path()
+        path_b = self._temp_flow_path()
+        table_a = self._register_table(ns_id, "reuse_table_a")
+        table_b = self._register_table(ns_id, "reuse_table_b")
+
+        reg_a = _create_flow_registration(ns_id, name="flow_a", path=path_a)
+        graph_a = _create_graph(flow_id=1, source_registration_id=reg_a)
+        self._add_reader(graph_a, 1, table_a)
+        graph_a.save_flow(path_a)
+        assert self._linked_table_ids(reg_a) == {table_a}
+
+        with get_db_context() as db:
+            SQLAlchemyCatalogRepository(db).delete_flow(reg_a)
+
+        reg_b = _create_flow_registration(ns_id, name="flow_b", path=path_b)
+        assert reg_b == reg_a, "SQLite should hand the freed rowid to the next registration"
+
+        graph_b = _create_graph(flow_id=2, source_registration_id=reg_b)
+        self._add_reader(graph_b, 1, table_b)
+        graph_b.save_flow(path_b)
+        assert self._linked_table_ids(reg_b) == {table_b}
+
+        # graph_a still points at the recycled id; its save must not touch flow B.
+        graph_a.delete_node(1)
+        graph_a.save_flow(path_a)
+        assert self._linked_table_ids(reg_b) == {table_b}
+        assert graph_a.flow_settings.source_registration_id is None
+
+        os.unlink(path_a)
+        os.unlink(path_b)
+
+    def test_save_flow_ignores_registration_id_of_a_copied_flow(self):
+        """A copied YAML carries the original's id; saving the copy must not prune the original."""
+        ns_id = _create_namespace()
+        original_path = self._temp_flow_path()
+        copy_path = self._temp_flow_path()
+        table_id = self._register_table(ns_id, "copied_flow_table")
+
+        reg_id = _create_flow_registration(ns_id, name="original", path=original_path)
+        graph = _create_graph(source_registration_id=reg_id)
+        self._add_reader(graph, 1, table_id)
+        graph.save_flow(original_path)
+        assert self._linked_table_ids(reg_id) == {table_id}
+
+        copy_graph = _create_graph(flow_id=2, source_registration_id=reg_id)
+        copy_graph.save_flow(copy_path)
+        assert self._linked_table_ids(reg_id) == {table_id}
+        assert copy_graph.flow_settings.source_registration_id is None
+
+        os.unlink(original_path)
+        os.unlink(copy_path)
+
+    def test_import_flow_strips_foreign_registration_id(self):
+        """Opening/copying a YAML must not adopt the id baked into it."""
+        from flowfile_core.flowfile.handler import FlowfileHandler
+
+        ns_id = _create_namespace()
+        original_path = self._temp_flow_path()
+        table_id = self._register_table(ns_id, "imported_flow_table")
+
+        reg_id = _create_flow_registration(ns_id, name="import_origin", path=original_path)
+        graph = _create_graph(source_registration_id=reg_id)
+        self._add_reader(graph, 1, table_id)
+        graph.save_flow(original_path)
+
+        copy_path = self._temp_flow_path()
+        shutil.copyfile(original_path, copy_path)
+
+        handler = FlowfileHandler()
+        imported_id = handler.import_flow(copy_path, user_id=1)
+        imported = handler.get_flow(imported_id)
+        assert imported.flow_settings.source_registration_id is None
+
+        # The copy's own save leaves the original's lineage alone.
+        imported.save_flow(copy_path)
+        assert self._linked_table_ids(reg_id) == {table_id}
+
+        os.unlink(original_path)
+        os.unlink(copy_path)
+
+    def test_save_flow_syncs_links_after_registration_rename(self):
+        """A renamed registration keeps its path, so the guard must not misfire on it."""
+        ns_id = _create_namespace()
+        save_path = self._temp_flow_path()
+        reg_id = _create_flow_registration(ns_id, name="before_rename", path=save_path)
+        table_a = self._register_table(ns_id, "rename_table_a")
+        table_b = self._register_table(ns_id, "rename_table_b")
+
+        graph = _create_graph(source_registration_id=reg_id)
+        self._add_reader(graph, 1, table_a)
+        graph.save_flow(save_path)
+        assert self._linked_table_ids(reg_id) == {table_a}
+
+        with get_db_context() as db:
+            svc = CatalogService(SQLAlchemyCatalogRepository(db))
+            svc.update_flow(registration_id=reg_id, requesting_user_id=1, name="after_rename")
+
+        self._add_reader(graph, 2, table_b)
+        graph.save_flow(save_path)
+        assert self._linked_table_ids(reg_id) == {table_a, table_b}
+        assert graph.flow_settings.source_registration_id == reg_id
+
+        os.unlink(save_path)
+
+    def test_save_flow_records_read_links(self):
+        """Saving a flow with catalog_reader nodes should record read links."""
+        ns_id = _create_namespace()
+        save_path = self._temp_flow_path()
+        reg_id = _create_flow_registration(ns_id, name="reader_flow", path=save_path)
 
         df = pl.DataFrame(SAMPLE_DATA)
         tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
@@ -516,9 +751,6 @@ class TestSyncCatalogReadLinks:
             catalog_table_id=table_id,
         )
         graph.add_catalog_reader(reader)
-
-        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
-            save_path = f.name
 
         graph.save_flow(save_path)
 

--- a/flowfile_core/tests/test_catalog.py
+++ b/flowfile_core/tests/test_catalog.py
@@ -1165,10 +1165,10 @@ class TestScratchNamespaceCleanup:
 
 
 class TestReadLinks:
-    """Tests for CatalogTableReadLink upsert and query methods."""
+    """Tests for CatalogTableReadLink replace and query methods."""
 
     @staticmethod
-    def _setup_flow_and_table():
+    def _setup_flow_and_table(flow_path: str = "/tmp/reader.yaml"):
         """Create a namespace, flow registration, and catalog table for testing."""
         with get_db_context() as db:
             ns = CatalogNamespace(name="LinkCat", level=0, owner_id=1)
@@ -1183,7 +1183,7 @@ class TestReadLinks:
 
             flow = FlowRegistration(
                 name="reader_flow",
-                flow_path="/tmp/reader.yaml",
+                flow_path=flow_path,
                 namespace_id=schema.id,
                 owner_id=1,
             )
@@ -1203,32 +1203,43 @@ class TestReadLinks:
 
             return flow.id, table.id
 
-    def test_upsert_read_link_creates_record(self):
+    def test_replace_read_links_creates_record(self):
         flow_id, table_id = self._setup_flow_and_table()
         with get_db_context() as db:
             repo = SQLAlchemyCatalogRepository(db)
-            repo.upsert_read_link(table_id, flow_id)
+            repo.replace_read_links(flow_id, [table_id])
 
         with get_db_context() as db:
             link = db.query(CatalogTableReadLink).filter_by(table_id=table_id, registration_id=flow_id).first()
             assert link is not None
 
-    def test_upsert_read_link_is_idempotent(self):
+    def test_replace_read_links_is_idempotent(self):
         flow_id, table_id = self._setup_flow_and_table()
         with get_db_context() as db:
             repo = SQLAlchemyCatalogRepository(db)
-            repo.upsert_read_link(table_id, flow_id)
-            repo.upsert_read_link(table_id, flow_id)
+            repo.replace_read_links(flow_id, [table_id])
+            repo.replace_read_links(flow_id, [table_id])
 
         with get_db_context() as db:
             links = db.query(CatalogTableReadLink).filter_by(table_id=table_id, registration_id=flow_id).all()
             assert len(links) == 1
 
+    def test_replace_read_links_prunes_dropped_tables(self):
+        flow_id, table_id = self._setup_flow_and_table()
+        with get_db_context() as db:
+            repo = SQLAlchemyCatalogRepository(db)
+            repo.replace_read_links(flow_id, [table_id])
+            repo.replace_read_links(flow_id, [])
+
+        with get_db_context() as db:
+            links = db.query(CatalogTableReadLink).filter_by(registration_id=flow_id).all()
+            assert links == []
+
     def test_list_readers_for_table(self):
         flow_id, table_id = self._setup_flow_and_table()
         with get_db_context() as db:
             repo = SQLAlchemyCatalogRepository(db)
-            repo.upsert_read_link(table_id, flow_id)
+            repo.replace_read_links(flow_id, [table_id])
             readers = repo.list_readers_for_table(table_id)
             assert len(readers) == 1
             assert readers[0].id == flow_id
@@ -1244,7 +1255,7 @@ class TestReadLinks:
         flow_id, table_id = self._setup_flow_and_table()
         with get_db_context() as db:
             repo = SQLAlchemyCatalogRepository(db)
-            repo.upsert_read_link(table_id, flow_id)
+            repo.replace_read_links(flow_id, [table_id])
             tables = repo.list_read_tables_for_flow(flow_id)
             assert len(tables) == 1
             assert tables[0].id == table_id
@@ -1273,11 +1284,57 @@ class TestReadLinks:
 
         with get_db_context() as db:
             repo = SQLAlchemyCatalogRepository(db)
-            repo.upsert_read_link(table_id, flow_id_1)
-            repo.upsert_read_link(table_id, flow_id_2)
+            repo.replace_read_links(flow_id_1, [table_id])
+            repo.replace_read_links(flow_id_2, [table_id])
             readers = repo.list_readers_for_table(table_id)
             reader_ids = {r.id for r in readers}
             assert reader_ids == {flow_id_1, flow_id_2}
+
+    def test_delete_flow_removes_read_links(self):
+        """A deleted flow leaves no read links behind for a reused id to inherit."""
+        flow_id, table_id = self._setup_flow_and_table()
+        with get_db_context() as db:
+            repo = SQLAlchemyCatalogRepository(db)
+            repo.replace_read_links(flow_id, [table_id])
+            repo.delete_flow(flow_id)
+
+        with get_db_context() as db:
+            assert db.query(CatalogTableReadLink).filter_by(registration_id=flow_id).all() == []
+
+    def test_removed_reader_drops_out_of_tables_read(self, tmp_path):
+        """End-to-end: the catalog stops reporting a table read once its reader node is gone."""
+        from flowfile_core.schemas import input_schema
+
+        flow_path = tmp_path / "reader_flow.yaml"
+        reg_id, table_id = self._setup_flow_and_table(flow_path=str(flow_path))
+        internal_id = flow_file_handler.add_flow(name="reader_flow", flow_path=str(flow_path), user_id=1)
+        graph = flow_file_handler.get_flow(internal_id)
+        graph.flow_settings.source_registration_id = reg_id
+        graph.add_node_promise(
+            input_schema.NodePromise(flow_id=graph.flow_id, node_id=1, node_type="catalog_reader")
+        )
+        graph.add_catalog_reader(
+            input_schema.NodeCatalogReader(flow_id=graph.flow_id, node_id=1, catalog_table_id=table_id)
+        )
+        graph.save_flow(str(flow_path))
+
+        try:
+            with get_db_context() as db:
+                svc = CatalogService(SQLAlchemyCatalogRepository(db))
+                assert [t.id for t in svc.get_flow(reg_id, user_id=1).tables_read] == [table_id]
+                listed = [f for f in svc.list_flows(user_id=1) if f.id == reg_id]
+                assert [t.id for t in listed[0].tables_read] == [table_id]
+
+            graph.delete_node(1)
+            graph.save_flow(str(flow_path))
+
+            with get_db_context() as db:
+                svc = CatalogService(SQLAlchemyCatalogRepository(db))
+                assert svc.get_flow(reg_id, user_id=1).tables_read == []
+                listed = [f for f in svc.list_flows(user_id=1) if f.id == reg_id]
+                assert listed[0].tables_read == []
+        finally:
+            flow_file_handler.delete_flow(internal_id)
 
 
 # Table lineage tests (source_registration_id on CatalogTable)
@@ -1460,7 +1517,7 @@ class TestServiceLineageEnrichment:
             db.refresh(table)
 
             repo = SQLAlchemyCatalogRepository(db)
-            repo.upsert_read_link(table.id, reader.id)
+            repo.replace_read_links(reader.id, [table.id])
 
             return schema.id, producer.id, reader.id, table.id
 

--- a/flowfile_core/tests/test_catalog.py
+++ b/flowfile_core/tests/test_catalog.py
@@ -672,13 +672,13 @@ def test_open_run_snapshot_does_not_reuse_registration(tmp_path):
     matched by the registration-scoped reuse — the snapshot opens as a fresh, unlinked tab."""
     from datetime import datetime, timezone
 
-    # Build a real flow, stamp a registration id, and serialize it as the run snapshot.
+    # Build a real flow and serialize it as the run snapshot. save_flow now scrubs an id that
+    # resolves to no registration, so the foreign id is injected into the snapshot text instead.
     flow_path = tmp_path / "snap_src.yaml"
     flow_id = flow_file_handler.add_flow(name="snap_src", flow_path=str(flow_path), user_id=1)
     flow = flow_file_handler.get_flow(flow_id)
-    flow.flow_settings.source_registration_id = 4242
     flow.save_flow(str(flow_path))
-    snapshot_text = flow_path.read_text()
+    snapshot_text = flow_path.read_text().replace("source_registration_id: null", "source_registration_id: 4242")
     flow_file_handler.delete_flow(flow_id)
     assert "4242" in snapshot_text  # sanity: the id is baked into the snapshot
 


### PR DESCRIPTION
## Problem

A flow that reads from a catalog table shows that table as a dependency in the Catalog view — but removing the dependency from the flow and saving (without running) left the stale dependency visible forever. Running the flow didn't clear it either.

Root cause: `catalog_table_read_links` was **add-only**. `FlowGraph._sync_catalog_read_links` (the only writer, called at the tail of `save_flow`) inserted links for the current `catalog_reader` nodes via an insert-if-absent "upsert" and never pruned; an `if not table_ids: return` guard meant removing the *last* reader didn't touch the table at all. `repository.delete_flow` also cleaned up nine sibling record types but not read links, orphaning them — and SQLite rowid reuse can hand the dead registration id to a future flow.

## Fix

- **True resync**: `replace_read_links(registration_id, table_ids)` replaces `upsert_read_link` — prunes rows not in the current set, inserts missing ones, and an empty set deletes all. The empty-set guard is gone; every save is now authoritative.
- **`delete_flow` cleanup**: read links are removed alongside the other per-flow records.
- **Stale-id guard** (the destructive sync must not trust a wrong id): `save_flow` validates that `source_registration_id` resolves to a registration whose `flow_path` is this flow's own file — **before serializing**, so the correction is persisted rather than resurrected on reload. A non-owned id is re-resolved by the flow's own path (full self-heal in one save when the path is registered) and otherwise persisted as `None`, so the next open re-resolves cleanly; DB errors leave the id untouched. The sync keeps its own guard as a backstop for non-save callers. Without this, a reused rowid (registration deleted, id recycled while an old flow still holds it in memory or in its YAML) or a copied flow YAML could wipe another flow's lineage. `FlowRegistration.flow_path` is never mutated in-tree (rename explicitly keeps the path), so path equality is the correct ownership test.
- **`import_flow` strips the machine-local `source_registration_id`**, matching the two existing precedents (`save_as_flow`, project normalize), with a legacy-pickle-safe fallback. Plain open is unaffected — the route re-resolves the id by path immediately after.

Stale links self-heal: opening an affected flow and saving once prunes them. No migration needed.

## Tests

11 new tests + 1 strengthened across `test_catalog_flow_graph.py` / `test_catalog.py`: prune on reader removal (including the last reader), re-add after prune, other flows' links untouched, rowid-reuse and copied-flow scenarios leave the other flow's links intact, import strips the foreign id, legit-rename non-regression, `delete_flow` cleanup, and an end-to-end pin that the enriched `tables_read` (both `get_flow` and the bulk `list_flows` path — previously vacuously asserted) drops the removed table. Each fix was mutation-verified: reverting any one of them fails its named test.

`pytest flowfile_core/tests/flowfile/test_catalog_flow_graph.py flowfile_core/tests/test_catalog.py flowfile_core/tests/flowfile/test_handler.py`: 229 passed on this branch. Wider catalog/handler/yaml suites: 237 + 35 passed. Ruff clean.
