### PR TITLE
feat: add version management for artifacts and enhance UI artifacts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -115,7 +115,7 @@ jobs:
         env:
           TEST_URL: http://localhost:4173
           API_URL: http://localhost:63578
-        run: npx playwright test tests/web-flow.spec.ts tests/tutorial.spec.ts --reporter=html
+        run: npx playwright test tests/web-flow.spec.ts tests/tutorial.spec.ts tests/catalog-artifact-versions.spec.ts --reporter=html
 
       # Upload test results on failure
       - name: Upload Playwright report

--- a/docs/users/visual-editor/catalog/index.md
+++ b/docs/users/visual-editor/catalog/index.md
@@ -345,7 +345,18 @@ Once published, the flow's detail panel shows the **Expose as API** section: the
 
 Global artifacts are Python objects (ML models, DataFrames, configs) persisted in the catalog and accessible from any flow. They are published from [Kernel code](../kernel-api.md#global-artifacts-catalog) using `flowfile_ctx.publish_global()`.
 
-Click an artifact in the tree to view its versions, metadata, and producing flow.
+Click an artifact in the tree to view its versions, metadata, and producing flow. Each publish adds a version; the tree shows one row per artifact (with a version count when there is more than one), and the detail panel pages through the full version list (25 at a time).
+
+Version management (available to the artifact's owner and anyone with a manage grant):
+
+| Action | Effect |
+|--------|--------|
+| **Restore** | Copies an older version forward as a new highest version, so it becomes what "latest" resolves to. History stays append-only — nothing is overwritten. Not offered on the latest version. |
+| **Delete version** | Permanently removes that version and its stored data. The latest version is protected; delete the artifact itself to remove it entirely. |
+| **Prune versions** | Keeps the newest *N* versions (always including the latest) and deletes the rest. Preview first — the dialog reports how many versions and how much space the prune would free before you commit. |
+
+!!! warning "Deletes are permanent"
+    Version deletes and prunes remove the stored object immediately. There is no trash window or undo.
 
 ---
 

--- a/docs/users/visual-editor/creating-custom-nodes.md
+++ b/docs/users/visual-editor/creating-custom-nodes.md
@@ -303,6 +303,9 @@ return lf.select(getattr(pl.col("amount"), op)())
 
 **When to use** — one choice from a fixed list. For picking a single input column, prefer **Column Selector**; reach for `options=nd.IncomingColumns` only for a lightweight column dropdown.
 
+!!! info "Picking artifacts with `AvailableArtifacts`"
+    `options=nd.AvailableArtifacts(scope="global")` populates the dropdown from the catalog. Each entry is one artifact, not one version — the value stored in the node settings is a **namespace-qualified** reference (`catalog.schema::name`, or the bare name for an artifact with no namespace), and the node resolves the **latest** version of that artifact at run time. With `scope="all"` the catalog entries are qualified the same way, but a pick from the **upstream** part of the list stores the artifact's plain in-flow name. There is no version pinning here; pin a version from Kernel code with `flowfile_ctx.get_global(name, version=N)`. Settings saved before qualified references existed are bare names: opening a `scope="global"` selector upgrades one to its qualified form when the name is unique across namespaces, and clears it when the name now exists in more than one namespace so you re-pick (that value could not resolve server-side either). A `scope="all"` selector never rewrites its saved value, since that value may name an upstream artifact.
+
 ### Multi Select — `.value` → `list[str]`
 
 A dropdown for picking several options from a list.

--- a/docs/users/visual-editor/kernel-api.md
+++ b/docs/users/visual-editor/kernel-api.md
@@ -195,8 +195,11 @@ artifact_id = flowfile_ctx.publish_global(
     tags=["ml", "classification"],
 )
 
-# Retrieve from the global catalog
+# Retrieve from the global catalog (latest version)
 model = flowfile_ctx.get_global("sales_model_v2")
+
+# Same artifact, addressed by its qualified reference
+model = flowfile_ctx.get_global("General.default::sales_model_v2")
 
 # Get a specific version
 model_v1 = flowfile_ctx.get_global("sales_model_v2", version=1)
@@ -212,6 +215,20 @@ flowfile_ctx.delete_global_artifact("sales_model_v2")
 
 !!! note "Registered flow required to persist"
     `publish_global` needs a flow registration to persist the artifact. Core normally auto-provisions a scratch registration for you, so this works in most cases. When no registration is available it returns `-1` and skips persisting rather than raising.
+
+#### Referring to an artifact by name
+
+Every name-based operation (`get_global`, `delete_global_artifact`, and the corresponding `/artifacts/by-name/...` routes) accepts two forms:
+
+| Form | Example | Resolution |
+|------|---------|------------|
+| Bare name | `"sales_model_v2"` | Searched across every namespace you can see. Fails with a conflict when the same name exists in more than one namespace. |
+| Qualified reference | `"General.default::sales_model_v2"` | `catalog.schema` before the separator, artifact name after it. Unambiguous by construction. |
+
+The reference is split on the **last** `::`, so artifact names themselves cannot contain `::` — `publish_global` rejects such a name. If the namespace path no longer resolves (a renamed catalog or schema) the bare name is used as a fallback, and only fails when that name is ambiguous. When no `version` is given, the newest active version is resolved.
+
+!!! warning "Version deletes are guarded"
+    `DELETE /artifacts/{id}` refuses to delete the current latest version while other versions exist (409 `CANNOT_DELETE_LATEST`, overridable with `force=true`) and refuses to delete the last remaining version (delete the artifact itself with `DELETE /artifacts/by-name/{ref}` instead). Kernel calls authenticate as the internal service principal and bypass both guards, so `delete_global_artifact` behaves exactly as before.
 
 !!! tip "Artifact Persistence"
     Local artifacts are automatically saved to disk and recovered if the kernel restarts — no configuration needed.
@@ -322,9 +339,9 @@ The following functions are available inside kernel code via the `flowfile_ctx` 
 | Function | Description |
 |----------|-------------|
 | `publish_global(name, obj, ...)` | Persist an object to the global catalog |
-| `get_global(name, version=None)` | Retrieve from the global catalog |
+| `get_global(name, version=None)` | Retrieve from the global catalog; `name` may be bare or qualified `catalog.schema::name`, latest version when unset |
 | `list_global_artifacts(...)` | List available global artifacts |
-| `delete_global_artifact(name, ...)` | Delete a global artifact |
+| `delete_global_artifact(name, ...)` | Delete a global artifact (same reference forms) |
 
 ### Display & Logging
 

--- a/flowfile_core/flowfile_core/artifacts/exceptions.py
+++ b/flowfile_core/flowfile_core/artifacts/exceptions.py
@@ -97,7 +97,7 @@ class CannotDeleteLastVersionError(ArtifactError):
         self.version = version
         super().__init__(
             f"Version {version} is the only remaining version of '{name}'. "
-            "Delete the whole artifact with DELETE /artifacts/by-name/{ref} instead."
+            f"Delete the whole artifact with DELETE /artifacts/by-name/{name} instead."
         )
 
 

--- a/flowfile_core/flowfile_core/artifacts/exceptions.py
+++ b/flowfile_core/flowfile_core/artifacts/exceptions.py
@@ -42,6 +42,8 @@ class AmbiguousArtifactError(ArtifactError):
     result would be ambiguous, so the caller must disambiguate.
     """
 
+    code = "AMBIGUOUS_ARTIFACT"
+
     def __init__(self, name: str, namespace_ids: list[int | None]):
         self.name = name
         self.namespace_ids = namespace_ids
@@ -49,6 +51,53 @@ class AmbiguousArtifactError(ArtifactError):
         super().__init__(
             f"Multiple artifacts named '{name}' exist across namespaces [{rendered}]. "
             "Specify a namespace_id to disambiguate."
+        )
+
+
+class InvalidArtifactNameError(ArtifactError):
+    """Raised when an artifact name is not usable as a reference.
+
+    ``::`` is the qualified-reference separator (``catalog.schema::name``), so it
+    can never appear inside a name.
+    """
+
+    def __init__(self, name: str, reason: str):
+        self.name = name
+        self.reason = reason
+        super().__init__(f"Invalid artifact name '{name}': {reason}")
+
+
+class CannotDeleteLatestVersionError(ArtifactError):
+    """Raised when deleting the current latest version would silently repoint consumers.
+
+    Every ``get_global(name)`` resolves ``max(version)``, so removing the latest
+    changes what already-saved nodes load. Callers may pass ``force`` to override.
+    """
+
+    code = "CANNOT_DELETE_LATEST"
+
+    def __init__(self, artifact_id: int, name: str, version: int):
+        self.artifact_id = artifact_id
+        self.name = name
+        self.version = version
+        super().__init__(
+            f"Version {version} is the current latest version of '{name}'. "
+            "Delete an older version, or pass force=true to delete it anyway."
+        )
+
+
+class CannotDeleteLastVersionError(ArtifactError):
+    """Raised when the deletion would remove the only remaining active version."""
+
+    code = "CANNOT_DELETE_LAST_VERSION"
+
+    def __init__(self, artifact_id: int, name: str, version: int):
+        self.artifact_id = artifact_id
+        self.name = name
+        self.version = version
+        super().__init__(
+            f"Version {version} is the only remaining version of '{name}'. "
+            "Delete the whole artifact with DELETE /artifacts/by-name/{ref} instead."
         )
 
 
@@ -117,6 +166,8 @@ class AmbiguousNamespaceError(ArtifactError):
     Namespace names are unique only within their parent (catalog vs schema), so
     resolving a bare name can match several; the caller must use ``namespace_id``.
     """
+
+    code = "AMBIGUOUS_NAMESPACE"
 
     def __init__(self, name: str, namespace_ids: list[int]):
         self.name = name

--- a/flowfile_core/flowfile_core/artifacts/routes.py
+++ b/flowfile_core/flowfile_core/artifacts/routes.py
@@ -13,25 +13,31 @@ IMPORTANT: Core API never handles blob data. All binary data flows directly
 between kernel and storage backend. Core only manages metadata.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from flowfile_core.artifacts.exceptions import (
     AmbiguousArtifactError,
     AmbiguousNamespaceError,
+    ArtifactError,
     ArtifactNotActiveError,
     ArtifactNotFoundError,
     ArtifactUploadError,
+    CannotDeleteLastVersionError,
+    CannotDeleteLatestVersionError,
+    InvalidArtifactNameError,
     NamespaceNotFoundError,
 )
 from flowfile_core.artifacts.service import ArtifactService
-from flowfile_core.auth.jwt import get_user_or_internal_service
-from flowfile_core.catalog.exceptions import FlowNotFoundError
+from flowfile_core.auth.jwt import get_user_or_internal_service, verify_internal_token
+from flowfile_core.catalog.access import AccessResolver
+from flowfile_core.catalog.exceptions import FlowNotFoundError, NotAuthorizedError
 from flowfile_core.database.connection import get_db
 from flowfile_core.schemas.artifact_schema import (
     ArtifactDeleteResponse,
     ArtifactListItem,
     ArtifactOut,
+    ArtifactPruneResponse,
     ArtifactWithVersions,
     FinalizeUploadRequest,
     FinalizeUploadResponse,
@@ -42,18 +48,51 @@ from flowfile_core.schemas.artifact_schema import (
 router = APIRouter(
     prefix="/artifacts",
     tags=["artifacts"],
+    # Every artifact endpoint authenticates; handlers that need the principal
+    # itself (owner id, internal-service detection) declare it explicitly.
+    dependencies=[Depends(get_user_or_internal_service)],
 )
 
 
 # Dependency injection
 
 
-def get_artifact_service(db: Session = Depends(get_db)) -> ArtifactService:
-    """FastAPI dependency that provides a configured ``ArtifactService``."""
+def get_artifact_service(
+    db: Session = Depends(get_db),
+    current_user=Depends(get_user_or_internal_service),
+) -> ArtifactService:
+    """FastAPI dependency that provides a configured ``ArtifactService``.
+
+    Every artifact endpoint authenticates (``download_source`` hands out a real
+    path / presigned URL). The ``AccessResolver`` additionally makes reads
+    private-by-default in multi-user mode; it is a no-op for admins, the kernel
+    internal-service principal, and electron.
+    """
     from flowfile_core.artifacts import get_storage_backend
 
     storage = get_storage_backend()
-    return ArtifactService(db, storage)
+    return ArtifactService(db, storage, access=AccessResolver(db, current_user))
+
+
+def is_internal_service_call(
+    x_internal_token: str | None = Header(None, alias="X-Internal-Token"),
+) -> bool:
+    """True for kernel calls, which bypass the version-safety delete guards.
+
+    Released kernel images call ``delete_global_artifact(name, version=latest)``
+    and must keep working unchanged.
+    """
+    if not x_internal_token:
+        return False
+    try:
+        return verify_internal_token(x_internal_token)
+    except ValueError:
+        return False
+
+
+def _conflict(exc: ArtifactError) -> HTTPException:
+    """409 carrying a machine-readable error code alongside the message."""
+    return HTTPException(409, {"error_code": getattr(exc, "code", "CONFLICT"), "message": str(exc)})
 
 
 # Upload workflow
@@ -83,6 +122,8 @@ async def prepare_upload(
         raise HTTPException(404, "Source registration not found") from None
     except NamespaceNotFoundError:
         raise HTTPException(404, "Namespace not found") from None
+    except InvalidArtifactNameError as e:
+        raise HTTPException(422, str(e)) from e
 
 
 @router.post(
@@ -128,6 +169,7 @@ def list_artifacts(
     python_type_contains: str | None = Query(None, description="Filter by Python type substring"),
     limit: int = Query(100, ge=1, le=500, description="Maximum results"),
     offset: int = Query(0, ge=0, description="Pagination offset"),
+    latest_only: bool = Query(False, description="One row per (name, namespace): the newest active version"),
     service: ArtifactService = Depends(get_artifact_service),
 ):
     """List artifacts with optional filtering."""
@@ -138,6 +180,7 @@ def list_artifacts(
         python_type_contains=python_type_contains,
         limit=limit,
         offset=offset,
+        latest_only=latest_only,
     )
 
 
@@ -163,7 +206,8 @@ def list_artifact_names(
     response_model=ArtifactOut,
     summary="Get artifact by name",
     description=(
-        "Lookup artifact by name. Returns latest version unless specified. "
+        "Lookup artifact by name or qualified 'catalog.schema::name' reference. "
+        "Returns latest version unless specified. "
         "Includes download_source for kernel to fetch blob directly."
     ),
 )
@@ -184,7 +228,7 @@ def get_artifact_by_name(
             version=version,
         )
     except (AmbiguousArtifactError, AmbiguousNamespaceError) as e:
-        raise HTTPException(409, str(e)) from e
+        raise _conflict(e) from e
     except (ArtifactNotFoundError, NamespaceNotFoundError) as e:
         raise HTTPException(404, str(e)) from e
 
@@ -193,24 +237,31 @@ def get_artifact_by_name(
     "/by-name/{name}/versions",
     response_model=ArtifactWithVersions,
     summary="Get artifact with all versions",
-    description="Get artifact metadata and list of all available versions.",
+    description=(
+        "Get artifact metadata and its versions (newest first). Accepts a qualified "
+        "'catalog.schema::name' reference. Without a limit every version is returned."
+    ),
 )
 def get_artifact_versions(
     name: str,
     namespace_id: int | None = Query(None, description="Namespace filter"),
     namespace: str | None = Query(None, description="Namespace name (resolved to id; alternative to namespace_id)"),
+    limit: int | None = Query(None, ge=1, le=500, description="Maximum versions to return"),
+    offset: int = Query(0, ge=0, description="Offset into the version list"),
     service: ArtifactService = Depends(get_artifact_service),
 ):
-    """Get artifact with all available versions."""
+    """Get artifact with its available versions."""
     try:
         if namespace_id is None and namespace is not None:
             namespace_id = service.resolve_namespace_id(namespace)
         return service.get_artifact_with_versions(
             name=name,
             namespace_id=namespace_id,
+            limit=limit,
+            offset=offset,
         )
     except (AmbiguousArtifactError, AmbiguousNamespaceError) as e:
-        raise HTTPException(409, str(e)) from e
+        raise _conflict(e) from e
     except (ArtifactNotFoundError, NamespaceNotFoundError) as e:
         raise HTTPException(404, str(e)) from e
 
@@ -232,6 +283,69 @@ def get_artifact_by_id(
         raise HTTPException(404, "Artifact not found") from None
 
 
+# Version management
+
+
+@router.post(
+    "/{artifact_id}/promote",
+    response_model=ArtifactOut,
+    summary="Promote an artifact version",
+    description=(
+        "Copy an older version forward as a new highest version, so it becomes what "
+        "'latest' resolves to. History stays append-only; the blob is copied by the "
+        "storage backend."
+    ),
+)
+def promote_artifact_version(
+    artifact_id: int,
+    service: ArtifactService = Depends(get_artifact_service),
+):
+    """Promote a version to the new latest."""
+    try:
+        return service.promote_version(artifact_id)
+    except NotAuthorizedError as e:
+        raise HTTPException(403, str(e)) from e
+    except ArtifactNotFoundError:
+        raise HTTPException(404, "Artifact version not found or its data is missing") from None
+    except ArtifactUploadError as e:
+        raise _conflict(e) from e
+
+
+@router.post(
+    "/by-name/{name}/prune",
+    response_model=ArtifactPruneResponse,
+    summary="Prune old artifact versions",
+    description=(
+        "Delete all but the newest `keep` active versions. The current latest is always "
+        "kept. With dry_run=true nothing is deleted."
+    ),
+)
+def prune_artifact_versions(
+    name: str,
+    keep: int = Query(5, ge=1, description="How many newest versions to keep"),
+    dry_run: bool = Query(True, description="Report what would be deleted without deleting"),
+    namespace_id: int | None = Query(None, description="Namespace filter"),
+    namespace: str | None = Query(None, description="Namespace name (resolved to id; alternative to namespace_id)"),
+    service: ArtifactService = Depends(get_artifact_service),
+):
+    """Prune older versions of an artifact."""
+    try:
+        if namespace_id is None and namespace is not None:
+            namespace_id = service.resolve_namespace_id(namespace)
+        return service.prune_versions(
+            name=name,
+            namespace_id=namespace_id,
+            keep=keep,
+            dry_run=dry_run,
+        )
+    except NotAuthorizedError as e:
+        raise HTTPException(403, str(e)) from e
+    except (AmbiguousArtifactError, AmbiguousNamespaceError) as e:
+        raise _conflict(e) from e
+    except (ArtifactNotFoundError, NamespaceNotFoundError) as e:
+        raise HTTPException(404, str(e)) from e
+
+
 # Deletion
 
 
@@ -241,22 +355,29 @@ def get_artifact_by_id(
     summary="Delete artifact",
     description=(
         "Delete a specific artifact version (soft delete in DB, hard delete blob). "
+        "Refuses the current latest version (409 CANNOT_DELETE_LATEST) unless force=true, "
+        "and the last remaining version (delete the whole artifact by name instead). "
         "Accepts either JWT auth or X-Internal-Token header for kernel calls."
     ),
 )
 async def delete_artifact(
     artifact_id: int,
-    current_user=Depends(get_user_or_internal_service),
+    force: bool = Query(False, description="Allow deleting the current latest version"),
+    internal_service: bool = Depends(is_internal_service_call),
     service: ArtifactService = Depends(get_artifact_service),
 ):
     """Delete a specific artifact version."""
     try:
-        service.delete_artifact(artifact_id)
+        service.delete_artifact(artifact_id, force=force, bypass_guards=internal_service)
         return ArtifactDeleteResponse(
             status="deleted",
             artifact_id=artifact_id,
             versions_deleted=1,
         )
+    except NotAuthorizedError as e:
+        raise HTTPException(403, str(e)) from e
+    except (CannotDeleteLatestVersionError, CannotDeleteLastVersionError) as e:
+        raise _conflict(e) from e
     except ArtifactNotFoundError:
         raise HTTPException(404, "Artifact not found") from None
 
@@ -274,7 +395,6 @@ async def delete_artifact_by_name(
     name: str,
     namespace_id: int | None = Query(None, description="Namespace filter"),
     namespace: str | None = Query(None, description="Namespace name (resolved to id; alternative to namespace_id)"),
-    current_user=Depends(get_user_or_internal_service),
     service: ArtifactService = Depends(get_artifact_service),
 ):
     """Delete all versions of an artifact."""
@@ -290,7 +410,9 @@ async def delete_artifact_by_name(
             artifact_id=0,  # Multiple versions deleted
             versions_deleted=versions_deleted,
         )
+    except NotAuthorizedError as e:
+        raise HTTPException(403, str(e)) from e
     except AmbiguousNamespaceError as e:
-        raise HTTPException(409, str(e)) from e
+        raise _conflict(e) from e
     except (ArtifactNotFoundError, NamespaceNotFoundError) as e:
         raise HTTPException(404, str(e)) from e

--- a/flowfile_core/flowfile_core/artifacts/service.py
+++ b/flowfile_core/flowfile_core/artifacts/service.py
@@ -12,7 +12,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from sqlalchemy import text
+from sqlalchemy import and_, func, or_, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -22,14 +22,19 @@ from flowfile_core.artifacts.exceptions import (
     ArtifactNotFoundError,
     ArtifactStateError,
     ArtifactUploadError,
+    CannotDeleteLastVersionError,
+    CannotDeleteLatestVersionError,
+    InvalidArtifactNameError,
     NamespaceNotFoundError,
 )
 from flowfile_core.auth import sharing
 from flowfile_core.catalog.exceptions import FlowNotFoundError
-from flowfile_core.database.models import CatalogNamespace, FlowRegistration, GlobalArtifact
+from flowfile_core.database.models import CatalogNamespace, FlowRegistration, GlobalArtifact, ResourceGrant
 from flowfile_core.schemas.artifact_schema import (
     ArtifactListItem,
     ArtifactOut,
+    ArtifactPruneCandidate,
+    ArtifactPruneResponse,
     ArtifactVersionInfo,
     ArtifactWithVersions,
     DownloadSource,
@@ -39,9 +44,14 @@ from flowfile_core.schemas.artifact_schema import (
 )
 
 if TYPE_CHECKING:
+    from flowfile_core.catalog.access import AccessResolver
     from shared.artifact_storage import ArtifactStorageBackend
 
 logger = logging.getLogger(__name__)
+
+# Separator between a namespace path and the artifact name in a qualified
+# reference: "catalog.schema::name". Split on the LAST occurrence.
+REFERENCE_SEPARATOR = "::"
 
 
 def _project_sync_artifacts(owner_id: int) -> None:
@@ -60,6 +70,9 @@ class ArtifactService:
         SQLAlchemy database session.
     storage:
         Storage backend for blob operations.
+    access:
+        Per-request authorization resolver. ``None`` ⇒ unrestricted (electron,
+        internal callers, tests), mirroring ``CatalogService``.
 
     TODO: Add a periodic cleanup task or TTL-based reaper to mark old "pending"
     artifacts as "failed". If a kernel crashes between prepare_upload and
@@ -69,9 +82,46 @@ class ArtifactService:
     - TTL column with automatic status transition
     """
 
-    def __init__(self, db: Session, storage: ArtifactStorageBackend) -> None:
+    def __init__(
+        self,
+        db: Session,
+        storage: ArtifactStorageBackend,
+        access: AccessResolver | None = None,
+    ) -> None:
         self.db = db
         self.storage = storage
+        self.access = access
+
+    # ------------------------------------------------------------------ #
+    # Authorization
+    # ------------------------------------------------------------------ #
+
+    def _accessible_ids(self) -> set[int] | None:
+        """Ids the caller may read, or None when unrestricted."""
+        if self.access is None or not self.access.restricted:
+            return None
+        return self.access.accessible_ids("global_artifact")
+
+    def _scope(self, query):
+        """Restrict a GlobalArtifact query to the rows the caller may read."""
+        ids = self._accessible_ids()
+        if ids is None:
+            return query
+        return query.filter(GlobalArtifact.id.in_(ids))
+
+    def _require_manage(self, artifact: GlobalArtifact) -> None:
+        if self.access is None:
+            return
+        self.access.require_manage("global_artifact", artifact.id, artifact.owner_id)
+
+    def _require_readable(self, artifact: GlobalArtifact) -> None:
+        """404 a row the caller cannot even read, so mutations are no existence oracle.
+
+        403 stays reserved for rows the caller can read but not manage.
+        """
+        ids = self._accessible_ids()
+        if ids is not None and artifact.id not in ids:
+            raise ArtifactNotFoundError(artifact_id=artifact.id)
 
     # ------------------------------------------------------------------ #
     # Upload workflow
@@ -98,7 +148,14 @@ class ArtifactService:
         Raises:
             FlowNotFoundError: If source registration doesn't exist.
             NamespaceNotFoundError: If specified namespace doesn't exist.
+            InvalidArtifactNameError: If the name contains the reference separator.
         """
+        if REFERENCE_SEPARATOR in request.name:
+            raise InvalidArtifactNameError(
+                request.name,
+                f"'{REFERENCE_SEPARATOR}' is reserved as the namespace/name separator in artifact references",
+            )
+
         registration = self.db.get(FlowRegistration, request.source_registration_id)
         if registration is None:
             raise FlowNotFoundError(registration_id=request.source_registration_id)
@@ -125,6 +182,7 @@ class ArtifactService:
             .all()
         )
         for row in stale:
+            sharing.delete_grants_for_resource(self.db, "global_artifact", row.id)
             self.db.delete(row)
         if stale:
             self.db.commit()
@@ -246,6 +304,12 @@ class ArtifactService:
             self.db.commit()
             raise ArtifactUploadError(artifact_id, str(e)) from e
 
+        # Grants key on the version row id, so a direct share would be revoked by
+        # every publish; carry the previous latest version's grants forward.
+        previous = self._latest_active(artifact.name, artifact.namespace_id, exclude_id=artifact.id)
+        if previous is not None:
+            self._copy_grants(previous.id, artifact.id)
+
         artifact.status = "active"
         artifact.storage_key = storage_key
         artifact.sha256 = sha256
@@ -263,6 +327,48 @@ class ArtifactService:
     # Retrieval
     # ------------------------------------------------------------------ #
 
+    def resolve_reference(self, ref: str, namespace_id: int | None = None) -> tuple[str, int | None]:
+        """Split a possibly-qualified ``catalog.schema::name`` reference.
+
+        Every by-name route parses references through here, so a qualified value
+        resolves identically whichever endpoint receives it. An unqualified ref is
+        returned untouched (today's behavior, ambiguity check included). When the
+        namespace path no longer resolves (a renamed catalog) the bare name is
+        accepted if it is unambiguous; otherwise the lookup fails.
+        """
+        if REFERENCE_SEPARATOR not in ref:
+            return ref, namespace_id
+
+        path, _, name = ref.rpartition(REFERENCE_SEPARATOR)
+        if namespace_id is not None:
+            return name, namespace_id
+
+        resolved = self._resolve_namespace_path(path)
+        if resolved is not None:
+            return name, resolved
+
+        namespaces = self._distinct_namespaces(name)
+        if len(namespaces) == 1:
+            return name, namespaces[0]
+        raise NamespaceNotFoundError(name=path)
+
+    def _resolve_namespace_path(self, path: str) -> int | None:
+        """Resolve a dotted ``catalog[.schema]`` path to a namespace id (never creates)."""
+        catalog_name, _, schema_name = path.partition(".")
+        if not catalog_name:
+            return None
+        from flowfile_core.catalog.repository import SQLAlchemyCatalogRepository
+        from flowfile_core.catalog.services.namespaces import NamespaceService
+
+        service = NamespaceService(SQLAlchemyCatalogRepository(self.db))
+        return service.resolve_namespace_id_by_path(catalog_name, schema_name or None)
+
+    def _distinct_namespaces(self, name: str) -> list[int | None]:
+        rows = self._scope(self.db.query(GlobalArtifact).filter_by(name=name, status="active")).with_entities(
+            GlobalArtifact.namespace_id
+        )
+        return [r[0] for r in rows.distinct().all()]
+
     def get_artifact_by_name(
         self,
         name: str,
@@ -272,7 +378,7 @@ class ArtifactService:
         """Lookup artifact by name with download source.
 
         Args:
-            name: Artifact name.
+            name: Artifact name (may be a qualified ``catalog.schema::name`` reference).
             namespace_id: Optional namespace filter.
             version: Optional specific version (latest if not specified).
 
@@ -282,11 +388,14 @@ class ArtifactService:
         Raises:
             ArtifactNotFoundError: If artifact doesn't exist.
         """
+        name, namespace_id = self.resolve_reference(name, namespace_id)
         self._assert_unambiguous(name, namespace_id)
 
-        query = self.db.query(GlobalArtifact).filter_by(
-            name=name,
-            status="active",
+        query = self._scope(
+            self.db.query(GlobalArtifact).filter_by(
+                name=name,
+                status="active",
+            )
         )
         if namespace_id is not None:
             query = query.filter_by(namespace_id=namespace_id)
@@ -316,6 +425,9 @@ class ArtifactService:
         artifact = self.db.get(GlobalArtifact, artifact_id)
         if not artifact or artifact.status != "active":
             raise ArtifactNotFoundError(artifact_id=artifact_id)
+        ids = self._accessible_ids()
+        if ids is not None and artifact.id not in ids:
+            raise ArtifactNotFoundError(artifact_id=artifact_id)
 
         return self._artifact_to_out(artifact, include_download=True)
 
@@ -323,12 +435,16 @@ class ArtifactService:
         self,
         name: str,
         namespace_id: int | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> ArtifactWithVersions:
-        """Get artifact with list of all available versions.
+        """Get artifact with a (optionally paginated) list of its versions.
 
         Args:
-            name: Artifact name.
+            name: Artifact name (may be a qualified ``catalog.schema::name`` reference).
             namespace_id: Optional namespace filter.
+            limit: Maximum versions to return; ``None`` returns them all.
+            offset: Offset into the version list (newest first).
 
         Returns:
             ArtifactWithVersions with latest version and version list.
@@ -336,9 +452,10 @@ class ArtifactService:
         Raises:
             ArtifactNotFoundError: If artifact doesn't exist.
         """
+        name, namespace_id = self.resolve_reference(name, namespace_id)
         self._assert_unambiguous(name, namespace_id)
 
-        query = self.db.query(GlobalArtifact).filter_by(name=name, status="active")
+        query = self._scope(self.db.query(GlobalArtifact).filter_by(name=name, status="active"))
         if namespace_id is not None:
             query = query.filter_by(namespace_id=namespace_id)
 
@@ -347,7 +464,11 @@ class ArtifactService:
         if not latest:
             raise ArtifactNotFoundError(name=name)
 
-        versions = query.order_by(GlobalArtifact.version.desc()).all()
+        total_versions = query.count()
+        page = query.order_by(GlobalArtifact.version.desc()).offset(offset)
+        if limit is not None:
+            page = page.limit(limit)
+        versions = page.all()
 
         version_infos = [
             ArtifactVersionInfo(
@@ -356,6 +477,8 @@ class ArtifactService:
                 created_at=v.created_at,
                 size_bytes=v.size_bytes,
                 sha256=v.sha256,
+                python_type=v.python_type,
+                blob_exists=self._blob_exists(v),
             )
             for v in versions
         ]
@@ -364,6 +487,7 @@ class ArtifactService:
         return ArtifactWithVersions(
             **out.model_dump(),
             all_versions=version_infos,
+            total_versions=total_versions,
         )
 
     def resolve_namespace_id(self, namespace: str) -> int:
@@ -392,6 +516,7 @@ class ArtifactService:
         python_type_contains: str | None = None,
         limit: int = 100,
         offset: int = 0,
+        latest_only: bool = False,
     ) -> list[ArtifactListItem]:
         """List artifacts with optional filtering.
 
@@ -402,11 +527,14 @@ class ArtifactService:
             python_type_contains: Filter by Python type substring.
             limit: Maximum results to return.
             offset: Offset for pagination.
+            latest_only: Collapse to one row per (name, namespace_id) — the newest
+                active version. Applied after access filtering, before limit/offset,
+                so pagination counts artifacts rather than versions.
 
         Returns:
             List of ArtifactListItem objects.
         """
-        query = self.db.query(GlobalArtifact).filter_by(status="active")
+        query = self._scope(self.db.query(GlobalArtifact).filter_by(status="active"))
 
         if namespace_id is not None:
             query = query.filter_by(namespace_id=namespace_id)
@@ -432,6 +560,31 @@ class ArtifactService:
                     ).bindparams(tag=tag)
                 )
 
+        if latest_only:
+            newest = (
+                query.with_entities(
+                    GlobalArtifact.name.label("group_name"),
+                    GlobalArtifact.namespace_id.label("group_namespace_id"),
+                    func.max(GlobalArtifact.version).label("group_version"),
+                )
+                .group_by(GlobalArtifact.name, GlobalArtifact.namespace_id)
+                .subquery()
+            )
+            query = query.join(
+                newest,
+                and_(
+                    GlobalArtifact.name == newest.c.group_name,
+                    GlobalArtifact.version == newest.c.group_version,
+                    or_(
+                        GlobalArtifact.namespace_id == newest.c.group_namespace_id,
+                        and_(
+                            GlobalArtifact.namespace_id.is_(None),
+                            newest.c.group_namespace_id.is_(None),
+                        ),
+                    ),
+                ),
+            )
+
         # Order by name and version, most recent versions first
         # Pagination is applied AFTER all filtering
         artifacts = (
@@ -444,7 +597,16 @@ class ArtifactService:
             .all()
         )
 
-        return [self._artifact_to_list_item(a) for a in artifacts]
+        counts = self._active_version_counts(artifacts)
+        paths = self._bulk_namespace_paths({a.namespace_id for a in artifacts if a.namespace_id is not None})
+        return [
+            self._artifact_to_list_item(
+                a,
+                namespace_path=paths.get(a.namespace_id) if a.namespace_id is not None else None,
+                version_count=counts.get((a.name, a.namespace_id)),
+            )
+            for a in artifacts
+        ]
 
     def list_artifact_names(
         self,
@@ -458,12 +620,12 @@ class ArtifactService:
         Returns:
             List of unique artifact names.
         """
-        query = self.db.query(GlobalArtifact.name).filter_by(status="active")
+        query = self._scope(self.db.query(GlobalArtifact).filter_by(status="active"))
 
         if namespace_id is not None:
             query = query.filter_by(namespace_id=namespace_id)
 
-        names = query.distinct().all()
+        names = query.with_entities(GlobalArtifact.name).distinct().all()
         return [n[0] for n in names]
 
     # ------------------------------------------------------------------ #
@@ -473,40 +635,190 @@ class ArtifactService:
     def delete_artifact(
         self,
         artifact_id: int,
+        force: bool = False,
+        bypass_guards: bool = False,
     ) -> int:
         """Delete a specific artifact version (soft delete in DB, hard delete blob).
 
         Args:
             artifact_id: Database ID of the artifact to delete.
+            force: Allow deleting the current latest version.
+            bypass_guards: Skip the version-safety guards entirely (kernel/internal
+                callers, whose released images delete "the latest version" by design).
 
         Returns:
             Number of versions deleted (always 1).
 
         Raises:
-            ArtifactNotFoundError: If artifact doesn't exist.
+            ArtifactNotFoundError: If artifact doesn't exist or is not readable.
+            CannotDeleteLatestVersionError: If the row is the current latest and force is False.
+            CannotDeleteLastVersionError: If the row is the only remaining active version.
         """
         artifact = self.db.get(GlobalArtifact, artifact_id)
         if not artifact:
             raise ArtifactNotFoundError(artifact_id=artifact_id)
 
-        if artifact.storage_key:
-            try:
-                self.storage.delete(artifact.storage_key)
-            except Exception as exc:
-                logger.warning(
-                    "Failed to delete blob for artifact %s (storage_key=%s): %s",
-                    artifact_id,
-                    artifact.storage_key,
-                    exc,
-                )
+        self._require_readable(artifact)
+        self._require_manage(artifact)
+
+        if not bypass_guards and artifact.status == "active":
+            siblings = self._active_versions(artifact.name, artifact.namespace_id, exclude_id=artifact.id)
+            if not siblings:
+                raise CannotDeleteLastVersionError(artifact.id, artifact.name, artifact.version)
+            if not force and artifact.version > max(s.version for s in siblings):
+                raise CannotDeleteLatestVersionError(artifact.id, artifact.name, artifact.version)
 
         owner_id = artifact.owner_id
-        artifact.status = "deleted"
-        sharing.delete_grants_for_resource(self.db, "global_artifact", artifact_id)
+        self._delete_row(artifact)
         self.db.commit()
         _project_sync_artifacts(owner_id)
 
         return 1
+
+    def promote_version(self, artifact_id: int, _max_retries: int = 3) -> ArtifactOut:
+        """Copy an older version forward as the new latest version.
+
+        "Latest" is ``max(version)``, so restoring an old version means
+        re-publishing its bytes under a new highest version — history stays
+        append-only and every ``get_global(name)`` picks it up unchanged. The blob
+        is copied by the storage backend; Core never touches the bytes.
+
+        A concurrent publish can claim the same version number, so the mint is
+        retried on the unique constraint like ``prepare_upload`` does.
+
+        Raises:
+            ArtifactNotFoundError: If the source row is missing, not active, or its blob is gone.
+            ArtifactUploadError: If every attempt lost the version race.
+        """
+        source = self.db.get(GlobalArtifact, artifact_id)
+        if not source or source.status != "active":
+            raise ArtifactNotFoundError(artifact_id=artifact_id)
+
+        self._require_readable(source)
+        self._require_manage(source)
+
+        if not source.storage_key:
+            raise ArtifactNotFoundError(artifact_id=artifact_id)
+
+        filename = source.storage_key.split("/", 1)[-1]
+        last_error: IntegrityError | None = None
+        for attempt in range(_max_retries):
+            previous_latest = self._latest_active(source.name, source.namespace_id)
+            latest_any = (
+                self.db.query(GlobalArtifact)
+                .filter_by(name=source.name, namespace_id=source.namespace_id)
+                .order_by(GlobalArtifact.version.desc())
+                .first()
+            )
+            next_version = (latest_any.version + 1) if latest_any else 1
+
+            promoted = GlobalArtifact(
+                name=source.name,
+                namespace_id=source.namespace_id,
+                version=next_version,
+                status="active",
+                owner_id=source.owner_id,
+                source_registration_id=source.source_registration_id,
+                source_flow_id=source.source_flow_id,
+                source_node_id=source.source_node_id,
+                source_kernel_id=source.source_kernel_id,
+                python_type=source.python_type,
+                python_module=source.python_module,
+                serialization_format=source.serialization_format,
+                sha256=source.sha256,
+                size_bytes=source.size_bytes,
+                description=source.description,
+                tags=source.tags,
+            )
+            self.db.add(promoted)
+            try:
+                self.db.flush()
+            except IntegrityError as e:
+                self.db.rollback()
+                last_error = e
+                continue
+
+            storage_key = f"{promoted.id}/{filename}"
+            try:
+                promoted.size_bytes = self.storage.copy(source.storage_key, storage_key)
+            except FileNotFoundError:
+                self.db.rollback()
+                raise ArtifactNotFoundError(artifact_id=artifact_id) from None
+            promoted.storage_key = storage_key
+
+            if previous_latest is not None:
+                self._copy_grants(previous_latest.id, promoted.id)
+
+            try:
+                self.db.commit()
+            except IntegrityError as e:
+                self.db.rollback()
+                self._discard_blob(storage_key)
+                last_error = e
+                logger.warning(
+                    "Version conflict promoting artifact '%s' v%d (attempt %d/%d), retrying...",
+                    source.name,
+                    next_version,
+                    attempt + 1,
+                    _max_retries,
+                )
+                continue
+
+            self.db.refresh(promoted)
+            _project_sync_artifacts(promoted.owner_id)
+            return self._artifact_to_out(promoted, include_download=True)
+
+        raise ArtifactUploadError(
+            artifact_id=artifact_id,
+            reason=f"Failed to promote after {_max_retries} attempts due to version conflicts: {last_error}",
+        )
+
+    def prune_versions(
+        self,
+        name: str,
+        namespace_id: int | None = None,
+        keep: int = 5,
+        dry_run: bool = True,
+    ) -> ArtifactPruneResponse:
+        """Delete all but the newest ``keep`` active versions (the latest is always kept).
+
+        Raises:
+            ArtifactNotFoundError: If the artifact has no active versions.
+        """
+        keep = max(1, keep)
+        name, namespace_id = self.resolve_reference(name, namespace_id)
+        if namespace_id is None:
+            # Versions must be grouped by namespace, so a bare name has to resolve to
+            # exactly one (possibly the namespace-less one).
+            namespaces = self._distinct_namespaces(name)
+            if len(namespaces) > 1:
+                raise AmbiguousArtifactError(name, namespaces)
+            namespace_id = namespaces[0] if namespaces else None
+
+        versions = self._active_versions(name, namespace_id)
+        if not versions:
+            raise ArtifactNotFoundError(name=name)
+
+        self._require_manage(versions[0])
+
+        candidates = versions[keep:]
+        would_delete = [ArtifactPruneCandidate(id=v.id, version=v.version, size_bytes=v.size_bytes) for v in candidates]
+        freed_bytes = sum(v.size_bytes or 0 for v in candidates)
+
+        if dry_run or not candidates:
+            return ArtifactPruneResponse(would_delete=would_delete, freed_bytes=freed_bytes, deleted=0)
+
+        owner_id = candidates[0].owner_id
+        for artifact in candidates:
+            self._delete_row(artifact)
+        self.db.commit()
+        _project_sync_artifacts(owner_id)
+
+        return ArtifactPruneResponse(
+            would_delete=would_delete,
+            freed_bytes=freed_bytes,
+            deleted=len(candidates),
+        )
 
     def delete_all_versions(
         self,
@@ -525,7 +837,10 @@ class ArtifactService:
         Raises:
             ArtifactNotFoundError: If no artifacts found.
         """
-        query = self.db.query(GlobalArtifact).filter_by(name=name).filter(GlobalArtifact.status != "deleted")
+        name, namespace_id = self.resolve_reference(name, namespace_id)
+        query = self._scope(
+            self.db.query(GlobalArtifact).filter_by(name=name).filter(GlobalArtifact.status != "deleted")
+        )
         if namespace_id is not None:
             query = query.filter_by(namespace_id=namespace_id)
         artifacts = query.all()
@@ -533,22 +848,15 @@ class ArtifactService:
         if not artifacts:
             raise ArtifactNotFoundError(name=name)
 
+        # Every row, not just the first: a bare name can span namespaces and owners,
+        # so one manageable row must never authorize deleting someone else's.
+        for artifact in artifacts:
+            self._require_manage(artifact)
+
         owner_id = artifacts[0].owner_id
         count = 0
         for artifact in artifacts:
-            if artifact.storage_key:
-                try:
-                    self.storage.delete(artifact.storage_key)
-                except Exception as exc:
-                    logger.warning(
-                        "Failed to delete blob for artifact %s v%s (storage_key=%s): %s",
-                        name,
-                        artifact.version,
-                        artifact.storage_key,
-                        exc,
-                    )
-            artifact.status = "deleted"
-            sharing.delete_grants_for_resource(self.db, "global_artifact", artifact.id)
+            self._delete_row(artifact)
             count += 1
 
         self.db.commit()
@@ -565,14 +873,142 @@ class ArtifactService:
         The same name can be published into several namespaces, so resolving by
         name alone (``namespace_id is None``) is only safe when exactly one
         namespace holds an active artifact with that name. Otherwise the caller
-        must disambiguate with an explicit ``namespace_id``.
+        must disambiguate with an explicit ``namespace_id`` or a qualified
+        ``catalog.schema::name`` reference.
         """
         if namespace_id is not None:
             return
-        rows = self.db.query(GlobalArtifact.namespace_id).filter_by(name=name, status="active").distinct().all()
-        namespaces = [r[0] for r in rows]
+        namespaces = self._distinct_namespaces(name)
         if len(namespaces) > 1:
             raise AmbiguousArtifactError(name, namespaces)
+
+    def _active_versions(
+        self,
+        name: str,
+        namespace_id: int | None,
+        exclude_id: int | None = None,
+    ) -> list[GlobalArtifact]:
+        """Active versions of one artifact the caller may read, newest first."""
+        query = self._scope(
+            self.db.query(GlobalArtifact).filter_by(name=name, namespace_id=namespace_id, status="active")
+        )
+        if exclude_id is not None:
+            query = query.filter(GlobalArtifact.id != exclude_id)
+        return query.order_by(GlobalArtifact.version.desc()).all()
+
+    def _latest_active(
+        self,
+        name: str,
+        namespace_id: int | None,
+        exclude_id: int | None = None,
+    ) -> GlobalArtifact | None:
+        versions = self._active_versions(name, namespace_id, exclude_id=exclude_id)
+        return versions[0] if versions else None
+
+    def _copy_grants(self, from_artifact_id: int, to_artifact_id: int) -> None:
+        """Re-point a version's sharing grants onto a newly created version row."""
+        grants = (
+            self.db.query(ResourceGrant).filter_by(resource_type="global_artifact", resource_id=from_artifact_id).all()
+        )
+        existing = {
+            g.group_id
+            for g in self.db.query(ResourceGrant).filter_by(resource_type="global_artifact", resource_id=to_artifact_id)
+        }
+        for grant in grants:
+            if grant.group_id in existing:
+                continue
+            self.db.add(
+                ResourceGrant(
+                    resource_type="global_artifact",
+                    resource_id=to_artifact_id,
+                    group_id=grant.group_id,
+                    permission=grant.permission,
+                    granted_by=grant.granted_by,
+                )
+            )
+
+    def _delete_row(self, artifact: GlobalArtifact) -> None:
+        """Hard-delete the blob, soft-delete the row, drop its grants. Caller commits."""
+        if artifact.storage_key:
+            self._discard_blob(artifact.storage_key)
+        artifact.status = "deleted"
+        sharing.delete_grants_for_resource(self.db, "global_artifact", artifact.id)
+
+    def _discard_blob(self, storage_key: str) -> None:
+        """Best-effort blob removal; a storage failure must not abort the DB work."""
+        try:
+            self.storage.delete(storage_key)
+        except Exception as exc:
+            logger.warning("Failed to delete artifact blob (storage_key=%s): %s", storage_key, exc)
+
+    def _blob_exists(self, artifact: GlobalArtifact) -> bool:
+        """Filesystem backends only — one cheap stat per row.
+
+        An S3 HEAD per version row would put a network call in every versions page,
+        which is exactly what ``bulk_enrich_artifacts`` refuses to do.
+        """
+        from shared.artifact_storage import SharedFilesystemStorage
+
+        if not artifact.storage_key:
+            return False
+        if not isinstance(self.storage, SharedFilesystemStorage):
+            return True
+        try:
+            return self.storage.exists(artifact.storage_key)
+        except Exception:
+            return False
+
+    def _active_version_counts(self, artifacts: list[GlobalArtifact]) -> dict[tuple[str, int | None], int]:
+        """Active-version count per (name, namespace_id) for a page of rows, in one query."""
+        names = {a.name for a in artifacts}
+        if not names:
+            return {}
+        rows = (
+            self._scope(self.db.query(GlobalArtifact).filter(GlobalArtifact.status == "active"))
+            .filter(GlobalArtifact.name.in_(names))
+            .with_entities(
+                GlobalArtifact.name,
+                GlobalArtifact.namespace_id,
+                func.count(GlobalArtifact.id),
+            )
+            .group_by(GlobalArtifact.name, GlobalArtifact.namespace_id)
+            .all()
+        )
+        return {(name, namespace_id): count for name, namespace_id, count in rows}
+
+    def _bulk_namespace_paths(self, namespace_ids: set[int]) -> dict[int, str]:
+        """Dotted paths for a set of namespaces, walking parents in bulk (no per-row query)."""
+        if not namespace_ids:
+            return {}
+        known: dict[int, tuple[str, int | None]] = {}
+        pending = set(namespace_ids)
+        attempted: set[int] = set()
+        while pending:
+            # Track what was looked up, not what came back: a dangling parent_id
+            # (SQLite does not enforce FKs) would otherwise re-query forever.
+            attempted |= pending
+            rows = (
+                self.db.query(CatalogNamespace.id, CatalogNamespace.name, CatalogNamespace.parent_id)
+                .filter(CatalogNamespace.id.in_(pending))
+                .all()
+            )
+            for ns_id, name, parent_id in rows:
+                known[ns_id] = (name, parent_id)
+            pending = {parent for _n, parent in known.values() if parent is not None and parent not in attempted}
+
+        paths: dict[int, str] = {}
+        for ns_id in namespace_ids:
+            parts: list[str] = []
+            seen: set[int] = set()
+            current: int | None = ns_id
+            while current is not None and current in known and current not in seen:
+                seen.add(current)
+                name, parent_id = known[current]
+                parts.append(name)
+                current = parent_id
+            if parts:
+                paths[ns_id] = ".".join(reversed(parts))
+        return paths
 
     def _artifact_to_out(
         self,
@@ -620,7 +1056,12 @@ class ArtifactService:
             download_source=download_source,
         )
 
-    def _artifact_to_list_item(self, artifact: GlobalArtifact) -> ArtifactListItem:
+    def _artifact_to_list_item(
+        self,
+        artifact: GlobalArtifact,
+        namespace_path: str | None = None,
+        version_count: int | None = None,
+    ) -> ArtifactListItem:
         """Convert database model to list item schema."""
         return ArtifactListItem(
             id=artifact.id,
@@ -635,4 +1076,6 @@ class ArtifactService:
             created_at=artifact.created_at,
             tags=json.loads(artifact.tags) if artifact.tags else [],
             owner_id=artifact.owner_id,
+            namespace_path=namespace_path,
+            version_count=version_count,
         )

--- a/flowfile_core/flowfile_core/artifacts/service.py
+++ b/flowfile_core/flowfile_core/artifacts/service.py
@@ -802,6 +802,10 @@ class ArtifactService:
         self._require_manage(versions[0])
 
         candidates = versions[keep:]
+        # Every candidate, not just the newest row: sibling versions can carry
+        # different owners, so managing the latest must never authorize deleting theirs.
+        for artifact in candidates:
+            self._require_manage(artifact)
         would_delete = [ArtifactPruneCandidate(id=v.id, version=v.version, size_bytes=v.size_bytes) for v in candidates]
         freed_bytes = sum(v.size_bytes or 0 for v in candidates)
 

--- a/flowfile_core/flowfile_core/catalog/repository.py
+++ b/flowfile_core/flowfile_core/catalog/repository.py
@@ -10,7 +10,7 @@ from collections.abc import Collection
 from datetime import datetime, timedelta
 from typing import Protocol, runtime_checkable
 
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
 from flowfile_core.auth import sharing
@@ -104,6 +104,8 @@ class CatalogRepository(Protocol):
     # -- Artifact operations -------------------------------------------------
 
     def list_artifacts_for_namespace(self, namespace_id: int) -> list[GlobalArtifact]: ...
+
+    def artifact_version_counts_for_namespace(self, namespace_id: int) -> dict[str, int]: ...
 
     def list_artifacts_for_flow(self, registration_id: int) -> list[GlobalArtifact]: ...
 
@@ -595,14 +597,38 @@ class SQLAlchemyCatalogRepository:
     # -- Artifact operations -------------------------------------------------
 
     def list_artifacts_for_namespace(self, namespace_id: int) -> list[GlobalArtifact]:
-        """List active artifacts belonging to a namespace."""
-        return (
+        """One row per artifact name in a namespace: its latest active version.
+
+        An artifact with no active version falls back to its newest non-deleted row so
+        a failed or pending publish stays visible (flagged unavailable) instead of
+        vanishing from the tree.
+        """
+        rows = (
             self._db.query(GlobalArtifact)
             .filter_by(namespace_id=namespace_id)
             .filter(GlobalArtifact.status != "deleted")
             .order_by(GlobalArtifact.name, GlobalArtifact.version.desc())
             .all()
         )
+        latest: dict[str, GlobalArtifact] = {}
+        for row in rows:
+            current = latest.get(row.name)
+            if current is None or (current.status != "active" and row.status == "active"):
+                latest[row.name] = row
+        return list(latest.values())
+
+    def artifact_version_counts_for_namespace(self, namespace_id: int) -> dict[str, int]:
+        """name -> version count in a namespace: active versions, or the non-deleted group
+        size when an artifact has none (a failed publish's rows still count as versions)."""
+        active = func.sum(case((GlobalArtifact.status == "active", 1), else_=0))
+        rows = (
+            self._db.query(GlobalArtifact.name, active, func.count(GlobalArtifact.id))
+            .filter_by(namespace_id=namespace_id)
+            .filter(GlobalArtifact.status != "deleted")
+            .group_by(GlobalArtifact.name)
+            .all()
+        )
+        return {name: (active_count or group_size) for name, active_count, group_size in rows}
 
     def list_artifacts_for_flow(self, registration_id: int) -> list[GlobalArtifact]:
         """List active artifacts produced by a specific flow."""

--- a/flowfile_core/flowfile_core/catalog/services/namespaces.py
+++ b/flowfile_core/flowfile_core/catalog/services/namespaces.py
@@ -85,7 +85,10 @@ def _project_sync_namespace(owner_id: int) -> None:
     project_sync.namespace_changed(owner_id)
 
 
-def bulk_enrich_artifacts(artifacts: list[GlobalArtifact]) -> list[GlobalArtifactOut]:
+def bulk_enrich_artifacts(
+    artifacts: list[GlobalArtifact],
+    version_counts: dict[str, int] | None = None,
+) -> list[GlobalArtifactOut]:
     """Serialize artifacts, flagging ones whose backing blob is missing on disk
     (filesystem backend only — exists() is one cheap stat; an S3 probe per item
     would be a network call on every load)."""
@@ -99,7 +102,10 @@ def bulk_enrich_artifacts(artifacts: list[GlobalArtifact]) -> list[GlobalArtifac
         blob_exists = True
         if fs_storage is not None and a.storage_key:
             blob_exists = fs_storage.exists(a.storage_key)
-        items.append(artifact_to_out(a, blob_exists=blob_exists))
+        out = artifact_to_out(a, blob_exists=blob_exists)
+        if version_counts is not None:
+            out.version_count = version_counts.get(a.name, 1)
+        items.append(out)
     return items
 
 
@@ -329,7 +335,13 @@ class NamespaceService:
         namespace_table_map: dict[int, list[CatalogTableOut]] = {}
 
         def _artifacts_out(ns_id: int) -> list[GlobalArtifactOut]:
-            return bulk_enrich_artifacts(self.repo.list_artifacts_for_namespace(ns_id))
+            artifacts = self.repo.list_artifacts_for_namespace(ns_id)
+            if not artifacts:
+                return []
+            return bulk_enrich_artifacts(
+                artifacts,
+                version_counts=self.repo.artifact_version_counts_for_namespace(ns_id),
+            )
 
         # Visualizations are surfaced as a peer of flows / tables / artifacts in
         # whatever namespace they were saved into (their own ``namespace_id``,

--- a/flowfile_core/flowfile_core/flowfile/community_nodes/dry_run_local.py
+++ b/flowfile_core/flowfile_core/flowfile/community_nodes/dry_run_local.py
@@ -368,12 +368,40 @@ class _FlowfileCtx:
         return lambda *a, **k: None
 
 
-def _seed_example_artifacts(node, ctx):
+def _artifact_aliases(settings_values):
+    """bare artifact name -> qualified "catalog.schema::name" settings values naming it.
+
+    Mirrors core's dry-run prologue: an artifact-select stores a qualified string while
+    example_artifacts() is keyed by the bare name, so both spellings must be seeded.
+    """
+    aliases = {}
+
+    def _record(value):
+        if isinstance(value, list):
+            for item in value:
+                _record(item)
+            return
+        if not isinstance(value, str) or "::" not in value:
+            return
+        bare = value.rsplit("::", 1)[1]
+        if bare and value not in aliases.setdefault(bare, []):
+            aliases[bare].append(value)
+
+    for components in (settings_values or {}).values():
+        if not isinstance(components, dict):
+            continue
+        for value in components.values():
+            _record(value)
+    return aliases
+
+
+def _seed_example_artifacts(node, ctx, settings_values=None):
     """Seed ``node.example_artifacts()`` into both artifact stores before process().
 
     A flat ``{name: obj}`` dict lands in the flow-local store *and* the global
     store, so a node reading via either ``read_artifact`` or ``get_global`` finds
-    it without the author having to know which scope the dry run uses.
+    it without the author having to know which scope the dry run uses. Each entry
+    is also seeded under any qualified reference the example settings select.
     """
     hook = getattr(node, "example_artifacts", None)
     if hook is None:
@@ -384,9 +412,11 @@ def _seed_example_artifacts(node, ctx):
     # Before the emptiness check, so `[]` fails like `[1]` does.
     if not isinstance(artifacts, dict):
         raise TypeError("example_artifacts() must return a dict, got %s" % type(artifacts).__name__)
+    aliases = _artifact_aliases(settings_values)
     for name, obj in artifacts.items():
-        ctx._seed_artifact(name, obj)
-        ctx._seed_global(name, obj)
+        for key in [name] + aliases.get(name, []):
+            ctx._seed_artifact(key, obj)
+            ctx._seed_global(key, obj)
 
 
 def _normalize(result, output_names):
@@ -425,7 +455,7 @@ def _run(folder, config):
     if settings and node.settings_schema:
         node.settings_schema.populate_values(settings)
     node.set_execution_context(-1, resolver=None)
-    _seed_example_artifacts(node, ctx)
+    _seed_example_artifacts(node, ctx, settings)
     outputs = _normalize(node.process(*lazy_inputs), config["output_names"])
     names = []
     for name, lf in outputs.items():

--- a/flowfile_core/flowfile_core/flowfile/user_defined/kernel_codegen.py
+++ b/flowfile_core/flowfile_core/flowfile/user_defined/kernel_codegen.py
@@ -103,6 +103,34 @@ def _bake_settings(settings_values: dict[str, dict[str, Any]]) -> str:
     return json.dumps(settings_values or {})
 
 
+def _artifact_aliases(settings_values: dict[str, dict[str, Any]]) -> dict[str, list[str]]:
+    """Map a bare artifact name to the qualified ``catalog.schema::name`` values referring to it.
+
+    An artifact-select stores a namespace-qualified string, but ``example_artifacts()``
+    is keyed by the bare name, so a dry run must seed both spellings or the node's
+    ``get_global(<qualified>)`` falls through to the live catalog.
+    """
+    aliases: dict[str, list[str]] = {}
+
+    def _record(value: Any) -> None:
+        if isinstance(value, list):
+            for item in value:
+                _record(item)
+            return
+        if not isinstance(value, str) or "::" not in value:
+            return
+        bare = value.rsplit("::", 1)[1]
+        if bare and value not in aliases.setdefault(bare, []):
+            aliases[bare].append(value)
+
+    for components in (settings_values or {}).values():
+        if not isinstance(components, dict):
+            continue
+        for value in components.values():
+            _record(value)
+    return aliases
+
+
 def _indent(block: str, spaces: int = 4) -> str:
     pad = " " * spaces
     return "\n".join(pad + line if line.strip() else line for line in block.splitlines())
@@ -188,9 +216,13 @@ def generate_kernel_script(
     # — so pin the known-noisy ones to WARNING to keep the Test panel readable.
     # Seeds example_artifacts() into both scopes; publish_global is sandboxed in a dry
     # run. Deletes first because each Test press gets a fresh node_id, so the
-    # per-execution clear never reclaims the previous press's seed.
+    # per-execution clear never reclaims the previous press's seed. Each seed is also
+    # published under any qualified "ns.path::name" the settings select, so a dry run
+    # never falls through to the live catalog.
     if dry_run:
+        aliases_json = json.dumps(_artifact_aliases(settings_values))
         run_node = (
+            f"_SEED_ALIASES = _json.loads({aliases_json!r})\n"
             "_node = _Node()\n"
             '_seed_hook = getattr(_node, "example_artifacts", None)\n'
             "if _seed_hook is not None:\n"
@@ -201,12 +233,13 @@ def generate_kernel_script(
             '        raise TypeError("example_artifacts() must return a dict, got %s"\n'
             "                        % type(_seed_artifacts).__name__)\n"
             "    for _seed_name, _seed_obj in _seed_artifacts.items():\n"
-            "        flowfile_ctx.publish_global(_seed_name, _seed_obj)\n"
-            "        try:\n"
-            "            flowfile_ctx.delete_artifact(_seed_name)\n"
-            "        except KeyError:\n"
-            "            pass\n"
-            "        flowfile_ctx.publish_artifact(_seed_name, _seed_obj)\n"
+            "        for _seed_key in [_seed_name] + _SEED_ALIASES.get(_seed_name, []):\n"
+            "            flowfile_ctx.publish_global(_seed_key, _seed_obj)\n"
+            "            try:\n"
+            "                flowfile_ctx.delete_artifact(_seed_key)\n"
+            "            except KeyError:\n"
+            "                pass\n"
+            "            flowfile_ctx.publish_artifact(_seed_key, _seed_obj)\n"
             "_result = _node.process(*_inputs)\n"
         )
     else:

--- a/flowfile_core/flowfile_core/project/importer.py
+++ b/flowfile_core/flowfile_core/project/importer.py
@@ -474,7 +474,8 @@ def _import_artifacts(root: Path, owner_id: int) -> set[int]:
 
     Upserts by (name, namespace, version) so reloads never bloat versions. The blob isn't restored
     (it lives outside the project) — a fresh row is ``active`` but its data refills when the producing
-    flow re-runs. An artifact whose source flow isn't present is skipped (its FK can't be satisfied)."""
+    flow re-runs. An artifact whose source flow isn't present is skipped (its FK can't be satisfied), and a
+    version deleted locally is left deleted — import must never resurrect a deletion."""
     kept: set[int] = set()
     artifact_entries = _read_yaml(manifest.models_manifest_path(root)).get("models", []) or []
     _assert_within_cap(artifact_entries, _MAX_ARTIFACTS, "models")
@@ -493,6 +494,9 @@ def _import_artifacts(root: Path, owner_id: int) -> set[int]:
             existing = repository.owned_or_none(
                 db, GlobalArtifact, "owner_id", owner_id, name=name, namespace_id=ns_id, version=version
             )
+            if existing is not None and existing.status == "deleted":
+                # A version deleted locally stays deleted; import must not resurrect it.
+                continue
             artifact = existing or GlobalArtifact(name=name, namespace_id=ns_id, version=version, owner_id=owner_id)
             artifact.source_registration_id = src_reg_id
             artifact.serialization_format = entry.get("serialization_format", "pickle")

--- a/flowfile_core/flowfile_core/schemas/artifact_schema.py
+++ b/flowfile_core/flowfile_core/schemas/artifact_schema.py
@@ -146,6 +146,8 @@ class ArtifactListItem(BaseModel):
     created_at: datetime
     tags: list[str] = Field(default_factory=list)
     owner_id: int
+    namespace_path: str | None = Field(None, description="Dotted namespace path, e.g. 'General.models'")
+    version_count: int | None = Field(None, description="Number of active versions of this artifact")
 
     model_config = {"from_attributes": True}
 
@@ -158,12 +160,15 @@ class ArtifactVersionInfo(BaseModel):
     created_at: datetime
     size_bytes: int | None = None
     sha256: str | None = None
+    python_type: str | None = None
+    blob_exists: bool = True
 
 
 class ArtifactWithVersions(ArtifactOut):
     """Artifact with list of all available versions."""
 
     all_versions: list[ArtifactVersionInfo] = Field(default_factory=list)
+    total_versions: int = 0
 
 
 # ==================== Search and Filter Schemas ====================
@@ -189,3 +194,22 @@ class ArtifactDeleteResponse(BaseModel):
     status: str = Field(default="deleted", description="Status of the deletion")
     artifact_id: int = Field(..., description="ID of the deleted artifact")
     versions_deleted: int = Field(default=1, description="Number of versions deleted (>1 if all versions deleted)")
+
+
+# ==================== Retention ====================
+
+
+class ArtifactPruneCandidate(BaseModel):
+    """One version a prune would remove (or removed)."""
+
+    id: int
+    version: int
+    size_bytes: int | None = None
+
+
+class ArtifactPruneResponse(BaseModel):
+    """Result of a prune run (``dry_run=true`` deletes nothing)."""
+
+    would_delete: list[ArtifactPruneCandidate] = Field(default_factory=list)
+    freed_bytes: int = 0
+    deleted: int = 0

--- a/flowfile_core/flowfile_core/schemas/catalog_schema.py
+++ b/flowfile_core/flowfile_core/schemas/catalog_schema.py
@@ -223,6 +223,7 @@ class GlobalArtifactOut(BaseModel):
     created_at: datetime | None = None
     updated_at: datetime | None = None
     blob_exists: bool = True  # False when the backing blob is missing (filesystem backend only)
+    version_count: int = 1  # Active versions of this artifact (the tree lists only the latest)
     access: AccessInfo | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/flowfile_core/tests/flowfile/community_nodes/test_dry_run_ctx_parity.py
+++ b/flowfile_core/tests/flowfile/community_nodes/test_dry_run_ctx_parity.py
@@ -105,3 +105,49 @@ def test_is_dry_run_is_on_both_sides():
     """The signal itself must not be the thing that drifts."""
     assert "is_dry_run" in _kernel_client_api(), "is_dry_run() is missing from the real kernel client"
     assert "is_dry_run" in _fake_methods(), "is_dry_run() is missing from the dry-run fake"
+
+
+class _StripAnnotations(ast.NodeTransformer):
+    """Type hints are the one licensed difference: the child runs unannotated source."""
+
+    def visit_arg(self, node: ast.arg) -> ast.arg:
+        node.annotation = None
+        return self.generic_visit(node)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+        node.returns = None
+        return self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> ast.stmt:
+        if node.value is None:
+            return node
+        return self.generic_visit(ast.Assign(targets=[node.target], value=node.value))
+
+
+def _artifact_aliases_ast(source: str) -> str:
+    for stmt in ast.parse(source).body:
+        if isinstance(stmt, ast.FunctionDef) and stmt.name == "_artifact_aliases":
+            stripped = _StripAnnotations().visit(stmt)
+            stripped.body = [s for s in stripped.body if not (isinstance(s, ast.Expr) and _is_docstring(s))]
+            return ast.dump(ast.fix_missing_locations(stripped))
+    pytest.fail("_artifact_aliases not found")
+
+
+def _is_docstring(stmt: ast.Expr) -> bool:
+    return isinstance(stmt.value, ast.Constant) and isinstance(stmt.value.value, str)
+
+
+def test_artifact_alias_rules_match_on_both_sides():
+    """The dry-run child cannot import core's copy, so the two must be pinned equal.
+
+    Drift means the Test panel and the community-CI dry run disagree about what a
+    qualified ``get_global("catalog.schema::name")`` resolves to.
+    """
+    from flowfile_core.flowfile.user_defined import kernel_codegen
+
+    core = _artifact_aliases_ast(Path(kernel_codegen.__file__).read_text(encoding="utf-8"))
+    child = _artifact_aliases_ast(dry_run_local._RUNNER)
+    assert core == child, (
+        "kernel_codegen._artifact_aliases and dry_run_local's copy diverged; "
+        "change both or the two dry-run paths seed different artifact aliases."
+    )

--- a/flowfile_core/tests/flowfile/community_nodes/test_dry_run_local.py
+++ b/flowfile_core/tests/flowfile/community_nodes/test_dry_run_local.py
@@ -123,6 +123,29 @@ class SeededConsumer(nd.CustomNodeBase):
         return inputs[0].with_columns((pl.col("a") * bundle["coef"]).alias("scaled"))
 '''
 
+_QUALIFIED_SETTINGS_NODE = '''
+import polars as pl
+from flowfile import node_designer as nd
+
+
+class QualifiedConsumer(nd.CustomNodeBase):
+    node_name: str = "Qualified Consumer"
+    environment: str = "kernel"
+    example_inputs: list = [{"a": [1, 2]}]
+    example_settings: dict = {"main": {"model": "General.models::seeded_model", "other": "plain"}}
+
+    def example_artifacts(self) -> dict:
+        return {"seeded_model": {"coef": 3}}
+
+    def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+        bundle = flowfile_ctx.get_global("General.models::seeded_model")
+        if bundle != {"coef": 3}:
+            raise RuntimeError("the qualified settings value was not seeded")
+        if flowfile_ctx.get_global("seeded_model") != {"coef": 3}:
+            raise RuntimeError("the bare name must stay seeded too")
+        return inputs[0].with_columns((pl.col("a") * bundle["coef"]).alias("scaled"))
+'''
+
 _CATALOG_NODE = '''
 import polars as pl
 from flowfile import node_designer as nd
@@ -164,6 +187,12 @@ def test_flow_local_artifact_store_matches_kernel_semantics(tmp_path: Path):
 
 def test_example_artifacts_are_seeded_and_is_dry_run_is_true(tmp_path: Path):
     outcome = _dry_run(tmp_path, _SEEDED_NODE)
+    assert outcome.success, outcome.error
+
+
+def test_qualified_settings_values_are_seeded_as_aliases(tmp_path: Path):
+    """A `catalog.schema::name` selector value must resolve without a live catalog."""
+    outcome = _dry_run(tmp_path, _QUALIFIED_SETTINGS_NODE)
     assert outcome.success, outcome.error
 
 

--- a/flowfile_core/tests/flowfile/node_designer/test_dry_run.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_dry_run.py
@@ -475,12 +475,63 @@ def test_dry_run_kernel_script_seeds_example_artifacts():
     assert "_result = _Node().process(*_inputs)" in production
     assert "_seed_hook" in dry
     # Both scopes: seeding only the global store breaks read_artifact() nodes.
-    assert "flowfile_ctx.publish_global(_seed_name, _seed_obj)" in dry
-    assert "flowfile_ctx.publish_artifact(_seed_name, _seed_obj)" in dry
+    assert "flowfile_ctx.publish_global(_seed_key, _seed_obj)" in dry
+    assert "flowfile_ctx.publish_artifact(_seed_key, _seed_obj)" in dry
     assert "example_artifacts() must return a dict" in dry
     # Delete-then-publish, so an edited hook isn't shadowed by the previous press.
-    assert "flowfile_ctx.delete_artifact(_seed_name)" in dry
+    assert "flowfile_ctx.delete_artifact(_seed_key)" in dry
     assert "except ValueError" not in dry
+
+
+def _seeded_aliases(script: str) -> dict:
+    """The alias table the prologue actually bakes into the dry-run script."""
+    import ast
+    import json
+    import re
+
+    match = re.search(r"_SEED_ALIASES = _json\.loads\((.+)\)\s*$", script, re.M)
+    assert match, "the dry-run prologue does not emit _SEED_ALIASES"
+    return json.loads(ast.literal_eval(match.group(1)))
+
+
+def test_dry_run_prologue_seeds_qualified_artifact_aliases():
+    """A namespace-qualified selector value must resolve inside the sandbox too."""
+    from flowfile_core.flowfile.user_defined.kernel_codegen import generate_kernel_script
+
+    source = (
+        "import polars as pl\n"
+        "from flowfile import node_designer as nd\n\n\n"
+        "class N(nd.CustomNodeBase):\n"
+        '    node_name: str = "N"\n'
+        "\n"
+        "    def example_artifacts(self) -> dict:\n"
+        '        return {"m": {"coef": 2}}\n'
+        "\n"
+        "    def process(self, *inputs):\n"
+        "        return inputs[0]\n"
+    )
+    def _script(settings_values: dict) -> str:
+        return generate_kernel_script(
+            node_source=source,
+            class_name="N",
+            settings_values=settings_values,
+            output_names=["main"],
+            number_of_inputs=1,
+            dry_run=True,
+        )
+
+    dry = _script({"main": {"model": "General.models::m", "other": "plain"}})
+    assert _seeded_aliases(dry) == {"m": ["General.models::m"]}
+    # The seed loop keys on the bare name, so the alias is what makes the
+    # qualified spelling resolve inside the sandbox.
+    assert "for _seed_key in [_seed_name] + _SEED_ALIASES.get(_seed_name, [])" in dry
+
+    # A multi-select contributes every qualified entry it holds.
+    multi = _script({"main": {"models": ["General.models::m", "Other.ns::m", "bare"]}})
+    assert _seeded_aliases(multi) == {"m": ["General.models::m", "Other.ns::m"]}
+
+    # No qualified value ⇒ nothing to alias.
+    assert _seeded_aliases(_script({"main": {"model": "m", "count": 3}})) == {}
 
 
 @pytest.mark.kernel

--- a/flowfile_core/tests/project/test_roundtrip.py
+++ b/flowfile_core/tests/project/test_roundtrip.py
@@ -1039,6 +1039,34 @@ def test_model_round_trips_and_upserts_by_version(tmp_path):
         project_sync.close_project(OWNER)
 
 
+def test_import_does_not_resurrect_a_deleted_model(tmp_path):
+    """A version deleted in the catalog must stay deleted across a project reload."""
+    from flowfile_core.project.importer import import_project
+
+    project_sync.close_project(OWNER)
+    model = f"deleted_mdl_{uuid4().hex[:6]}"
+    flow_uuid, _ = _make_flow(tmp_path, f"deleted_mdl_flow_{uuid4().hex[:6]}")
+    _make_artifact(model, _reg_id(flow_uuid), version=1)
+    root = tmp_path / "project"
+    try:
+        project_sync.init_project(str(root), "Deleted Model Test", OWNER)
+        assert (model, 1) in _models_yaml(root)
+
+        project_sync.close_project(OWNER)
+        with get_db_context() as db:
+            db.query(GlobalArtifact).filter_by(name=model).update({"status": "deleted"})
+            db.commit()
+
+        import_project(root, OWNER)
+        with get_db_context() as db:
+            rows = db.query(GlobalArtifact).filter_by(name=model).all()
+            assert [r.status for r in rows] == ["deleted"]
+    finally:
+        _delete_artifacts(model)
+        _delete_flow(flow_uuid)
+        project_sync.close_project(OWNER)
+
+
 def test_model_skipped_when_source_flow_absent(tmp_path):
     from flowfile_core.project.importer import import_project
 

--- a/flowfile_core/tests/sharing/test_sharing_artifacts.py
+++ b/flowfile_core/tests/sharing/test_sharing_artifacts.py
@@ -1,0 +1,231 @@
+"""Artifact sharing: read filtering, owner-or-manage gates, and grant continuity across versions."""
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from flowfile_core.database import models as db_models
+from flowfile_core.database.connection import get_db_context
+
+
+@pytest.fixture
+def team(users, group_factory):
+    """alice (owner) shares with bob (member)."""
+    return group_factory("artifact-team", users["admin"].id, {users["alice"].id: "owner", users["bob"].id: "member"})
+
+
+@pytest.fixture
+def alice_flow(users, resource_factory):
+    catalog_id = resource_factory(
+        db_models.CatalogNamespace, name="AliceModels", parent_id=None, level=0, owner_id=users["alice"].id
+    )
+    schema_id = resource_factory(
+        db_models.CatalogNamespace, name="alice_models", parent_id=catalog_id, level=1, owner_id=users["alice"].id
+    )
+    return resource_factory(
+        db_models.FlowRegistration,
+        name="alice_model_flow",
+        flow_path="/tmp/alice_model_flow.flowfile",
+        namespace_id=schema_id,
+        owner_id=users["alice"].id,
+    )
+
+
+@pytest.fixture
+def bob_flow(users, resource_factory):
+    """A registration bob owns, in his own namespace."""
+    catalog_id = resource_factory(
+        db_models.CatalogNamespace, name="BobModels", parent_id=None, level=0, owner_id=users["bob"].id
+    )
+    schema_id = resource_factory(
+        db_models.CatalogNamespace, name="bob_models", parent_id=catalog_id, level=1, owner_id=users["bob"].id
+    )
+    return resource_factory(
+        db_models.FlowRegistration,
+        name="bob_model_flow",
+        flow_path="/tmp/bob_model_flow.flowfile",
+        namespace_id=schema_id,
+        owner_id=users["bob"].id,
+    )
+
+
+@pytest.fixture
+def publish_as(client_for, resource_factory):
+    """Publish an artifact as any user; every published name is removed on teardown.
+
+    Depends on ``resource_factory`` for teardown order: artifacts must go before the
+    registrations they point at.
+    """
+    clients: dict[str, object] = {}
+    names: set[str] = set()
+
+    def _publish(user: str, name: str, registration_id: int, payload: bytes = b"model-bytes") -> int:
+        names.add(name)
+        client = clients.setdefault(user, client_for(user))
+        prep = client.post(
+            "/artifacts/prepare-upload",
+            json={
+                "name": name,
+                "source_registration_id": registration_id,
+                "serialization_format": "pickle",
+                "python_type": "builtins.dict",
+            },
+        )
+        assert prep.status_code == 201, prep.text
+        data = prep.json()
+        path = Path(data["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+        fin = client.post(
+            "/artifacts/finalize",
+            json={
+                "artifact_id": data["artifact_id"],
+                "storage_key": data["storage_key"],
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+            },
+        )
+        assert fin.status_code == 200, fin.text
+        return data["artifact_id"]
+
+    yield _publish
+    with get_db_context() as db:
+        for name in names:
+            for row in db.query(db_models.GlobalArtifact).filter_by(name=name).all():
+                db.query(db_models.ResourceGrant).filter_by(
+                    resource_type="global_artifact", resource_id=row.id
+                ).delete()
+                db.delete(row)
+        db.commit()
+
+
+@pytest.fixture
+def published(alice_flow, publish_as):
+    """Publish versions of an artifact as alice."""
+
+    def _publish(name: str, payload: bytes = b"model-bytes") -> int:
+        return publish_as("alice", name, alice_flow, payload=payload)
+
+    return _publish
+
+
+def _grants_for(artifact_id: int) -> list[db_models.ResourceGrant]:
+    with get_db_context() as db:
+        return db.query(db_models.ResourceGrant).filter_by(
+            resource_type="global_artifact", resource_id=artifact_id
+        ).all()
+
+
+def test_artifact_reads_are_private_by_default(users, client_for, published):
+    artifact_id = published("private_model")
+    bob = client_for("bob")
+
+    assert "private_model" not in [a["name"] for a in bob.get("/artifacts/").json()]
+    assert bob.get(f"/artifacts/{artifact_id}").status_code == 404
+    assert bob.get("/artifacts/by-name/private_model").status_code == 404
+    assert client_for("alice").get(f"/artifacts/{artifact_id}").status_code == 200
+
+
+def test_grant_survives_a_new_version(users, client_for, published, team, grant_factory):
+    """A direct artifact share must not be silently revoked by the next publish."""
+    v1 = published("continuity_model")
+    grant_factory("global_artifact", v1, team, permission="use", granted_by=users["alice"].id)
+    bob = client_for("bob")
+    assert bob.get(f"/artifacts/{v1}").status_code == 200
+
+    v2 = published("continuity_model", payload=b"model-bytes-v2")
+
+    assert [g.permission for g in _grants_for(v2)] == ["use"]
+    assert bob.get(f"/artifacts/{v2}").status_code == 200
+    assert bob.get("/artifacts/by-name/continuity_model").json()["id"] == v2
+
+
+def test_version_delete_revokes_only_that_versions_grants(users, client_for, published, team, grant_factory):
+    v1 = published("revoke_model")
+    grant_factory("global_artifact", v1, team, permission="manage", granted_by=users["alice"].id)
+    v2 = published("revoke_model", payload=b"v2")
+    v3 = published("revoke_model", payload=b"v3")
+
+    alice = client_for("alice")
+    assert alice.delete(f"/artifacts/{v1}").status_code == 200
+
+    assert _grants_for(v1) == []
+    assert len(_grants_for(v2)) == 1
+    assert len(_grants_for(v3)) == 1
+
+
+def test_use_grantee_cannot_mutate_versions(users, client_for, published, team, grant_factory):
+    v1 = published("use_only_model")
+    v2 = published("use_only_model", payload=b"v2")
+    for artifact_id in (v1, v2):
+        grant_factory("global_artifact", artifact_id, team, permission="use", granted_by=users["alice"].id)
+
+    bob = client_for("bob")
+    assert bob.delete(f"/artifacts/{v1}").status_code == 403
+    assert bob.post(f"/artifacts/{v1}/promote").status_code == 403
+    assert bob.post("/artifacts/by-name/use_only_model/prune", params={"keep": 1}).status_code == 403
+    assert bob.delete("/artifacts/by-name/use_only_model").status_code == 403
+
+
+def test_manage_grantee_can_promote_and_prune_without_forking_ownership(
+    users, client_for, published, team, grant_factory
+):
+    v1 = published("manage_model")
+    v2 = published("manage_model", payload=b"v2")
+    v3 = published("manage_model", payload=b"v3")
+    for artifact_id in (v1, v2, v3):
+        grant_factory("global_artifact", artifact_id, team, permission="manage", granted_by=users["alice"].id)
+
+    bob = client_for("bob")
+    promoted = bob.post(f"/artifacts/{v1}/promote")
+    assert promoted.status_code == 200, promoted.text
+    assert promoted.json()["owner_id"] == users["alice"].id
+    assert promoted.json()["version"] == 4
+
+    pruned = bob.post("/artifacts/by-name/manage_model/prune", params={"keep": 2, "dry_run": False})
+    assert pruned.status_code == 200, pruned.text
+    assert pruned.json()["deleted"] == 2
+
+
+def test_use_grantee_cannot_delete_another_owners_same_named_artifact(
+    users, client_for, publish_as, alice_flow, bob_flow, team, grant_factory
+):
+    """Owning a same-named artifact must not authorize deleting the one merely shared."""
+    alice_row = publish_as("alice", "churn", alice_flow)
+    grant_factory("global_artifact", alice_row, team, permission="use", granted_by=users["alice"].id)
+    bob_row = publish_as("bob", "churn", bob_flow)
+
+    bob = client_for("bob")
+    assert bob.delete("/artifacts/by-name/churn").status_code == 403
+
+    with get_db_context() as db:
+        assert db.get(db_models.GlobalArtifact, alice_row).status == "active"
+        assert db.get(db_models.GlobalArtifact, bob_row).status == "active"
+
+
+def test_stranger_cannot_see_or_prune(users, client_for, published, alice_flow):
+    v1 = published("hidden_model")
+    v2 = published("hidden_model", payload=b"v2")
+    carol = client_for("carol")
+    with get_db_context() as db:
+        namespace_id = db.get(db_models.FlowRegistration, alice_flow).namespace_id
+
+    # Invisible rather than forbidden: an unshared artifact must not be probeable —
+    # not by bare name, not with an explicit namespace, not by row id.
+    assert carol.post("/artifacts/by-name/hidden_model/prune", params={"keep": 1}).status_code == 404
+    assert (
+        carol.post(
+            "/artifacts/by-name/hidden_model/prune", params={"keep": 1, "namespace_id": namespace_id}
+        ).status_code
+        == 404
+    )
+    assert (
+        carol.post(
+            "/artifacts/by-name/AliceModels.alice_models::hidden_model/prune", params={"keep": 1}
+        ).status_code
+        == 404
+    )
+    assert carol.post(f"/artifacts/{v1}/promote").status_code == 404
+    assert carol.delete(f"/artifacts/{v2}").status_code == 404
+    assert carol.delete("/artifacts/by-name/hidden_model").status_code == 404

--- a/flowfile_core/tests/sharing/test_sharing_artifacts.py
+++ b/flowfile_core/tests/sharing/test_sharing_artifacts.py
@@ -204,6 +204,26 @@ def test_use_grantee_cannot_delete_another_owners_same_named_artifact(
         assert db.get(db_models.GlobalArtifact, bob_row).status == "active"
 
 
+def test_managing_only_the_latest_version_does_not_authorize_pruning_older_rows(
+    users, client_for, published, team, grant_factory
+):
+    """Prune must require manage on every row it deletes, not just the newest one."""
+    v1 = published("prunable_model")
+    v2 = published("prunable_model", payload=b"v2")
+    grant_factory("global_artifact", v1, team, permission="use", granted_by=users["alice"].id)
+    grant_factory("global_artifact", v2, team, permission="manage", granted_by=users["alice"].id)
+
+    bob = client_for("bob")
+    resp = bob.post(
+        "/artifacts/by-name/prunable_model/prune", params={"keep": 1, "dry_run": False}
+    )
+    assert resp.status_code == 403
+
+    with get_db_context() as db:
+        assert db.get(db_models.GlobalArtifact, v1).status == "active"
+        assert db.get(db_models.GlobalArtifact, v2).status == "active"
+
+
 def test_stranger_cannot_see_or_prune(users, client_for, published, alice_flow):
     v1 = published("hidden_model")
     v2 = published("hidden_model", payload=b"v2")

--- a/flowfile_core/tests/test_artifacts.py
+++ b/flowfile_core/tests/test_artifacts.py
@@ -135,6 +135,60 @@ def _create_test_registration(
     return resp.json()["id"]
 
 
+def _publish(
+    name: str,
+    reg_id: int,
+    namespace_id: int | None = None,
+    tags: list[str] | None = None,
+    python_type: str = "builtins.dict",
+    payload: bytes = b"test artifact data",
+) -> dict:
+    """prepare + finalize one version; returns the prepare response."""
+    import hashlib
+
+    prep_resp = client.post(
+        "/artifacts/prepare-upload",
+        json={
+            "name": name,
+            "source_registration_id": reg_id,
+            "serialization_format": "pickle",
+            "namespace_id": namespace_id,
+            "tags": tags or [],
+            "python_type": python_type,
+        },
+    )
+    assert prep_resp.status_code == 201, prep_resp.text
+    prep_data = prep_resp.json()
+
+    staging_path = Path(prep_data["path"])
+    staging_path.parent.mkdir(parents=True, exist_ok=True)
+    staging_path.write_bytes(payload)
+
+    fin_resp = client.post(
+        "/artifacts/finalize",
+        json={
+            "artifact_id": prep_data["artifact_id"],
+            "storage_key": prep_data["storage_key"],
+            "sha256": hashlib.sha256(payload).hexdigest(),
+            "size_bytes": len(payload),
+        },
+    )
+    assert fin_resp.status_code == 200, fin_resp.text
+    return prep_data
+
+
+def _blob_exists(storage_key: str) -> bool:
+    from flowfile_core.artifacts import get_storage_backend
+
+    return get_storage_backend().exists(storage_key)
+
+
+def _internal_headers() -> dict:
+    from flowfile_core.auth.jwt import get_internal_token
+
+    return {"X-Internal-Token": get_internal_token()}
+
+
 # Fixtures
 
 
@@ -628,7 +682,8 @@ class TestRetrieveArtifact:
         # Same name in two namespaces + no namespace_id -> ambiguous.
         resp = client.get("/artifacts/by-name/ns_filtered")
         assert resp.status_code == 409
-        assert "namespace_id" in resp.json()["detail"]
+        assert resp.json()["detail"]["error_code"] == "AMBIGUOUS_ARTIFACT"
+        assert "namespace_id" in resp.json()["detail"]["message"]
 
     def test_get_artifact_by_namespace_name(self, test_namespace):
         """Lookup by namespace *name* resolves to the same artifact as namespace_id."""
@@ -797,6 +852,84 @@ class TestListArtifacts:
         page2_ids = {a["id"] for a in page2}
         assert page1_ids.isdisjoint(page2_ids)
 
+    def test_list_latest_only_collapses_versions(self):
+        """latest_only returns one row per (name, namespace) — the newest version."""
+        for _ in range(3):
+            self._create_active_artifact("collapse_me")
+        self._create_active_artifact("other_one")
+
+        resp = client.get("/artifacts/", params={"latest_only": True})
+        assert resp.status_code == 200
+        data = resp.json()
+        rows = [a for a in data if a["name"] == "collapse_me"]
+        assert len(rows) == 1
+        assert rows[0]["version"] == 3
+        assert rows[0]["version_count"] == 3
+        assert len([a for a in data if a["name"] == "other_one"]) == 1
+
+    def test_list_latest_only_keeps_namespaces_apart(self, test_namespace):
+        """The same name in two namespaces stays two rows, each with its namespace path."""
+        self._create_active_artifact("same_name", namespace_id=test_namespace)
+        self._create_active_artifact("same_name", namespace_id=test_namespace)
+        self._create_active_artifact("same_name")
+
+        resp = client.get("/artifacts/", params={"latest_only": True, "name_contains": "same_name"})
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert len(rows) == 2
+        by_ns = {a["namespace_id"]: a for a in rows}
+        assert set(by_ns) == {test_namespace, None}
+        assert by_ns[test_namespace]["version"] == 2
+        assert by_ns[test_namespace]["version_count"] == 2
+        assert by_ns[test_namespace]["namespace_path"] == "ArtifactTestCatalog.ArtifactTestSchema"
+        assert by_ns[None]["namespace_path"] is None
+        assert by_ns[None]["version_count"] == 1
+
+    def test_list_latest_only_composes_with_filters(self, test_namespace):
+        """latest_only composes with namespace/tag/name/type filters."""
+        self._create_active_artifact("filtered_model", namespace_id=test_namespace, tags=["ml"])
+        self._create_active_artifact("filtered_model", namespace_id=test_namespace, tags=["ml"])
+        self._create_active_artifact("filtered_other", namespace_id=test_namespace, tags=["ops"])
+        self._create_active_artifact("filtered_model")
+
+        resp = client.get(
+            "/artifacts/",
+            params={
+                "latest_only": True,
+                "namespace_id": test_namespace,
+                "tags": ["ml"],
+                "name_contains": "filtered",
+                "python_type_contains": "dict",
+            },
+        )
+        assert resp.status_code == 200
+        rows = resp.json()
+        assert [(a["name"], a["version"]) for a in rows] == [("filtered_model", 2)]
+
+    def test_list_latest_only_pagination_is_disjoint(self):
+        """Pagination counts artifacts, not versions."""
+        for i in range(5):
+            self._create_active_artifact(f"page_art_{i}")
+            self._create_active_artifact(f"page_art_{i}")
+
+        page1 = client.get(
+            "/artifacts/", params={"latest_only": True, "name_contains": "page_art_", "limit": 2, "offset": 0}
+        ).json()
+        page2 = client.get(
+            "/artifacts/", params={"latest_only": True, "name_contains": "page_art_", "limit": 2, "offset": 2}
+        ).json()
+        assert len(page1) == 2 and len(page2) == 2
+        assert {a["name"] for a in page1}.isdisjoint({a["name"] for a in page2})
+        assert all(a["version"] == 2 for a in page1 + page2)
+
+    def test_list_without_latest_only_is_unchanged(self):
+        """The default still returns one item per version row."""
+        self._create_active_artifact("all_rows")
+        self._create_active_artifact("all_rows")
+
+        rows = client.get("/artifacts/", params={"name_contains": "all_rows"}).json()
+        assert sorted(a["version"] for a in rows) == [1, 2]
+
     def test_list_artifact_names(self):
         """Should list unique artifact names."""
         self._create_active_artifact("unique_name_1")
@@ -809,6 +942,52 @@ class TestListArtifacts:
         assert "unique_name_1" in names
         assert "unique_name_2" in names
         assert len(names) == len(set(names))
+
+    def test_namespace_path_survives_a_dangling_parent(self, test_namespace):
+        """SQLite does not enforce FKs, so the parent walk must not loop on a missing row."""
+        with get_db_context() as db:
+            ns = db.get(CatalogNamespace, test_namespace)
+            ns.parent_id = 999_999
+            db.commit()
+
+        self._create_active_artifact("orphan_ns", namespace_id=test_namespace)
+
+        resp = client.get("/artifacts/", params={"name_contains": "orphan_ns"})
+        assert resp.status_code == 200
+        assert resp.json()[0]["namespace_path"] == "ArtifactTestSchema"
+
+    def test_tree_version_count_falls_back_to_the_group_size(self, test_namespace):
+        """A failed publish keeps its row count; only active artifacts count actives."""
+        from flowfile_core.catalog.repository import SQLAlchemyCatalogRepository
+        from flowfile_core.catalog.services.namespaces import bulk_enrich_artifacts
+
+        self._create_active_artifact("healthy", namespace_id=test_namespace)
+        self._create_active_artifact("healthy", namespace_id=test_namespace)
+        with get_db_context() as db:
+            for version in (1, 2, 3):
+                db.add(
+                    GlobalArtifact(
+                        name="failed_publish",
+                        namespace_id=test_namespace,
+                        version=version,
+                        status="failed",
+                        owner_id=_get_local_user_id(),
+                        source_registration_id=self._reg_id,
+                        serialization_format="pickle",
+                    )
+                )
+            db.commit()
+
+        with get_db_context() as db:
+            repo = SQLAlchemyCatalogRepository(db)
+            enriched = bulk_enrich_artifacts(
+                repo.list_artifacts_for_namespace(test_namespace),
+                version_counts=repo.artifact_version_counts_for_namespace(test_namespace),
+            )
+
+        counts = {a.name: a.version_count for a in enriched}
+        assert counts["healthy"] == 2
+        assert counts["failed_publish"] == 3
 
 
 # Deletion Tests
@@ -853,8 +1032,9 @@ class TestDeleteArtifact:
         return prep_data["artifact_id"]
 
     def test_delete_artifact_by_id(self):
-        """Should delete specific artifact version by ID."""
+        """Should delete a specific (non-latest) artifact version by ID."""
         artifact_id = self._create_active_artifact("delete_by_id")
+        self._create_active_artifact("delete_by_id")
 
         resp = client.delete(f"/artifacts/{artifact_id}")
         assert resp.status_code == 200
@@ -947,9 +1127,10 @@ class TestFlowDeletionWithArtifacts:
         """Deleting a flow should succeed after all its artifacts are deleted."""
         _cleanup_registrations()
         reg_id = _create_test_registration(name="ArtifactTestFlowAllow")
-        artifact_id = self._create_active_artifact("deletable_artifact", reg_id)
+        self._create_active_artifact("deletable_artifact", reg_id)
 
-        client.delete(f"/artifacts/{artifact_id}")
+        # The only version of an artifact is removed by name, not per-version.
+        assert client.delete("/artifacts/by-name/deletable_artifact").status_code == 200
 
         resp = client.delete(f"/catalog/flows/{reg_id}")
         assert resp.status_code == 204
@@ -1083,3 +1264,468 @@ class TestEdgeCases:
         """Should reject negative offset."""
         resp = client.get("/artifacts/", params={"offset": -1})
         assert resp.status_code == 422
+
+
+# Qualified references
+
+
+class TestQualifiedReference:
+    """`catalog.schema::name` references on every by-name route."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_registration_with_namespace):
+        self._reg_id, self._ns_id = test_registration_with_namespace
+        self._plain_reg_id = _create_test_registration(name="ArtifactTestFlowPlain")
+        self._path = "ArtifactTestCatalog.ArtifactTestSchema"
+
+    def test_qualified_reference_resolves(self):
+        _publish("qual_model", self._reg_id, namespace_id=self._ns_id)
+
+        resp = client.get(f"/artifacts/by-name/{self._path}::qual_model")
+        assert resp.status_code == 200
+        assert resp.json()["namespace_id"] == self._ns_id
+
+    def test_qualified_reference_disambiguates_a_collision(self):
+        _publish("collide", self._reg_id, namespace_id=self._ns_id)
+        _publish("collide", self._plain_reg_id)
+
+        # Bare name still 409s (unchanged contract), in the router's one 409 shape ...
+        collision = client.get("/artifacts/by-name/collide")
+        assert collision.status_code == 409
+        assert collision.json()["detail"]["error_code"] == "AMBIGUOUS_ARTIFACT"
+        assert "collide" in collision.json()["detail"]["message"]
+        # ... while the qualified reference resolves.
+        resp = client.get(f"/artifacts/by-name/{self._path}::collide")
+        assert resp.status_code == 200
+        assert resp.json()["namespace_id"] == self._ns_id
+
+    def test_versions_and_delete_accept_the_same_reference(self):
+        _publish("qual_versions", self._reg_id, namespace_id=self._ns_id)
+        _publish("qual_versions", self._reg_id, namespace_id=self._ns_id)
+        _publish("qual_versions", self._plain_reg_id)
+
+        resp = client.get(f"/artifacts/by-name/{self._path}::qual_versions/versions")
+        assert resp.status_code == 200
+        assert resp.json()["total_versions"] == 2
+
+        resp = client.delete(f"/artifacts/by-name/{self._path}::qual_versions")
+        assert resp.status_code == 200
+        assert resp.json()["versions_deleted"] == 2
+        # The other namespace's copy survives, and is now unambiguous.
+        assert client.get("/artifacts/by-name/qual_versions").json()["namespace_id"] is None
+
+    def test_duplicate_schema_name_resolves_by_path(self):
+        """A schema name reused under another catalog is ambiguous by name, not by path."""
+        cat_b = client.post("/catalog/namespaces", json={"name": "ArtifactTestCatalogB"})
+        assert cat_b.status_code == 201, cat_b.text
+        schema_b = client.post(
+            "/catalog/namespaces",
+            json={"name": "ArtifactTestSchema", "parent_id": cat_b.json()["id"]},
+        )
+        assert schema_b.status_code == 201, schema_b.text
+        ns_b = schema_b.json()["id"]
+
+        reg_b = _create_test_registration(namespace_id=ns_b, name="ArtifactTestFlowB")
+        _publish("dup_schema", self._reg_id, namespace_id=self._ns_id)
+        _publish("dup_schema", reg_b, namespace_id=ns_b)
+
+        # The flat namespace-name lookup cannot disambiguate...
+        flat = client.get("/artifacts/by-name/dup_schema", params={"namespace": "ArtifactTestSchema"})
+        assert flat.status_code == 409
+        # ...the path form can.
+        resp = client.get("/artifacts/by-name/ArtifactTestCatalogB.ArtifactTestSchema::dup_schema")
+        assert resp.status_code == 200
+        assert resp.json()["namespace_id"] == ns_b
+
+    def test_unknown_namespace_path_falls_back_to_an_unambiguous_name(self):
+        """A renamed catalog must not break an already-saved qualified value."""
+        _publish("renamed_ns", self._reg_id, namespace_id=self._ns_id)
+
+        resp = client.get("/artifacts/by-name/Gone.Missing::renamed_ns")
+        assert resp.status_code == 200
+        assert resp.json()["namespace_id"] == self._ns_id
+
+    def test_unknown_namespace_path_with_ambiguous_name_is_404(self):
+        _publish("renamed_dup", self._reg_id, namespace_id=self._ns_id)
+        _publish("renamed_dup", self._plain_reg_id)
+
+        assert client.get("/artifacts/by-name/Gone.Missing::renamed_dup").status_code == 404
+
+    def test_reference_splits_on_the_last_separator(self):
+        """Splitting on the first separator would look for a name of 'B::target'."""
+        _publish("target", self._reg_id, namespace_id=self._ns_id)
+
+        resp = client.get("/artifacts/by-name/A::B::target")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "target"
+
+    def test_prepare_upload_rejects_separator_in_name(self):
+        resp = client.post(
+            "/artifacts/prepare-upload",
+            json={
+                "name": "General.models::bad",
+                "source_registration_id": self._reg_id,
+                "serialization_format": "pickle",
+            },
+        )
+        assert resp.status_code == 422
+
+
+# Per-version management
+
+
+class TestDeleteArtifactVersion:
+    """Per-version delete guards and blast radius."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_registration):
+        self._reg_id = test_registration
+
+    def _five_versions(self, name: str = "five") -> list[dict]:
+        return [_publish(name, self._reg_id, payload=f"payload-{i}".encode()) for i in range(5)]
+
+    def test_delete_middle_version_leaves_siblings(self):
+        versions = self._five_versions()
+        target = versions[2]
+
+        resp = client.delete(f"/artifacts/{target['artifact_id']}")
+        assert resp.status_code == 200
+
+        with get_db_context() as db:
+            rows = db.query(GlobalArtifact).filter_by(name="five").all()
+            statuses = {r.version: r.status for r in rows}
+        assert statuses[3] == "deleted"
+        assert [statuses[v] for v in (1, 2, 4, 5)] == ["active"] * 4
+        assert not _blob_exists(target["storage_key"])
+        assert all(_blob_exists(v["storage_key"]) for v in versions if v is not target)
+
+    def test_delete_version_drops_its_grants(self):
+        from flowfile_core.database.models import ResourceGrant
+
+        versions = self._five_versions("granted")
+        target_id = versions[1]["artifact_id"]
+        keeper_id = versions[0]["artifact_id"]
+        with get_db_context() as db:
+            for resource_id in (target_id, keeper_id):
+                db.add(
+                    ResourceGrant(
+                        resource_type="global_artifact",
+                        resource_id=resource_id,
+                        group_id=1,
+                        permission="use",
+                        granted_by=1,
+                    )
+                )
+            db.commit()
+
+        assert client.delete(f"/artifacts/{target_id}").status_code == 200
+
+        with get_db_context() as db:
+            remaining = {
+                g.resource_id
+                for g in db.query(ResourceGrant).filter_by(resource_type="global_artifact").all()
+            }
+            db.query(ResourceGrant).filter_by(resource_type="global_artifact").delete()
+            db.commit()
+        assert target_id not in remaining
+        assert keeper_id in remaining
+
+    def test_delete_latest_version_is_refused_without_force(self):
+        versions = self._five_versions("latest_guard")
+        latest_id = versions[-1]["artifact_id"]
+
+        resp = client.delete(f"/artifacts/{latest_id}")
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["error_code"] == "CANNOT_DELETE_LATEST"
+
+        resp = client.delete(f"/artifacts/{latest_id}", params={"force": True})
+        assert resp.status_code == 200
+        assert client.get("/artifacts/by-name/latest_guard").json()["version"] == 4
+
+    def test_delete_last_remaining_version_is_refused(self):
+        only = _publish("solo", self._reg_id)
+
+        resp = client.delete(f"/artifacts/{only['artifact_id']}")
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["error_code"] == "CANNOT_DELETE_LAST_VERSION"
+        assert "by-name" in resp.json()["detail"]["message"]
+
+        # force only overrides the latest-version guard, never the last-version one.
+        resp = client.delete(f"/artifacts/{only['artifact_id']}", params={"force": True})
+        assert resp.status_code == 409
+        assert resp.json()["detail"]["error_code"] == "CANNOT_DELETE_LAST_VERSION"
+        with get_db_context() as db:
+            assert db.get(GlobalArtifact, only["artifact_id"]).status == "active"
+
+    def test_internal_service_principal_bypasses_the_guards(self):
+        """Released kernel images delete 'the latest version' by design."""
+        only = _publish("kernel_delete", self._reg_id)
+
+        resp = client.delete(f"/artifacts/{only['artifact_id']}", headers=_internal_headers())
+        assert resp.status_code == 200
+        with get_db_context() as db:
+            assert db.get(GlobalArtifact, only["artifact_id"]).status == "deleted"
+
+    def test_republish_after_delete_does_not_reuse_the_version_number(self):
+        versions = self._five_versions("reuse")
+        assert client.delete(f"/artifacts/{versions[2]['artifact_id']}").status_code == 200
+
+        republished = _publish("reuse", self._reg_id)
+        with get_db_context() as db:
+            assert db.get(GlobalArtifact, republished["artifact_id"]).version == 6
+
+
+class TestPromoteArtifactVersion:
+    """Copy-forward restore."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_registration_with_namespace):
+        self._reg_id, self._ns_id = test_registration_with_namespace
+
+    def test_promote_creates_a_new_latest_from_an_old_version(self):
+        v1 = _publish("promote_me", self._reg_id, namespace_id=self._ns_id, payload=b"v1-bytes")
+        _publish("promote_me", self._reg_id, namespace_id=self._ns_id, payload=b"v2-bytes")
+        _publish("promote_me", self._reg_id, namespace_id=self._ns_id, payload=b"v3-bytes")
+
+        resp = client.post(f"/artifacts/{v1['artifact_id']}/promote")
+        assert resp.status_code == 200
+        promoted = resp.json()
+        assert promoted["version"] == 4
+        assert promoted["status"] == "active"
+        assert promoted["storage_key"] != v1["storage_key"]
+        assert _blob_exists(promoted["storage_key"])
+
+        with get_db_context() as db:
+            source = db.get(GlobalArtifact, v1["artifact_id"])
+            assert source.status == "active" and source.version == 1
+            assert promoted["sha256"] == source.sha256
+            assert promoted["owner_id"] == source.owner_id
+            assert promoted["namespace_id"] == source.namespace_id
+
+        latest = client.get("/artifacts/by-name/promote_me", params={"namespace_id": self._ns_id}).json()
+        assert latest["id"] == promoted["id"]
+
+    def test_promote_keeps_the_source_namespace(self):
+        v1 = _publish("promote_ns", self._reg_id, namespace_id=self._ns_id)
+        _publish("promote_ns", self._reg_id, namespace_id=self._ns_id)
+
+        promoted = client.post(f"/artifacts/{v1['artifact_id']}/promote").json()
+        assert promoted["namespace_id"] == self._ns_id
+
+    def test_promote_missing_or_deleted_version_is_404(self):
+        v1 = _publish("promote_gone", self._reg_id, namespace_id=self._ns_id)
+        _publish("promote_gone", self._reg_id, namespace_id=self._ns_id)
+        assert client.delete(f"/artifacts/{v1['artifact_id']}").status_code == 200
+
+        assert client.post(f"/artifacts/{v1['artifact_id']}/promote").status_code == 404
+        assert client.post("/artifacts/999999/promote").status_code == 404
+
+    def test_promote_with_a_missing_blob_is_404(self):
+        """The storage copy is what discovers the gone blob (no pre-flight probe)."""
+        from flowfile_core.artifacts import get_storage_backend
+
+        v1 = _publish("promote_noblob", self._reg_id, namespace_id=self._ns_id)
+        _publish("promote_noblob", self._reg_id, namespace_id=self._ns_id)
+        get_storage_backend().delete(v1["storage_key"])
+
+        assert client.post(f"/artifacts/{v1['artifact_id']}/promote").status_code == 404
+        with get_db_context() as db:
+            assert db.query(GlobalArtifact).filter_by(name="promote_noblob").count() == 2
+
+    def _service(self, db):
+        from flowfile_core.artifacts import get_storage_backend
+        from flowfile_core.artifacts.service import ArtifactService
+
+        return ArtifactService(db, get_storage_backend())
+
+    def test_promote_retries_a_lost_version_race(self):
+        """A concurrent publish taking the version number must not surface as a 500."""
+        from sqlalchemy.exc import IntegrityError
+
+        v1 = _publish("promote_race", self._reg_id, namespace_id=self._ns_id)
+        _publish("promote_race", self._reg_id, namespace_id=self._ns_id)
+
+        with get_db_context() as db:
+            service = self._service(db)
+            real_flush = db.flush
+            attempts = []
+
+            def flaky_flush(*args, **kwargs):
+                attempts.append(1)
+                if len(attempts) == 1:
+                    raise IntegrityError("INSERT", {}, Exception("UNIQUE constraint failed"))
+                return real_flush(*args, **kwargs)
+
+            db.flush = flaky_flush
+            promoted = service.promote_version(v1["artifact_id"])
+
+        assert len(attempts) >= 2, "the lost race was not retried"
+        assert promoted.version == 3
+        assert _blob_exists(promoted.storage_key)
+
+    def test_promote_cleans_up_its_blob_when_every_attempt_conflicts(self, monkeypatch):
+        from sqlalchemy.exc import IntegrityError
+
+        from flowfile_core.artifacts.exceptions import ArtifactUploadError
+
+        v1 = _publish("promote_race_lost", self._reg_id, namespace_id=self._ns_id)
+        _publish("promote_race_lost", self._reg_id, namespace_id=self._ns_id)
+
+        with get_db_context() as db:
+            service = self._service(db)
+            copied: list[str] = []
+            real_copy = service.storage.copy
+
+            def spy_copy(src_key, dst_key):
+                copied.append(dst_key)
+                return real_copy(src_key, dst_key)
+
+            monkeypatch.setattr(service.storage, "copy", spy_copy)
+            db.commit = lambda *a, **k: (_ for _ in ()).throw(
+                IntegrityError("INSERT", {}, Exception("UNIQUE constraint failed"))
+            )
+            with pytest.raises(ArtifactUploadError):
+                service.promote_version(v1["artifact_id"], _max_retries=2)
+
+        assert len(copied) == 2
+        assert not any(_blob_exists(key) for key in copied)
+
+
+class TestPruneVersions:
+    """Retention: keep the newest N, never the current latest."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_registration):
+        self._reg_id = test_registration
+
+    def _versions(self, name: str, count: int) -> list[dict]:
+        return [_publish(name, self._reg_id, payload=f"prune-{i}".encode()) for i in range(count)]
+
+    def test_dry_run_reports_without_deleting(self):
+        self._versions("prune_dry", 8)
+
+        resp = client.post("/artifacts/by-name/prune_dry/prune", params={"keep": 5, "dry_run": True})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["deleted"] == 0
+        assert [c["version"] for c in data["would_delete"]] == [3, 2, 1]
+        assert data["freed_bytes"] == sum(c["size_bytes"] for c in data["would_delete"])
+
+        with get_db_context() as db:
+            assert db.query(GlobalArtifact).filter_by(name="prune_dry", status="active").count() == 8
+
+    def test_prune_keeps_the_newest_versions_including_latest(self):
+        versions = self._versions("prune_real", 8)
+
+        resp = client.post("/artifacts/by-name/prune_real/prune", params={"keep": 5, "dry_run": False})
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == 3
+
+        with get_db_context() as db:
+            active = sorted(
+                v.version for v in db.query(GlobalArtifact).filter_by(name="prune_real", status="active").all()
+            )
+        assert active == [4, 5, 6, 7, 8]
+        assert not _blob_exists(versions[0]["storage_key"])
+        assert _blob_exists(versions[-1]["storage_key"])
+
+    def test_prune_with_keep_above_version_count_is_a_no_op(self):
+        self._versions("prune_noop", 3)
+
+        resp = client.post("/artifacts/by-name/prune_noop/prune", params={"keep": 10, "dry_run": False})
+        assert resp.status_code == 200
+        assert resp.json() == {"would_delete": [], "freed_bytes": 0, "deleted": 0}
+
+    def test_prune_unknown_artifact_is_404(self):
+        assert client.post("/artifacts/by-name/never_published/prune").status_code == 404
+
+
+class TestArtifactVersionsPagination:
+    """Server-side pagination of the versions endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_registration):
+        self._reg_id = test_registration
+        for i in range(5):
+            self._last = _publish("paged", self._reg_id, payload=f"paged-{i}".encode())
+
+    def test_pages_are_disjoint_and_ordered(self):
+        page1 = client.get("/artifacts/by-name/paged/versions", params={"limit": 2, "offset": 0}).json()
+        page2 = client.get("/artifacts/by-name/paged/versions", params={"limit": 2, "offset": 2}).json()
+
+        assert page1["total_versions"] == 5 and page2["total_versions"] == 5
+        assert [v["version"] for v in page1["all_versions"]] == [5, 4]
+        assert [v["version"] for v in page2["all_versions"]] == [3, 2]
+
+    def test_version_rows_carry_type_and_blob_state(self):
+        from flowfile_core.artifacts import get_storage_backend
+
+        get_storage_backend().delete(self._last["storage_key"])
+        data = client.get("/artifacts/by-name/paged/versions", params={"limit": 2}).json()
+        newest = data["all_versions"][0]
+        assert newest["python_type"] == "builtins.dict"
+        assert newest["blob_exists"] is False
+        assert data["all_versions"][1]["blob_exists"] is True
+
+    def test_default_returns_every_version(self):
+        data = client.get("/artifacts/by-name/paged/versions").json()
+        assert len(data["all_versions"]) == 5
+        assert data["total_versions"] == 5
+
+
+class TestArtifactAuthz:
+    """Every artifact endpoint authenticates; download_source is not public."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_registration):
+        self._reg_id = test_registration
+
+    def test_reads_and_finalize_require_authentication(self):
+        published = _publish("authz_model", self._reg_id)
+        anonymous = TestClient(main.app)
+
+        for path in (
+            "/artifacts/",
+            "/artifacts/names",
+            "/artifacts/by-name/authz_model",
+            "/artifacts/by-name/authz_model/versions",
+            f"/artifacts/{published['artifact_id']}",
+        ):
+            assert anonymous.get(path).status_code == 401, path
+
+        resp = anonymous.post(
+            "/artifacts/finalize",
+            json={
+                "artifact_id": published["artifact_id"],
+                "storage_key": published["storage_key"],
+                "sha256": "deadbeef",
+                "size_bytes": 1,
+            },
+        )
+        assert resp.status_code == 401
+        anonymous.close()
+
+    def test_mutations_require_authentication(self):
+        """Promote / prune / per-version delete must never become anonymous."""
+        published = _publish("authz_mutations", self._reg_id)
+        _publish("authz_mutations", self._reg_id, payload=b"v2")
+        artifact_id = published["artifact_id"]
+        anonymous = TestClient(main.app)
+
+        assert anonymous.post(f"/artifacts/{artifact_id}/promote").status_code == 401
+        assert anonymous.post("/artifacts/by-name/authz_mutations/prune").status_code == 401
+        assert anonymous.delete(f"/artifacts/{artifact_id}").status_code == 401
+        assert anonymous.delete("/artifacts/by-name/authz_mutations").status_code == 401
+
+        with get_db_context() as db:
+            assert db.query(GlobalArtifact).filter_by(name="authz_mutations", status="active").count() == 2
+        anonymous.close()
+
+    def test_internal_service_principal_can_read(self):
+        _publish("authz_kernel", self._reg_id)
+        kernel = TestClient(main.app)
+
+        resp = kernel.get("/artifacts/by-name/authz_kernel", headers=_internal_headers())
+        assert resp.status_code == 200
+        assert resp.json()["download_source"] is not None
+        kernel.close()

--- a/flowfile_frontend/src/renderer/app/api/catalog.api.ts
+++ b/flowfile_frontend/src/renderer/app/api/catalog.api.ts
@@ -3,6 +3,8 @@ import axios from "../services/axios.config";
 import type { AxiosRequestConfig } from "axios";
 import type {
   ActiveFlowRun,
+  ArtifactPruneResult,
+  ArtifactWithVersions,
   CatalogNamespace,
   CatalogStats,
   CatalogTable,
@@ -32,6 +34,7 @@ import type {
   OptimizeTableRequest,
   OptimizeTableResponse,
   PaginatedFlowRuns,
+  PromotedArtifactVersion,
   QueryVirtualTableCreate,
   SchedulerStatus,
   SqlQueryResult,
@@ -46,6 +49,12 @@ import type {
   VisualizationUpdatePayload,
   VizSourceDescriptor,
 } from "../types";
+
+// A namespace-qualified artifact ref ("catalog.schema::name") already carries its
+// namespace, so namespace_id is only sent alongside a bare name.
+function artifactRefParams(ref: string, namespaceId: number | null): Record<string, any> {
+  return !ref.includes("::") && namespaceId !== null ? { namespace_id: namespaceId } : {};
+}
 
 export class CatalogApi {
   // ====== Namespaces ======
@@ -206,6 +215,56 @@ export class CatalogApi {
   static async getFlowArtifacts(registrationId: number): Promise<GlobalArtifact[]> {
     const response = await axios.get<GlobalArtifact[]>(
       `/catalog/flows/${registrationId}/artifacts`,
+    );
+    return response.data;
+  }
+
+  /** One artifact row by id — resolves links carrying a non-latest version's id. */
+  static async getArtifactById(
+    artifactId: number,
+  ): Promise<Pick<GlobalArtifact, "id" | "name" | "namespace_id">> {
+    const response = await axios.get<Pick<GlobalArtifact, "id" | "name" | "namespace_id">>(
+      `/artifacts/${artifactId}`,
+    );
+    return response.data;
+  }
+
+  /** One page of a model's version history, newest first. */
+  static async getArtifactVersions(
+    ref: string,
+    namespaceId: number | null,
+    limit = 25,
+    offset = 0,
+  ): Promise<ArtifactWithVersions> {
+    const response = await axios.get<ArtifactWithVersions>(
+      `/artifacts/by-name/${encodeURIComponent(ref)}/versions`,
+      { params: { limit, offset, ...artifactRefParams(ref, namespaceId) } },
+    );
+    return response.data;
+  }
+
+  /** Delete one version row. `force` overrides the latest-version guard. */
+  static async deleteArtifactVersion(artifactId: number, force = false): Promise<void> {
+    await axios.delete(`/artifacts/${artifactId}`, { params: { force } });
+  }
+
+  /** Copy an older version forward so it becomes the new latest version. */
+  static async promoteArtifactVersion(artifactId: number): Promise<PromotedArtifactVersion> {
+    const response = await axios.post<PromotedArtifactVersion>(`/artifacts/${artifactId}/promote`);
+    return response.data;
+  }
+
+  /** Keep the newest `keep` versions and drop the rest. `dryRun` deletes nothing. */
+  static async pruneArtifactVersions(
+    ref: string,
+    namespaceId: number | null,
+    keep: number,
+    dryRun: boolean,
+  ): Promise<ArtifactPruneResult> {
+    const response = await axios.post<ArtifactPruneResult>(
+      `/artifacts/by-name/${encodeURIComponent(ref)}/prune`,
+      null,
+      { params: { keep, dry_run: dryRun, ...artifactRefParams(ref, namespaceId) } },
     );
     return response.data;
   }

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/applyModel/ApplyModel.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/applyModel/ApplyModel.vue
@@ -93,11 +93,11 @@
         </el-row>
 
         <el-row v-if="versionOptions.length > 1" class="setting-row">
-          <el-col :span="10" class="grid-content">Version</el-col>
+          <el-col :span="10" class="grid-content">Pin version</el-col>
           <el-col :span="14" class="grid-content">
             <el-select
               v-model="versionSelection"
-              placeholder="Latest"
+              placeholder="Latest (default)"
               clearable
               @change="onVersionSelected"
             >

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/CustomNode.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/CustomNode.vue
@@ -177,7 +177,12 @@ import { useKernelMatch } from "@/composables/useKernelMatch";
 import { CustomNodeSchema } from "./interface";
 import type { ArtifactOption, GlobalArtifactOption } from "./interface";
 import { getCustomNodeSchema, CustomNodeSchemaError } from "./interface";
-import { initializeFormData, schemaWantsGlobalArtifacts } from "./formInit";
+import {
+  coerceLegacyArtifactValues,
+  initializeFormData,
+  schemaWantsGlobalArtifacts,
+} from "./formInit";
+import { buildArtifactOptions } from "./components/artifactFilter";
 import type { CustomNodeFormData } from "./formInit";
 import { useNodeStore } from "../../../../../stores/column-store";
 import { NodeUserDefined } from "../../../baseNode/nodeInput";
@@ -357,13 +362,16 @@ async function fetchAvailableArtifacts(nodeId: number, kernelId: string | null) 
 // Trailing slash: /artifacts/ is the router root; a missing slash 307-drops the body in Docker.
 async function fetchGlobalArtifacts() {
   try {
-    const response = await axios.get("/artifacts/", { params: { limit: 500 } });
+    const response = await axios.get("/artifacts/", {
+      params: { latest_only: true, limit: 500 },
+    });
     const raw = response.data;
     const items: any[] = Array.isArray(raw) ? raw : (raw?.artifacts ?? raw?.items ?? []);
     globalArtifacts.value = items.map((a) => ({
       name: a.name,
       python_type: a.python_type ?? null,
       namespace_id: a.namespace_id ?? null,
+      namespace_path: a.namespace_path ?? null,
       version: a.version,
     }));
   } catch {
@@ -512,6 +520,16 @@ async function hydrateArtifacts(nodeId: number, kernelId: string | null, seq: nu
         ? fetchGlobalArtifacts()
         : Promise.resolve(),
     ]);
+    if (seq === loadSeq && schema.value && formData.value) {
+      coerceLegacyArtifactValues(schema.value, formData.value, (marker) =>
+        buildArtifactOptions(
+          marker.scope,
+          artifactOptions.value,
+          globalArtifacts.value,
+          marker.type_filter,
+        ),
+      );
+    }
   } finally {
     // The flag is owned by the latest artifact request (kernel token + load).
     if (seq === loadSeq && lastArtifactsKernelId.value === kernelId) {

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/MultiSelect.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/MultiSelect.vue
@@ -14,9 +14,9 @@
     >
       <el-option
         v-for="item in options"
-        :key="Array.isArray(item) ? item[0] : item"
-        :label="Array.isArray(item) ? item[1] : item"
-        :value="Array.isArray(item) ? item[0] : item"
+        :key="optionKey(item)"
+        :label="optionLabel(item)"
+        :value="optionValue(item)"
       />
     </el-select>
   </div>
@@ -25,7 +25,13 @@
 <script setup lang="ts">
 import { computed, PropType } from "vue";
 import type { ArtifactOption, GlobalArtifactOption, MultiSelectComponent } from "../interface";
-import { buildArtifactOptions } from "./artifactFilter";
+import {
+  buildArtifactOptions,
+  optionKey,
+  optionLabel,
+  optionValue,
+  type SelectOptionItem,
+} from "./artifactFilter";
 
 const props = defineProps({
   schema: {
@@ -56,8 +62,8 @@ const props = defineProps({
 
 defineEmits(["update:modelValue"]);
 
-// Value is always the bare artifact name; scope decides source and label.
-const options = computed(() => {
+// Artifact values are bare names or namespace-qualified refs; scope decides the source.
+const options = computed((): SelectOptionItem[] => {
   const opts = props.schema.options;
   if (Array.isArray(opts)) {
     return opts;

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/SingleSelect.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/SingleSelect.vue
@@ -13,9 +13,9 @@
     >
       <el-option
         v-for="item in options"
-        :key="Array.isArray(item) ? item[0] : item"
-        :label="Array.isArray(item) ? item[1] : item"
-        :value="Array.isArray(item) ? item[0] : item"
+        :key="optionKey(item)"
+        :label="optionLabel(item)"
+        :value="optionValue(item)"
       />
     </el-select>
   </div>
@@ -24,7 +24,13 @@
 <script setup lang="ts">
 import { computed, PropType } from "vue";
 import type { ArtifactOption, GlobalArtifactOption, SingleSelectComponent } from "../interface";
-import { buildArtifactOptions } from "./artifactFilter";
+import {
+  buildArtifactOptions,
+  optionKey,
+  optionLabel,
+  optionValue,
+  type SelectOptionItem,
+} from "./artifactFilter";
 
 const props = defineProps({
   schema: {
@@ -55,8 +61,8 @@ const props = defineProps({
 
 defineEmits(["update:modelValue"]);
 
-// Value is always the bare artifact name; scope decides source and label.
-const options = computed(() => {
+// Artifact values are bare names or namespace-qualified refs; scope decides the source.
+const options = computed((): SelectOptionItem[] => {
   const opts = props.schema.options;
   if (Array.isArray(opts)) {
     return opts;

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/artifactFilter.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/artifactFilter.test.ts
@@ -62,8 +62,8 @@ describe("buildArtifactOptions", () => {
 
   it("routes to the upstream list for scope 'upstream' (and undefined default)", () => {
     const expected = [
-      ["model", "model (Booster)"],
-      ["scaler", "scaler (StandardScaler)"],
+      { value: "model", label: "model (Booster)", key: "model" },
+      { value: "scaler", label: "scaler (StandardScaler)", key: "scaler" },
     ];
     expect(buildArtifactOptions("upstream", upstream, global)).toEqual(expected);
     expect(buildArtifactOptions(undefined, upstream, global)).toEqual(expected);
@@ -71,18 +71,18 @@ describe("buildArtifactOptions", () => {
 
   it("routes to the global list for scope 'global'", () => {
     expect(buildArtifactOptions("global", upstream, global)).toEqual([
-      ["model", "model (v3 · Booster)"],
-      ["encoder", "encoder (v1 · OneHotEncoder)"],
+      { value: "model", label: "model (Booster)", key: "::model", namespaceId: null },
+      { value: "encoder", label: "encoder (OneHotEncoder)", key: "::encoder", namespaceId: null },
     ]);
   });
 
   it("scope 'all' dedupes by name, upstream entry wins", () => {
     // "model" exists on both sides; the upstream entry + label survives, the
     // global one is dropped. Non-colliding "encoder" is appended.
-    expect(buildArtifactOptions("all", upstream, global)).toEqual([
-      ["model", "model (Booster)"],
-      ["scaler", "scaler (StandardScaler)"],
-      ["encoder", "encoder (v1 · OneHotEncoder)"],
+    expect(buildArtifactOptions("all", upstream, global).map((o) => o.value)).toEqual([
+      "model",
+      "scaler",
+      "encoder",
     ]);
   });
 
@@ -96,7 +96,7 @@ describe("buildArtifactOptions", () => {
       { name: "d", python_type: "sklearn.Foo", version: 2 },
     ];
     const out = buildArtifactOptions("all", up, gl, ["xgboost.*"]);
-    expect(out.map(([name]) => name)).toEqual(["a", "c"]);
+    expect(out.map((o) => o.value)).toEqual(["a", "c"]);
   });
 
   it("returns an empty list when both sources are empty", () => {
@@ -106,47 +106,114 @@ describe("buildArtifactOptions", () => {
   });
 });
 
-describe("global artifacts collapse to their newest version", () => {
-  // A bare name resolves to the newest version server-side, so older rows were N
-  // choices that all meant the same artifact.
-  const versioned: GlobalArtifactOption[] = [
-    { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 3 },
-    { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 2 },
-    { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 1 },
-    { name: "scaler", python_type: "sklearn.StandardScaler", namespace_id: 1, version: 1 },
+describe("global artifact options", () => {
+  // Two artifacts that happen to share a name are distinct artifacts, so each one
+  // needs a value core can resolve on its own: the namespace-qualified reference.
+  // Collapsing them (or emitting the bare name twice) is what made the picker
+  // offer indistinguishable entries that then failed as ambiguous at run time.
+  const twoNamespaces: GlobalArtifactOption[] = [
+    {
+      name: "churn",
+      python_type: "xgboost.Booster",
+      namespace_id: 1,
+      namespace_path: "General.default",
+      version: 2,
+    },
+    {
+      name: "churn",
+      python_type: "xgboost.Booster",
+      namespace_id: 7,
+      namespace_path: "General.news-predictions",
+      version: 5,
+    },
   ];
 
-  it("keeps one option per artifact, at its highest version", () => {
-    expect(buildArtifactOptions("global", [], versioned)).toEqual([
-      ["churn", "churn (v3 · Booster)"],
-      ["scaler", "scaler (v1 · StandardScaler)"],
-    ]);
-  });
-
-  it("picks the highest version regardless of arrival order", () => {
-    const shuffled = [versioned[1], versioned[2], versioned[0]];
-    expect(buildArtifactOptions("global", [], shuffled)).toEqual([["churn", "churn (v3 · Booster)"]]);
-  });
-
-  it("collapses for scope 'all' too, after the upstream-wins dedupe", () => {
-    const upstream: ArtifactOption[] = [{ name: "scaler", type_name: "StandardScaler" }];
-    expect(buildArtifactOptions("all", upstream, versioned)).toEqual([
-      ["scaler", "scaler (StandardScaler)"],
-      ["churn", "churn (v3 · Booster)"],
-    ]);
-  });
-
-  it("keeps same-named artifacts in different namespaces apart", () => {
-    // The backend rejects a bare-name lookup that is ambiguous across namespaces —
-    // merging them here would hide that conflict instead of surfacing it.
-    const twoNamespaces: GlobalArtifactOption[] = [
-      { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 2 },
-      { name: "churn", python_type: "xgboost.Booster", namespace_id: 7, version: 5 },
-    ];
+  it("qualifies same-named artifacts and labels the namespace only then", () => {
     expect(buildArtifactOptions("global", [], twoNamespaces)).toEqual([
-      ["churn", "churn (v2 · Booster)"],
-      ["churn", "churn (v5 · Booster)"],
+      {
+        value: "General.default::churn",
+        label: "churn (Booster) — General.default",
+        key: "1::churn",
+        namespaceId: 1,
+      },
+      {
+        value: "General.news-predictions::churn",
+        label: "churn (Booster) — General.news-predictions",
+        key: "7::churn",
+        namespaceId: 7,
+      },
     ]);
+  });
+
+  it("gives every option in a result set a unique value and key", () => {
+    const mixed: GlobalArtifactOption[] = [
+      ...twoNamespaces,
+      {
+        name: "scaler",
+        python_type: "sklearn.StandardScaler",
+        namespace_id: 1,
+        namespace_path: "General.default",
+        version: 1,
+      },
+    ];
+    const out = buildArtifactOptions("global", [], mixed);
+    expect(new Set(out.map((o) => o.value)).size).toBe(out.length);
+    expect(new Set(out.map((o) => o.key)).size).toBe(out.length);
+  });
+
+  it("never puts a version number in a label", () => {
+    const out = buildArtifactOptions("global", [], twoNamespaces);
+    for (const opt of out) {
+      expect(opt.label).not.toMatch(/\bv\d+\b/);
+    }
+  });
+
+  it("leaves an unambiguous name unsuffixed but still qualifies its value", () => {
+    const single: GlobalArtifactOption[] = [
+      {
+        name: "scaler",
+        python_type: "sklearn.StandardScaler",
+        namespace_id: 3,
+        namespace_path: "General.models",
+        version: 4,
+      },
+    ];
+    expect(buildArtifactOptions("global", [], single)).toEqual([
+      {
+        value: "General.models::scaler",
+        label: "scaler (StandardScaler)",
+        key: "3::scaler",
+        namespaceId: 3,
+      },
+    ]);
+  });
+
+  it("keeps upstream values bare — qualified values are global-scope only", () => {
+    const upstream: ArtifactOption[] = [{ name: "churn", type_name: "Booster" }];
+    const out = buildArtifactOptions("all", upstream, twoNamespaces);
+    // The upstream "churn" shadows both globals by bare name, as before.
+    expect(out).toEqual([{ value: "churn", label: "churn (Booster)", key: "churn" }]);
+  });
+
+  it("falls back to the bare name when the core ships no namespace_path", () => {
+    const legacy: GlobalArtifactOption[] = [
+      { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 2 },
+    ];
+    expect(buildArtifactOptions("global", [], legacy)).toEqual([
+      { value: "churn", label: "churn (Booster)", key: "1::churn", namespaceId: 1 },
+    ]);
+  });
+
+  it("collapses to the newest version when the server sends every row", () => {
+    // Safety net for an older core that ignores ?latest_only=true.
+    const versioned: GlobalArtifactOption[] = [
+      { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 1 },
+      { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 3 },
+      { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 2 },
+    ];
+    const out = buildArtifactOptions("global", [], versioned);
+    expect(out).toHaveLength(1);
+    expect(out[0].label).toBe("churn (Booster)");
   });
 
   it("treats a missing namespace_id as one bucket", () => {
@@ -155,7 +222,7 @@ describe("global artifacts collapse to their newest version", () => {
       { name: "churn", python_type: "xgboost.Booster", version: 4 },
     ];
     expect(buildArtifactOptions("global", [], noNamespace)).toEqual([
-      ["churn", "churn (v4 · Booster)"],
+      { value: "churn", label: "churn (Booster)", key: "::churn", namespaceId: null },
     ]);
   });
 
@@ -164,9 +231,9 @@ describe("global artifacts collapse to their newest version", () => {
       { name: "churn", python_type: "xgboost.Booster", namespace_id: 1, version: 9 },
       { name: "churn", python_type: "sklearn.Pipeline", namespace_id: 1, version: 2 },
     ];
-    // v9 is filtered out, so the surviving sklearn row must win — not "no options".
+    // The xgboost row is filtered out, so the surviving sklearn row must win.
     expect(buildArtifactOptions("global", [], mixed, ["sklearn.*"])).toEqual([
-      ["churn", "churn (v2 · Pipeline)"],
+      { value: "churn", label: "churn (Pipeline)", key: "1::churn", namespaceId: 1 },
     ]);
   });
 });

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/artifactFilter.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/components/artifactFilter.ts
@@ -20,8 +20,36 @@ export function formatTypeShort(fullType: string): string {
   return idx >= 0 ? fullType.slice(idx + 1) : fullType;
 }
 
-// [value, label] pair; value is always the bare artifact name.
-export type ArtifactSelectOption = [string, string];
+// `value` is what gets stored in the node settings: a bare artifact name, or a
+// namespace-qualified "catalog.schema::name" reference that core resolves. `key`
+// is display-only identity and is always distinct, even when two artifacts share
+// a name. Labels never carry a version — a selection always resolves to the
+// newest version at run time.
+export interface ArtifactSelectOption {
+  value: string;
+  label: string;
+  key: string;
+  namespaceId?: number | null;
+}
+
+// Static (string[]) and IncomingColumns options stay plain strings; the legacy
+// [value, label] tuple is still accepted by the selects.
+export type SelectOptionItem = string | [string, string] | ArtifactSelectOption;
+
+export function optionValue(item: SelectOptionItem): string {
+  if (typeof item === "string") return item;
+  return Array.isArray(item) ? item[0] : item.value;
+}
+
+export function optionLabel(item: SelectOptionItem): string {
+  if (typeof item === "string") return item;
+  return Array.isArray(item) ? item[1] : item.label;
+}
+
+export function optionKey(item: SelectOptionItem): string {
+  if (typeof item === "string") return item;
+  return Array.isArray(item) ? item[0] : item.key;
+}
 
 export function upstreamArtifactOptions(
   artifacts: ArtifactOption[],
@@ -30,14 +58,16 @@ export function upstreamArtifactOptions(
   return artifacts
     .filter((a) => matchesTypeFilter([a.module, a.type_name].filter(Boolean).join("."), typeFilter))
     .map(
-      (a): ArtifactSelectOption => [a.name, a.type_name ? `${a.name} (${a.type_name})` : a.name],
+      (a): ArtifactSelectOption => ({
+        value: a.name,
+        label: a.type_name ? `${a.name} (${a.type_name})` : a.name,
+        key: a.name,
+      }),
     );
 }
 
-// A name resolves to its newest version when no version is given, so every older
-// version is a duplicate choice. Namespace is part of the key: the same name in two
-// namespaces is two distinct artifacts (the backend rejects that lookup as ambiguous
-// rather than picking one), so collapsing them here would hide a real conflict.
+// Safety net for older cores that don't serve ?latest_only=true: a name resolves
+// to its newest version anyway, so every older row is a duplicate choice.
 function newestPerArtifact(artifacts: GlobalArtifactOption[]): GlobalArtifactOption[] {
   const newest = new Map<string, GlobalArtifactOption>();
   for (const a of artifacts) {
@@ -49,18 +79,39 @@ function newestPerArtifact(artifacts: GlobalArtifactOption[]): GlobalArtifactOpt
   return [...newest.values()];
 }
 
+function artifactOptionValue(a: GlobalArtifactOption): string {
+  return a.namespace_path ? `${a.namespace_path}::${a.name}` : a.name;
+}
+
+function artifactOptionKey(a: GlobalArtifactOption): string {
+  return `${a.namespace_id ?? ""}::${a.name}`;
+}
+
+function namespaceLabel(a: GlobalArtifactOption): string {
+  if (a.namespace_path) return a.namespace_path;
+  return a.namespace_id != null ? `ns ${a.namespace_id}` : "default";
+}
+
 export function globalArtifactOptions(
   artifacts: GlobalArtifactOption[],
   typeFilter?: string[],
 ): ArtifactSelectOption[] {
-  return newestPerArtifact(
+  const collapsed = newestPerArtifact(
     artifacts.filter((a) => matchesTypeFilter(a.python_type ?? "", typeFilter)),
-  ).map(
-    (a): ArtifactSelectOption => [
-      a.name,
-      `${a.name} (v${a.version}${a.python_type ? " · " + formatTypeShort(a.python_type) : ""})`,
-    ],
   );
+  const counts = new Map<string, number>();
+  for (const a of collapsed) counts.set(a.name, (counts.get(a.name) ?? 0) + 1);
+
+  return collapsed.map((a): ArtifactSelectOption => {
+    const type = a.python_type ? ` (${formatTypeShort(a.python_type)})` : "";
+    const suffix = (counts.get(a.name) ?? 0) > 1 ? ` — ${namespaceLabel(a)}` : "";
+    return {
+      value: artifactOptionValue(a),
+      label: `${a.name}${type}${suffix}`,
+      key: artifactOptionKey(a),
+      namespaceId: a.namespace_id ?? null,
+    };
+  });
 }
 
 // scope "all": upstream options first, then global options whose bare name is not
@@ -79,7 +130,10 @@ export function buildArtifactOptions(
   if (resolved === "upstream") {
     return upstreamOpts;
   }
-  const seen = new Set(upstreamOpts.map(([name]) => name));
-  const globalOpts = globalArtifactOptions(global, typeFilter).filter(([name]) => !seen.has(name));
+  const seen = new Set(upstreamOpts.map((o) => o.value));
+  const globalOpts = globalArtifactOptions(
+    global.filter((a) => !seen.has(a.name)),
+    typeFilter,
+  );
   return [...upstreamOpts, ...globalOpts];
 }

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/formInit.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/formInit.test.ts
@@ -1,7 +1,14 @@
 // Unit tests for the pure custom-node form helpers (no Vue/axios involved).
 import { describe, expect, it } from "vitest";
-import { initializeFormData, resolveOptionsLoading, schemaWantsGlobalArtifacts } from "./formInit";
+import {
+  coerceArtifactValue,
+  coerceLegacyArtifactValues,
+  initializeFormData,
+  resolveOptionsLoading,
+  schemaWantsGlobalArtifacts,
+} from "./formInit";
 import type { CustomNodeSchema, UIComponent } from "./interface";
+import type { ArtifactSelectOption } from "./components/artifactFilter";
 
 const schemaWith = (components: Record<string, Partial<UIComponent>>): CustomNodeSchema =>
   ({
@@ -53,6 +60,121 @@ describe("initializeFormData precedence", () => {
     });
     const data = initializeFormData(schema, { main: { gone: 1 }, dropped_section: { x: 2 } });
     expect(data).toEqual({ main: { a: "d" } });
+  });
+});
+
+describe("legacy bare-name artifact values", () => {
+  const opt = (value: string, key: string): ArtifactSelectOption => ({ value, label: value, key });
+  const options = [
+    opt("General.default::churn", "1::churn"),
+    opt("General.models::churn", "7::churn"),
+    opt("General.models::scaler", "7::scaler"),
+    opt("plain", "::plain"),
+  ];
+
+  it("resolves an unambiguous bare name onto its qualified option", () => {
+    expect(coerceArtifactValue("scaler", options)).toBe("General.models::scaler");
+  });
+
+  it("clears an ambiguous bare name instead of guessing", () => {
+    expect(coerceArtifactValue("churn", options)).toBeNull();
+  });
+
+  it("leaves already-qualified, unknown and non-string values alone", () => {
+    expect(coerceArtifactValue("General.models::churn", options)).toBe("General.models::churn");
+    expect(coerceArtifactValue("gone", options)).toBe("gone");
+    expect(coerceArtifactValue("plain", options)).toBe("plain");
+    expect(coerceArtifactValue("", options)).toBe("");
+    expect(coerceArtifactValue(7, options)).toBe(7);
+  });
+
+  it("maps multi-select arrays and drops the ambiguous entries", () => {
+    expect(coerceArtifactValue(["scaler", "churn", "plain"], options)).toEqual([
+      "General.models::scaler",
+      "plain",
+    ]);
+  });
+
+  it("only touches global-scope artifact selects", () => {
+    const schema = schemaWith({
+      global_pick: {
+        component_type: "SingleSelect",
+        input_type: "text",
+        value: undefined,
+        default: null,
+        options: { __type__: "AvailableArtifacts", scope: "global" },
+      } as never,
+      upstream_pick: {
+        component_type: "SingleSelect",
+        input_type: "text",
+        value: undefined,
+        default: null,
+        options: { __type__: "AvailableArtifacts", scope: "upstream" },
+      } as never,
+      all_pick: {
+        component_type: "SingleSelect",
+        input_type: "text",
+        value: undefined,
+        default: null,
+        options: { __type__: "AvailableArtifacts", scope: "all" },
+      } as never,
+      text: { component_type: "TextInput", value: undefined, default: null, input_type: "text" },
+    });
+    const data = {
+      main: {
+        global_pick: "scaler",
+        upstream_pick: "scaler",
+        all_pick: "scaler",
+        text: "scaler",
+      },
+    };
+    coerceLegacyArtifactValues(schema, data, () => options);
+    expect(data.main.global_pick).toBe("General.models::scaler");
+    expect(data.main.upstream_pick).toBe("scaler");
+    expect(data.main.all_pick).toBe("scaler");
+    expect(data.main.text).toBe("scaler");
+  });
+
+  // A scope-"all" value may name an upstream artifact; a failed upstream fetch
+  // leaves only catalog options, which must never repoint the saved selection.
+  it("never repoints a scope-all selection when the upstream fetch came back empty", () => {
+    const schema = schemaWith({
+      pick: {
+        component_type: "SingleSelect",
+        input_type: "text",
+        value: undefined,
+        default: null,
+        options: { __type__: "AvailableArtifacts", scope: "all" },
+      } as never,
+      ambiguous_pick: {
+        component_type: "SingleSelect",
+        input_type: "text",
+        value: undefined,
+        default: null,
+        options: { __type__: "AvailableArtifacts", scope: "all" },
+      } as never,
+    });
+    const data = { main: { pick: "scaler", ambiguous_pick: "churn" } };
+
+    coerceLegacyArtifactValues(schema, data, () => options);
+
+    expect(data.main.pick).toBe("scaler");
+    expect(data.main.ambiguous_pick).toBe("churn");
+  });
+
+  it("skips components with no saved selection", () => {
+    const schema = schemaWith({
+      pick: {
+        component_type: "SingleSelect",
+        input_type: "text",
+        value: undefined,
+        default: null,
+        options: { __type__: "AvailableArtifacts", scope: "global" },
+      } as never,
+    });
+    const data = { main: { pick: null } };
+    coerceLegacyArtifactValues(schema, data, () => options);
+    expect(data.main.pick).toBeNull();
   });
 });
 

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/formInit.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/formInit.ts
@@ -1,6 +1,12 @@
 // Pure helpers for the custom-node settings form (no Vue/axios imports so they
 // stay unit-testable in node-env vitest).
-import type { CustomNodeSchema, SectionComponent, UIComponent } from "./interface";
+import type {
+  AvailableArtifactsMarker,
+  CustomNodeSchema,
+  SectionComponent,
+  UIComponent,
+} from "./interface";
+import type { ArtifactSelectOption } from "./components/artifactFilter";
 
 // Inner values are `any`: the child inputs each declare their own modelValue type
 // and the drawer has always fed them untyped saved-settings values.
@@ -35,6 +41,48 @@ export function initializeFormData(
         }
         data[sectionKey][componentKey] = defaultValue;
       }
+    }
+  }
+  return data;
+}
+
+// Values saved before namespace-qualified references existed are bare names. Match
+// them onto the option carrying that bare name; when the name exists in more than
+// one namespace there is nothing to guess from, so the selection is cleared and the
+// user picks again (that value could not resolve server-side either).
+// Returns `unknown`: anything not shaped like a legacy value is passed straight back.
+export function coerceArtifactValue(saved: unknown, options: ArtifactSelectOption[]): unknown {
+  if (Array.isArray(saved)) {
+    return saved
+      .map((entry) => coerceArtifactValue(entry, options))
+      .filter((entry) => entry !== null);
+  }
+  if (typeof saved !== "string" || saved === "" || saved.includes("::")) return saved;
+  if (options.some((o) => o.value === saved)) return saved;
+  const matches = options.filter((o) => o.value.endsWith(`::${saved}`));
+  if (matches.length === 1) return matches[0].value;
+  return matches.length === 0 ? saved : null;
+}
+
+// Applies the coercion to every global-scope artifact select once the option lists
+// have been fetched. Mutates and returns the same form-data object. Scope "all" is
+// deliberately left alone: its saved value may name an upstream artifact, and a
+// failed upstream fetch would otherwise repoint it at a same-named catalog entry.
+export function coerceLegacyArtifactValues(
+  schemaData: CustomNodeSchema,
+  data: CustomNodeFormData,
+  optionsFor: (marker: AvailableArtifactsMarker) => ArtifactSelectOption[],
+): CustomNodeFormData {
+  for (const sectionKey in schemaData.settings_schema) {
+    const section = schemaData.settings_schema[sectionKey];
+    for (const componentKey in section.components) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const options = (section.components[componentKey] as any).options;
+      if (options?.__type__ !== "AvailableArtifacts") continue;
+      if (options.scope !== "global") continue;
+      const current = data[sectionKey]?.[componentKey];
+      if (current === undefined || current === null) continue;
+      data[sectionKey][componentKey] = coerceArtifactValue(current, optionsFor(options));
     }
   }
   return data;

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/interface.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/customNode/interface.ts
@@ -32,11 +32,14 @@ export interface ArtifactOption {
   status?: "published" | "declared";
 }
 
-// One global (catalog) artifact option surfaced by /artifacts/.
+// One global (catalog) artifact option surfaced by /artifacts/?latest_only=true.
+// namespace_path ("catalog.schema") is what makes a value unambiguous; older cores
+// omit it, in which case the bare name is still used.
 export interface GlobalArtifactOption {
   name: string;
   python_type?: string | null;
   namespace_id?: number | null;
+  namespace_path?: string | null;
   version: number;
 }
 

--- a/flowfile_frontend/src/renderer/app/stores/catalog-store.artifacts.test.ts
+++ b/flowfile_frontend/src/renderer/app/stores/catalog-store.artifacts.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import type { ArtifactVersionInfo, GlobalArtifact, NamespaceTree } from "../types";
+
+const getArtifactVersions = vi.fn();
+const deleteArtifactVersion = vi.fn();
+const promoteArtifactVersion = vi.fn();
+const pruneArtifactVersions = vi.fn();
+const getNamespaceTree = vi.fn();
+const getArtifactById = vi.fn();
+
+vi.mock("../api/catalog.api", () => ({
+  CatalogApi: {
+    getArtifactById: (...args: unknown[]) => getArtifactById(...args),
+    getArtifactVersions: (...args: unknown[]) => getArtifactVersions(...args),
+    deleteArtifactVersion: (...args: unknown[]) => deleteArtifactVersion(...args),
+    promoteArtifactVersion: (...args: unknown[]) => promoteArtifactVersion(...args),
+    pruneArtifactVersions: (...args: unknown[]) => pruneArtifactVersions(...args),
+    getNamespaceTree: (...args: unknown[]) => getNamespaceTree(...args),
+  },
+}));
+
+import { useCatalogStore } from "./catalog-store";
+
+const version = (v: number): ArtifactVersionInfo => ({
+  id: 1000 + v,
+  version: v,
+  created_at: "2026-08-01T00:00:00",
+  size_bytes: 10,
+  sha256: `sha-${v}`,
+  python_type: "xgboost.core.Booster",
+  blob_exists: true,
+});
+
+const artifact = (id: number, v: number): GlobalArtifact =>
+  ({
+    id,
+    name: "churn",
+    version: v,
+    namespace_id: 4,
+    status: "active",
+    blob_exists: true,
+  }) as unknown as GlobalArtifact;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const treeWith = (a: GlobalArtifact): NamespaceTree[] =>
+  [
+    {
+      id: 1,
+      name: "General",
+      children: [{ id: 4, name: "models", children: [], artifacts: [a] }],
+      artifacts: [],
+    },
+  ] as unknown as NamespaceTree[];
+
+describe("catalog-store artifact versions", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("loadArtifactVersions populates state and remembers the ref", async () => {
+    getArtifactVersions.mockResolvedValue({
+      all_versions: [version(42), version(41)],
+      total_versions: 42,
+    });
+    const store = useCatalogStore();
+
+    await store.loadArtifactVersions("General.models::churn", 4);
+
+    expect(getArtifactVersions).toHaveBeenCalledWith("General.models::churn", 4, 25, 0);
+    expect(store.artifactVersions.map((v) => v.version)).toEqual([42, 41]);
+    expect(store.artifactVersionsTotal).toBe(42);
+    expect(store.artifactVersionsRef).toBe("General.models::churn");
+  });
+
+  it("drops a superseded response so rows cannot land under another artifact", async () => {
+    const slow = deferred<unknown>();
+    getArtifactVersions
+      .mockReturnValueOnce(slow.promise)
+      .mockResolvedValueOnce({ all_versions: [version(2)], total_versions: 2 });
+    const store = useCatalogStore();
+
+    const first = store.loadArtifactVersions("General.models::alpha", 4);
+    await store.loadArtifactVersions("General.models::beta", 5);
+    slow.resolve({ all_versions: [version(99)], total_versions: 99 });
+    await first;
+
+    expect(store.artifactVersionsRef).toBe("General.models::beta");
+    expect(store.artifactVersions.map((v) => v.version)).toEqual([2]);
+    expect(store.artifactVersionsTotal).toBe(2);
+    expect(store.loadingArtifactVersions).toBe(false);
+  });
+
+  it("ignores a superseded failure instead of blanking the current list", async () => {
+    const slow = deferred<unknown>();
+    getArtifactVersions
+      .mockReturnValueOnce(slow.promise)
+      .mockResolvedValueOnce({ all_versions: [version(2)], total_versions: 2 });
+    const store = useCatalogStore();
+
+    const first = store.loadArtifactVersions("General.models::alpha", 4);
+    await store.loadArtifactVersions("General.models::beta", 5);
+    slow.reject({ response: { data: { detail: "gone" } } });
+    await first;
+
+    expect(store.artifactVersions.map((v) => v.version)).toEqual([2]);
+    expect(store.error).toBeNull();
+  });
+
+  it("requests the right offset for a later page", async () => {
+    getArtifactVersions.mockResolvedValue({ all_versions: [], total_versions: 42 });
+    const store = useCatalogStore();
+
+    await store.loadArtifactVersions("churn", null, 2);
+
+    expect(getArtifactVersions).toHaveBeenCalledWith("churn", null, 25, 25);
+    expect(store.artifactVersionsPage).toBe(2);
+  });
+
+  it("clears the list and records the error when the fetch fails", async () => {
+    getArtifactVersions.mockRejectedValue({ response: { data: { detail: "nope" } } });
+    const store = useCatalogStore();
+    store.artifactVersions = [version(1)];
+    store.artifactVersionsTotal = 1;
+
+    await store.loadArtifactVersions("churn", null);
+
+    expect(store.artifactVersions).toEqual([]);
+    expect(store.artifactVersionsTotal).toBe(0);
+    expect(store.error).toBe("nope");
+    expect(store.loadingArtifactVersions).toBe(false);
+  });
+
+  it("reloadArtifactVersions re-fetches the remembered ref", async () => {
+    getArtifactVersions.mockResolvedValue({ all_versions: [], total_versions: 0 });
+    const store = useCatalogStore();
+    await store.loadArtifactVersions("General.models::churn", 4, 3);
+    getArtifactVersions.mockClear();
+
+    await store.reloadArtifactVersions();
+
+    expect(getArtifactVersions).toHaveBeenCalledWith("General.models::churn", 4, 25, 50);
+  });
+
+  it("reloadArtifactVersions is a no-op when nothing is loaded", async () => {
+    const store = useCatalogStore();
+
+    await store.reloadArtifactVersions();
+
+    expect(getArtifactVersions).not.toHaveBeenCalled();
+  });
+
+  it("clearArtifactSelection also drops the version list", async () => {
+    getArtifactVersions.mockResolvedValue({ all_versions: [version(1)], total_versions: 1 });
+    const store = useCatalogStore();
+    await store.loadArtifactVersions("churn", null);
+
+    store.clearArtifactSelection();
+
+    expect(store.artifactVersions).toEqual([]);
+    expect(store.artifactVersionsRef).toBeNull();
+    expect(store.artifactVersionsPage).toBe(1);
+  });
+
+  it("deleteArtifactVersion forwards the force flag", async () => {
+    deleteArtifactVersion.mockResolvedValue(undefined);
+    const store = useCatalogStore();
+
+    await store.deleteArtifactVersion(1003, true);
+
+    expect(deleteArtifactVersion).toHaveBeenCalledWith(1003, true);
+  });
+
+  it("promoteArtifactVersion forwards the row id and returns the new row", async () => {
+    promoteArtifactVersion.mockResolvedValue({ id: 1099, version: 43 });
+    const store = useCatalogStore();
+
+    const promoted = await store.promoteArtifactVersion(1003);
+
+    expect(promoteArtifactVersion).toHaveBeenCalledWith(1003);
+    expect(promoted).toEqual({ id: 1099, version: 43 });
+  });
+
+  it("pruneArtifactVersions uses the loaded ref and namespace", async () => {
+    getArtifactVersions.mockResolvedValue({ all_versions: [], total_versions: 0 });
+    pruneArtifactVersions.mockResolvedValue({ would_delete: [], freed_bytes: 0, deleted: 0 });
+    const store = useCatalogStore();
+    await store.loadArtifactVersions("General.models::churn", 4);
+
+    await store.pruneArtifactVersions(5, true);
+
+    expect(pruneArtifactVersions).toHaveBeenCalledWith("General.models::churn", 4, 5, true);
+  });
+
+  it("pruneArtifactVersions rejects when no artifact is loaded", async () => {
+    const store = useCatalogStore();
+
+    await expect(store.pruneArtifactVersions(5, true)).rejects.toThrow("No artifact selected");
+  });
+
+  it("selectArtifact resolves a non-latest row id onto its family", async () => {
+    const latest = artifact(999, 43);
+    getArtifactById.mockResolvedValue({ id: 500, name: "churn", namespace_id: 4 });
+    const store = useCatalogStore();
+    store.tree = treeWith(latest);
+
+    await store.selectArtifact(500);
+
+    expect(getArtifactById).toHaveBeenCalledWith(500);
+    expect(store.selectedArtifactId).toBe(999);
+    expect(store.selectedArtifact?.version).toBe(43);
+  });
+
+  it("selectArtifact skips the by-id lookup when the tree already holds the row", async () => {
+    const store = useCatalogStore();
+    store.tree = treeWith(artifact(999, 43));
+
+    await store.selectArtifact(999);
+
+    expect(getArtifactById).not.toHaveBeenCalled();
+    expect(store.selectedArtifact?.id).toBe(999);
+  });
+
+  it("refreshSelectedArtifact re-resolves the family's latest row after a promote", async () => {
+    const promoted = artifact(999, 43);
+    getNamespaceTree.mockResolvedValue(treeWith(promoted));
+    const store = useCatalogStore();
+    store.selectedArtifact = artifact(500, 42);
+    store.selectedArtifactId = 500;
+
+    await store.refreshSelectedArtifact();
+
+    expect(store.selectedArtifactId).toBe(999);
+    expect(store.selectedArtifact?.version).toBe(43);
+  });
+
+  it("refreshSelectedArtifact clears the selection when the family is gone", async () => {
+    getNamespaceTree.mockResolvedValue([]);
+    const store = useCatalogStore();
+    store.selectedArtifact = artifact(500, 42);
+    store.selectedArtifactId = 500;
+
+    await store.refreshSelectedArtifact();
+
+    expect(store.selectedArtifact).toBeNull();
+    expect(store.selectedArtifactId).toBeNull();
+  });
+});

--- a/flowfile_frontend/src/renderer/app/stores/catalog-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/catalog-store.ts
@@ -2,8 +2,11 @@
 import { defineStore } from "pinia";
 import type { AxiosRequestConfig } from "axios";
 import { CatalogApi } from "../api/catalog.api";
+import { ARTIFACT_VERSIONS_PAGE_SIZE } from "../views/CatalogView/artifactVersions";
 import type {
   ActiveFlowRun,
+  ArtifactPruneResult,
+  ArtifactVersionInfo,
   CatalogStats,
   CatalogTab,
   CatalogTable,
@@ -21,6 +24,9 @@ import type {
   VisualizationUpdatePayload,
   VizSourceDescriptor,
 } from "../types";
+
+// Monotonic token guarding the artifact-versions fetch against out-of-order responses.
+let artifactVersionsRequestToken = 0;
 
 interface CatalogState {
   tree: NamespaceTree[];
@@ -44,6 +50,12 @@ interface CatalogState {
   selectedArtifact: GlobalArtifact | null;
   flowArtifacts: GlobalArtifact[];
   loadingArtifacts: boolean;
+  artifactVersions: ArtifactVersionInfo[];
+  artifactVersionsTotal: number;
+  artifactVersionsPage: number;
+  artifactVersionsRef: string | null;
+  artifactVersionsNamespaceId: number | null;
+  loadingArtifactVersions: boolean;
   selectedNamespaceId: number | null;
   selectedNamespace: NamespaceTree | null;
   selectedTableId: number | null;
@@ -135,6 +147,12 @@ export const useCatalogStore = defineStore("catalog", {
     selectedArtifact: null,
     flowArtifacts: [],
     loadingArtifacts: false,
+    artifactVersions: [],
+    artifactVersionsTotal: 0,
+    artifactVersionsPage: 1,
+    artifactVersionsRef: null,
+    artifactVersionsNamespaceId: null,
+    loadingArtifactVersions: false,
     selectedNamespaceId: null,
     selectedNamespace: null,
     selectedTableId: null,
@@ -389,17 +407,136 @@ export const useCatalogStore = defineStore("catalog", {
       }
     },
 
-    selectArtifact(artifactId: number) {
+    async selectArtifact(artifactId: number) {
       this.selectedArtifactId = artifactId;
-      this.selectedArtifact =
+      const local =
         this.flowArtifacts.find((a) => a.id === artifactId) ??
         this.findArtifactInTree(artifactId) ??
         null;
+      this.selectedArtifact = local;
+      if (local) return;
+      // The tree carries one row per family, so a link minted against an older
+      // version's id misses. Resolve that row and land on its family instead.
+      try {
+        const row = await CatalogApi.getArtifactById(artifactId);
+        if (this.selectedArtifactId !== artifactId) return;
+        const match = this.findArtifactByName(row.name, row.namespace_id ?? null);
+        if (match) {
+          this.selectedArtifact = match;
+          this.selectedArtifactId = match.id;
+        }
+      } catch {
+        // Id no longer resolves (deleted, or not visible to this user).
+      }
     },
 
     clearArtifactSelection() {
       this.selectedArtifactId = null;
       this.selectedArtifact = null;
+      this.clearArtifactVersions();
+    },
+
+    // -- Artifact version actions --
+
+    clearArtifactVersions() {
+      artifactVersionsRequestToken++;
+      this.artifactVersions = [];
+      this.artifactVersionsTotal = 0;
+      this.artifactVersionsPage = 1;
+      this.artifactVersionsRef = null;
+      this.artifactVersionsNamespaceId = null;
+    },
+
+    /**
+     * Load one page of an artifact's version history. `ref` may be namespace-qualified.
+     * A superseded request's response is dropped: rows landing under another
+     * artifact's panel would point the per-row delete/restore actions at it.
+     */
+    async loadArtifactVersions(ref: string, namespaceId: number | null, page = 1) {
+      const token = ++artifactVersionsRequestToken;
+      this.artifactVersionsRef = ref;
+      this.artifactVersionsNamespaceId = namespaceId;
+      this.artifactVersionsPage = page;
+      this.loadingArtifactVersions = true;
+      try {
+        const result = await CatalogApi.getArtifactVersions(
+          ref,
+          namespaceId,
+          ARTIFACT_VERSIONS_PAGE_SIZE,
+          (page - 1) * ARTIFACT_VERSIONS_PAGE_SIZE,
+        );
+        if (token !== artifactVersionsRequestToken) return;
+        this.artifactVersions = result.all_versions;
+        this.artifactVersionsTotal = result.total_versions;
+      } catch (e: any) {
+        if (token !== artifactVersionsRequestToken) return;
+        this.artifactVersions = [];
+        this.artifactVersionsTotal = 0;
+        this.error = e?.response?.data?.detail ?? e?.message ?? "Failed to load model versions";
+      } finally {
+        if (token === artifactVersionsRequestToken) this.loadingArtifactVersions = false;
+      }
+    },
+
+    /** Re-fetch the current (or a given) page of the loaded artifact's versions. */
+    async reloadArtifactVersions(page?: number) {
+      if (this.artifactVersionsRef === null) return;
+      await this.loadArtifactVersions(
+        this.artifactVersionsRef,
+        this.artifactVersionsNamespaceId,
+        page ?? this.artifactVersionsPage,
+      );
+    },
+
+    setArtifactVersionsPage(page: number) {
+      this.reloadArtifactVersions(page);
+    },
+
+    async deleteArtifactVersion(artifactId: number, force = false) {
+      await CatalogApi.deleteArtifactVersion(artifactId, force);
+    },
+
+    async promoteArtifactVersion(artifactId: number) {
+      return CatalogApi.promoteArtifactVersion(artifactId);
+    },
+
+    async pruneArtifactVersions(keep: number, dryRun: boolean): Promise<ArtifactPruneResult> {
+      if (this.artifactVersionsRef === null) throw new Error("No artifact selected");
+      return CatalogApi.pruneArtifactVersions(
+        this.artifactVersionsRef,
+        this.artifactVersionsNamespaceId,
+        keep,
+        dryRun,
+      );
+    },
+
+    /**
+     * Re-resolve the selected artifact after a version mutation: promote mints a
+     * new latest row and a forced latest-version delete retires one, so the id
+     * the panel was opened with can stop being the family's latest row.
+     */
+    async refreshSelectedArtifact() {
+      const current = this.selectedArtifact;
+      if (!current) return;
+      await this.loadTree();
+      const match = this.findArtifactByName(current.name, current.namespace_id);
+      this.selectedArtifact = match;
+      this.selectedArtifactId = match?.id ?? null;
+    },
+
+    /** Walk the namespace tree for the latest row of an artifact family. */
+    findArtifactByName(name: string, namespaceId: number | null): GlobalArtifact | null {
+      const walk = (nodes: NamespaceTree[]): GlobalArtifact | null => {
+        for (const node of nodes) {
+          for (const a of node.artifacts ?? []) {
+            if (a.name === name && a.namespace_id === namespaceId) return a;
+          }
+          const nested = walk(node.children ?? []);
+          if (nested) return nested;
+        }
+        return null;
+      };
+      return walk(this.tree);
     },
 
     // -- Catalog Table actions --

--- a/flowfile_frontend/src/renderer/app/types/catalog.types.ts
+++ b/flowfile_frontend/src/renderer/app/types/catalog.types.ts
@@ -210,7 +210,53 @@ export interface GlobalArtifact {
   created_at: string | null;
   updated_at: string | null;
   blob_exists: boolean;
+  // Number of versions in this artifact's family. The tree returns one row per
+  // (name, namespace) so the row count can no longer stand in for it.
+  version_count?: number | null;
   access?: AccessInfo | null;
+}
+
+/** One row of an artifact's version history (GET /artifacts/by-name/{ref}/versions). */
+export interface ArtifactVersionInfo {
+  id: number;
+  version: number;
+  created_at: string;
+  size_bytes: number | null;
+  sha256: string | null;
+  python_type: string | null;
+  blob_exists: boolean;
+}
+
+/** Paginated version history: `all_versions` is one page, `total_versions` the count. */
+export interface ArtifactWithVersions {
+  id: number;
+  name: string;
+  namespace_id: number | null;
+  version: number;
+  status: string;
+  all_versions: ArtifactVersionInfo[];
+  total_versions: number;
+}
+
+/** Row minted by POST /artifacts/{id}/promote (backend ArtifactOut). */
+export interface PromotedArtifactVersion {
+  id: number;
+  name: string;
+  namespace_id: number | null;
+  version: number;
+  status: string;
+}
+
+export interface ArtifactPruneCandidate {
+  id: number;
+  version: number;
+  size_bytes: number | null;
+}
+
+export interface ArtifactPruneResult {
+  would_delete: ArtifactPruneCandidate[];
+  freed_bytes: number;
+  deleted: number;
 }
 
 // Catalog Table

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/ArtifactDetailPanel.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/ArtifactDetailPanel.vue
@@ -26,6 +26,15 @@
           Share
         </button>
         <button
+          v-if="canManage(artifact) && totalVersions > 1"
+          class="btn btn-secondary btn-sm"
+          title="Delete older versions"
+          @click="showPruneDialog = true"
+        >
+          <i class="fa-solid fa-broom"></i>
+          Prune versions
+        </button>
+        <button
           v-if="canManage(artifact)"
           class="btn btn-danger btn-sm"
           title="Delete model"
@@ -44,6 +53,14 @@
       :resource-id="artifact.id"
       :resource-name="artifact.name"
       :can-manage-grants="canManageGrants(artifact)"
+    />
+
+    <ArtifactPruneDialog
+      v-model="showPruneDialog"
+      :artifact-name="artifact.name"
+      :total-versions="totalVersions"
+      :versions="versions"
+      @pruned="emit('versionsChanged')"
     />
 
     <!-- Data missing banner -->
@@ -78,7 +95,7 @@
       </div>
       <div class="meta-card">
         <span class="meta-label">Total Versions</span>
-        <span class="meta-value">{{ versions.length }}</span>
+        <span class="meta-value">{{ totalVersions }}</span>
       </div>
       <div class="meta-card">
         <span class="meta-label">Created</span>
@@ -132,7 +149,7 @@
     </div>
 
     <!-- Versions Table -->
-    <div v-if="versions.length > 1" class="section">
+    <div v-if="totalVersions > 0" class="section">
       <h3>Versions</h3>
       <div class="versions-table">
         <div class="versions-header">
@@ -140,29 +157,71 @@
           <span class="col-type">Type</span>
           <span class="col-size">Size</span>
           <span class="col-date">Created</span>
+          <span class="col-actions">Actions</span>
         </div>
-        <div
-          v-for="v in versions"
-          :key="v.id"
-          class="versions-row"
-          :class="{ current: v.id === artifact.id }"
+        <div v-if="loadingVersions" class="versions-loading">Loading versions…</div>
+        <template v-else>
+          <div
+            v-for="v in versions"
+            :key="v.id"
+            class="versions-row"
+            :class="{ current: isLatest(v.version, latestVersion) }"
+          >
+            <span class="col-version">
+              v{{ v.version }}
+              <span v-if="isLatest(v.version, latestVersion)" class="latest-tag">latest</span>
+              <el-tooltip
+                v-if="v.blob_exists === false"
+                content="Model data file not found on disk"
+                placement="top"
+                :show-after="300"
+              >
+                <i class="fa-solid fa-triangle-exclamation missing-icon"></i>
+              </el-tooltip>
+            </span>
+            <span class="col-type mono">{{ versionType(v) }}</span>
+            <span class="col-size">{{ formatSize(v.size_bytes) }}</span>
+            <span class="col-date">{{ v.created_at ? formatDate(v.created_at) : "--" }}</span>
+            <span class="col-actions">
+              <template v-if="canManage(artifact) && !isLatest(v.version, latestVersion)">
+                <el-tooltip content="Restore as newest version" placement="top" :show-after="400">
+                  <el-button size="small" text @click="emit('promoteVersion', v)">
+                    <i class="fa-solid fa-rotate-left" />
+                  </el-button>
+                </el-tooltip>
+                <el-tooltip content="Delete this version" placement="top" :show-after="400">
+                  <el-button size="small" type="danger" text @click="emit('deleteVersion', v)">
+                    <i class="fa-solid fa-trash" />
+                  </el-button>
+                </el-tooltip>
+              </template>
+            </span>
+          </div>
+        </template>
+      </div>
+
+      <div v-if="totalPages > 1" class="pagination-bar">
+        <button class="page-btn" :disabled="page <= 1" @click="emit('setVersionsPage', 1)">
+          <i class="fa-solid fa-angles-left" />
+        </button>
+        <button class="page-btn" :disabled="page <= 1" @click="emit('setVersionsPage', page - 1)">
+          <i class="fa-solid fa-angle-left" />
+        </button>
+        <span class="page-info">Page {{ page }} of {{ totalPages }}</span>
+        <button
+          class="page-btn"
+          :disabled="page >= totalPages"
+          @click="emit('setVersionsPage', page + 1)"
         >
-          <span class="col-version">
-            v{{ v.version }}
-            <span v-if="v.id === artifact.id" class="latest-tag">latest</span>
-            <el-tooltip
-              v-if="v.blob_exists === false"
-              content="Model data file not found on disk"
-              placement="top"
-              :show-after="300"
-            >
-              <i class="fa-solid fa-triangle-exclamation missing-icon"></i>
-            </el-tooltip>
-          </span>
-          <span class="col-type mono">{{ formatType(v) }}</span>
-          <span class="col-size">{{ formatSize(v.size_bytes) }}</span>
-          <span class="col-date">{{ v.created_at ? formatDate(v.created_at) : "--" }}</span>
-        </div>
+          <i class="fa-solid fa-angle-right" />
+        </button>
+        <button
+          class="page-btn"
+          :disabled="page >= totalPages"
+          @click="emit('setVersionsPage', totalPages)"
+        >
+          <i class="fa-solid fa-angles-right" />
+        </button>
       </div>
     </div>
 
@@ -170,10 +229,10 @@
     <div class="section">
       <h3>Usage</h3>
       <div class="code-block">
-        <code>obj = flowfile_ctx.get_global("{{ artifact.name }}"{{ nsArg }})</code>
+        <code>obj = flowfile_ctx.get_global("{{ usageRef }}")</code>
       </div>
-      <div v-if="versions.length > 1" class="code-block" style="margin-top: 8px">
-        <code>obj_v1 = flowfile_ctx.get_global("{{ artifact.name }}"{{ nsArg }}, version=1)</code>
+      <div v-if="totalVersions > 1" class="code-block" style="margin-top: 8px">
+        <code>obj_v1 = flowfile_ctx.get_global("{{ usageRef }}", version=1)</code>
       </div>
     </div>
   </div>
@@ -182,25 +241,54 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { useCatalogStore } from "../../stores/catalog-store";
-import type { GlobalArtifact } from "../../types";
-import { formatDate, formatSize, formatType } from "./catalog-formatters";
+import { findNamespacePath, type ArtifactVersionInfo, type GlobalArtifact } from "../../types";
+import { formatDate, formatPythonType, formatSize, formatType } from "./catalog-formatters";
+import {
+  artifactRef,
+  isLatest,
+  latestVersionNumber,
+  totalPages as computeTotalPages,
+} from "./artifactVersions";
+import ArtifactPruneDialog from "./ArtifactPruneDialog.vue";
 import ShareDialog from "../../components/sharing/ShareDialog.vue";
 import SharedBadge from "../../components/sharing/SharedBadge.vue";
 import { useResourceSharing } from "../../composables/useResourceSharing";
 
 const showShareDialog = ref(false);
+const showPruneDialog = ref(false);
 const { canShare, canManage, canManageGrants } = useResourceSharing();
 
 const props = defineProps<{
   artifact: GlobalArtifact;
-  versions: GlobalArtifact[];
+  versions: ArtifactVersionInfo[];
+  totalVersions: number;
+  page: number;
+  loadingVersions?: boolean;
 }>();
 
-const emit = defineEmits(["close", "navigate-to-flow", "deleteArtifact"]);
+const emit = defineEmits([
+  "close",
+  "navigate-to-flow",
+  "deleteArtifact",
+  "deleteVersion",
+  "promoteVersion",
+  "setVersionsPage",
+  "versionsChanged",
+]);
 
 const catalogStore = useCatalogStore();
 
+const totalPages = computed(() => computeTotalPages(props.totalVersions));
+
+// Latest is the highest version number, never row-id equality: a promote mints a
+// new max version and leaves the panel's own row behind.
+const latestVersion = computed(() => latestVersionNumber(props.artifact.version, props.versions));
+
 const isUnavailable = computed(() => props.artifact.blob_exists === false);
+
+// Same fallback the Type meta card uses, so one artifact never reads two ways.
+const versionType = (v: ArtifactVersionInfo): string =>
+  formatPythonType(v.python_type, props.artifact.serialization_format ?? "unknown");
 
 const sourceFlowName = computed((): string | null => {
   const regId = props.artifact.source_registration_id;
@@ -209,14 +297,12 @@ const sourceFlowName = computed((): string | null => {
   return flow?.name ?? null;
 });
 
-// Namespace-qualify the usage snippet so it resolves unambiguously when the
-// same name exists in multiple schemas. Prefer the readable namespace name,
-// falling back to the id; omitted when the artifact has no namespace.
-const nsArg = computed((): string => {
+// Qualified reference for the usage snippet so it resolves unambiguously when
+// the same name exists in multiple schemas; bare name when unnamespaced.
+const usageRef = computed((): string => {
   const id = props.artifact.namespace_id;
-  if (id === null || id === undefined) return "";
-  const name = catalogStore.getNamespaceName(id);
-  return name ? `, namespace=${JSON.stringify(name)}` : `, namespace_id=${id}`;
+  const path = id === null || id === undefined ? [] : findNamespacePath(catalogStore.tree, id);
+  return artifactRef(props.artifact.name, path);
 });
 </script>
 
@@ -378,7 +464,7 @@ const nsArg = computed((): string => {
 
 .versions-header {
   display: grid;
-  grid-template-columns: 120px 1fr 80px 140px;
+  grid-template-columns: 120px 1fr 80px 140px 96px;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
   background: var(--color-background-tertiary);
@@ -391,7 +477,7 @@ const nsArg = computed((): string => {
 
 .versions-row {
   display: grid;
-  grid-template-columns: 120px 1fr 80px 140px;
+  grid-template-columns: 120px 1fr 80px 140px 96px;
   gap: var(--spacing-2);
   padding: var(--spacing-2) var(--spacing-3);
   font-size: var(--font-size-sm);
@@ -401,6 +487,14 @@ const nsArg = computed((): string => {
 
 .versions-row:hover {
   background: var(--color-background-hover);
+}
+
+.versions-loading {
+  padding: var(--spacing-4);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  border-top: 1px solid var(--color-border-light);
 }
 
 .versions-row.current {

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/ArtifactPruneDialog.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/ArtifactPruneDialog.vue
@@ -1,0 +1,159 @@
+<template>
+  <el-dialog
+    :model-value="modelValue"
+    title="Prune versions"
+    width="460px"
+    append-to-body
+    @update:model-value="emit('update:modelValue', $event)"
+    @open="reset"
+  >
+    <div class="dialog-warning">
+      <i class="fa-solid fa-triangle-exclamation"></i>
+      <span>
+        Pruning permanently deletes the data files of the older versions of
+        <strong>{{ artifactName }}</strong
+        >. The newest version is always kept. Run a dry run first.
+      </span>
+    </div>
+    <div class="dialog-field">
+      <label class="dialog-label">Versions to keep</label>
+      <el-input-number v-model="keep" :min="1" size="small" />
+      <p class="dialog-hint">
+        This model has {{ totalVersions }} version{{ totalVersions === 1 ? "" : "s" }}.
+        <span v-if="localEstimate !== null">
+          Keeping {{ keep }} would delete {{ localEstimate.count }} ({{
+            formatSize(localEstimate.freedBytes)
+          }}).
+        </span>
+      </p>
+    </div>
+    <div class="dialog-field">
+      <el-checkbox v-model="dryRun" size="small">
+        Dry run (list versions only, delete nothing)
+      </el-checkbox>
+    </div>
+    <div v-if="result" class="dialog-result">
+      <i class="fa-solid fa-circle-check"></i>
+      {{ result.deleted > 0 ? "Deleted" : "Would delete" }}
+      {{ resultCount }} version{{ resultCount === 1 ? "" : "s" }} ({{
+        formatSize(result.freed_bytes)
+      }}).
+    </div>
+    <template #footer>
+      <el-button size="small" @click="emit('update:modelValue', false)">Close</el-button>
+      <el-button size="small" :type="dryRun ? 'primary' : 'danger'" :loading="running" @click="run">
+        {{ dryRun ? "Run dry run" : "Delete versions" }}
+      </el-button>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { ElMessage } from "element-plus";
+import type { ArtifactPruneResult, ArtifactVersionInfo } from "../../types";
+import { useCatalogStore } from "../../stores/catalog-store";
+import { formatSize } from "./catalog-formatters";
+import { pruneCandidates } from "./artifactVersions";
+
+const props = defineProps<{
+  modelValue: boolean;
+  artifactName: string;
+  totalVersions: number;
+  versions: ArtifactVersionInfo[];
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: boolean): void;
+  (e: "pruned"): void;
+}>();
+
+const store = useCatalogStore();
+
+const keep = ref(5);
+const dryRun = ref(true);
+const running = ref(false);
+const result = ref<ArtifactPruneResult | null>(null);
+
+function reset() {
+  keep.value = 5;
+  dryRun.value = true;
+  result.value = null;
+}
+
+// Only meaningful while the loaded page covers the whole history; otherwise the
+// server dry run is the only honest preview.
+const localEstimate = computed((): { count: number; freedBytes: number } | null => {
+  if (props.versions.length < props.totalVersions) return null;
+  const { toDelete, freedBytes } = pruneCandidates(props.versions, keep.value);
+  return { count: toDelete.length, freedBytes };
+});
+
+const resultCount = computed((): number =>
+  result.value ? result.value.deleted || result.value.would_delete.length : 0,
+);
+
+async function run() {
+  running.value = true;
+  try {
+    result.value = await store.pruneArtifactVersions(keep.value, dryRun.value);
+    if (!dryRun.value) {
+      ElMessage.success(`Deleted ${result.value.deleted} versions`);
+      emit("pruned");
+    }
+  } catch (e: any) {
+    ElMessage.error(e?.response?.data?.detail ?? e?.message ?? "Prune failed");
+  } finally {
+    running.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.dialog-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+}
+
+.dialog-hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--color-text-tertiary);
+}
+
+.dialog-warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  margin-bottom: 12px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.dialog-warning i {
+  color: var(--color-warning, #f59e0b);
+  margin-top: 2px;
+}
+
+.dialog-result {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--color-success, #22c55e);
+  margin-top: 4px;
+}
+</style>

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/ArtifactPruneDialog.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/ArtifactPruneDialog.vue
@@ -54,7 +54,7 @@ import { ElMessage } from "element-plus";
 import type { ArtifactPruneResult, ArtifactVersionInfo } from "../../types";
 import { useCatalogStore } from "../../stores/catalog-store";
 import { formatSize } from "./catalog-formatters";
-import { pruneCandidates } from "./artifactVersions";
+import { apiErrorMessage, pruneCandidates } from "./artifactVersions";
 
 const props = defineProps<{
   modelValue: boolean;
@@ -102,7 +102,7 @@ async function run() {
       emit("pruned");
     }
   } catch (e: any) {
-    ElMessage.error(e?.response?.data?.detail ?? e?.message ?? "Prune failed");
+    ElMessage.error(apiErrorMessage(e, e?.message ?? "Prune failed"));
   } finally {
     running.value = false;
   }

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -564,7 +564,7 @@ import { useWritableNamespaces } from "../../composables/useWritableNamespaces";
 import { useFlowOpener } from "../../composables/useFlowOpener";
 import { useRecentFlows } from "../../composables/useRecentFlows";
 import { countMatches, normalizeQuery } from "./catalogTreeFilter";
-import { artifactRef, pageAfterDelete } from "./artifactVersions";
+import { apiErrorMessage, artifactRef, pageAfterDelete } from "./artifactVersions";
 import { useCatalogTreeExpansion } from "./useCatalogTreeExpansion";
 import { findNamespacePath } from "../../types";
 import { catalogTabs } from "./catalogTabs";
@@ -1106,7 +1106,7 @@ async function handleDeleteArtifactVersion(version: ArtifactVersionInfo) {
     await catalogStore.deleteArtifactVersion(version.id);
     await refreshArtifactVersions();
   } catch (e: any) {
-    ElMessage.error(e?.response?.data?.detail ?? "Failed to delete version");
+    ElMessage.error(apiErrorMessage(e, "Failed to delete version"));
   }
 }
 
@@ -1127,7 +1127,7 @@ async function handlePromoteArtifactVersion(version: ArtifactVersionInfo) {
     ElMessage.success(`Restored v${version.version} as v${promoted.version}`);
     await refreshArtifactVersions(1);
   } catch (e: any) {
-    ElMessage.error(e?.response?.data?.detail ?? "Failed to restore version");
+    ElMessage.error(apiErrorMessage(e, "Failed to restore version"));
   }
 }
 
@@ -1248,7 +1248,7 @@ async function handleDeleteArtifact(artifact: GlobalArtifact) {
     catalogStore.clearArtifactSelection();
     await Promise.all([catalogStore.loadTree(), catalogStore.loadStats()]);
   } catch (e: any) {
-    ElMessage.error(e?.response?.data?.detail ?? "Failed to delete model");
+    ElMessage.error(apiErrorMessage(e, "Failed to delete model"));
   }
 }
 

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/CatalogView.vue
@@ -150,10 +150,17 @@
         <ArtifactDetailPanel
           v-else-if="catalogStore.selectedArtifact"
           :artifact="catalogStore.selectedArtifact"
-          :versions="selectedArtifactVersions"
+          :versions="catalogStore.artifactVersions"
+          :total-versions="catalogStore.artifactVersionsTotal"
+          :page="catalogStore.artifactVersionsPage"
+          :loading-versions="catalogStore.loadingArtifactVersions"
           @close="handleCloseDetail"
           @navigate-to-flow="navigateToFlow($event)"
           @delete-artifact="handleDeleteArtifact($event)"
+          @delete-version="handleDeleteArtifactVersion($event)"
+          @promote-version="handlePromoteArtifactVersion($event)"
+          @set-versions-page="catalogStore.setArtifactVersionsPage($event)"
+          @versions-changed="refreshArtifactVersions()"
         />
         <!-- Namespace (catalog) settings view -->
         <NamespaceDetailPanel
@@ -557,11 +564,13 @@ import { useWritableNamespaces } from "../../composables/useWritableNamespaces";
 import { useFlowOpener } from "../../composables/useFlowOpener";
 import { useRecentFlows } from "../../composables/useRecentFlows";
 import { countMatches, normalizeQuery } from "./catalogTreeFilter";
+import { artifactRef, pageAfterDelete } from "./artifactVersions";
 import { useCatalogTreeExpansion } from "./useCatalogTreeExpansion";
 import { findNamespacePath } from "../../types";
 import { catalogTabs } from "./catalogTabs";
 import { useGraphicWalkerAppearance } from "../../composables/useGraphicWalkerAppearance";
 import type {
+  ArtifactVersionInfo,
   CatalogTab,
   CatalogTable,
   FlowRegistration,
@@ -1036,28 +1045,91 @@ function handleCloseDetail() {
   router.back();
 }
 
-/** Collect all versions of the selected artifact from the tree. */
-function collectArtifactVersions(
-  nodes: NamespaceTree[],
-  name: string,
-  nsId: number | null,
-): GlobalArtifact[] {
-  const result: GlobalArtifact[] = [];
-  for (const node of nodes) {
-    for (const a of node.artifacts ?? []) {
-      if (a.name === name && a.namespace_id === nsId) result.push(a);
-    }
-    result.push(...collectArtifactVersions(node.children, name, nsId));
-  }
-  return result;
+// Namespace-qualified reference so same-named models in other schemas can't bleed
+// into this artifact's version list.
+function selectedArtifactRef(a: GlobalArtifact): string {
+  const path = a.namespace_id === null ? [] : findNamespacePath(catalogStore.tree, a.namespace_id);
+  return artifactRef(a.name, path);
 }
 
-const selectedArtifactVersions = computed((): GlobalArtifact[] => {
-  const a = catalogStore.selectedArtifact;
-  if (!a) return [];
-  const versions = collectArtifactVersions(catalogStore.tree, a.name, a.namespace_id);
-  return versions.sort((x, y) => y.version - x.version);
-});
+watch(
+  () => {
+    const a = catalogStore.selectedArtifact;
+    return a ? `${a.namespace_id ?? ""}::${a.name}` : null;
+  },
+  () => {
+    const a = catalogStore.selectedArtifact;
+    if (!a) {
+      catalogStore.clearArtifactVersions();
+      return;
+    }
+    catalogStore.loadArtifactVersions(selectedArtifactRef(a), a.namespace_id, 1);
+  },
+  { immediate: true },
+);
+
+/**
+ * Post-mutation refresh: reload the version page (stepping back when the current
+ * page emptied out) and re-resolve the artifact itself, since promote mints a new
+ * latest row and the panel's stat cards must stay truthful.
+ */
+async function refreshArtifactVersions(page?: number) {
+  await catalogStore.reloadArtifactVersions(page);
+  const settled = pageAfterDelete(
+    catalogStore.artifactVersionsPage,
+    catalogStore.artifactVersionsTotal,
+  );
+  if (settled !== catalogStore.artifactVersionsPage) {
+    await catalogStore.reloadArtifactVersions(settled);
+  }
+  const previousId = catalogStore.selectedArtifactId;
+  await catalogStore.refreshSelectedArtifact();
+  const nextId = catalogStore.selectedArtifactId;
+  if (nextId !== null && nextId !== previousId) {
+    router.replace({ name: "catalog", query: { tab: "catalog", artifactId: String(nextId) } });
+  }
+  catalogStore.loadStats();
+}
+
+async function handleDeleteArtifactVersion(version: ArtifactVersionInfo) {
+  const name = catalogStore.selectedArtifact?.name ?? "";
+  try {
+    await ElMessageBox.confirm(
+      `Delete version v${version.version} of "${name}"? Its data file is removed permanently.`,
+      "Delete version",
+      { confirmButtonText: "Delete", cancelButtonText: "Cancel", type: "warning" },
+    );
+  } catch {
+    return; // User cancelled
+  }
+  try {
+    await catalogStore.deleteArtifactVersion(version.id);
+    await refreshArtifactVersions();
+  } catch (e: any) {
+    ElMessage.error(e?.response?.data?.detail ?? "Failed to delete version");
+  }
+}
+
+async function handlePromoteArtifactVersion(version: ArtifactVersionInfo) {
+  const name = catalogStore.selectedArtifact?.name ?? "";
+  try {
+    await ElMessageBox.confirm(
+      `Restore v${version.version} of "${name}"? It is copied forward as a new version, ` +
+        "so nothing is deleted and you can always come back.",
+      "Restore version",
+      { confirmButtonText: "Restore", cancelButtonText: "Cancel", type: "warning" },
+    );
+  } catch {
+    return; // User cancelled
+  }
+  try {
+    const promoted = await catalogStore.promoteArtifactVersion(version.id);
+    ElMessage.success(`Restored v${version.version} as v${promoted.version}`);
+    await refreshArtifactVersions(1);
+  } catch (e: any) {
+    ElMessage.error(e?.response?.data?.detail ?? "Failed to restore version");
+  }
+}
 
 function openCreateSchema(parentId: number) {
   createSchemaParentId.value = parentId;

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/artifactVersions.test.ts
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/artifactVersions.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { ArtifactVersionInfo } from "../../types";
+import {
+  ARTIFACT_VERSIONS_PAGE_SIZE,
+  artifactRef,
+  isLatest,
+  latestVersionNumber,
+  pageAfterDelete,
+  pruneCandidates,
+  totalPages,
+} from "./artifactVersions";
+
+const version = (v: number, sizeBytes: number | null = 100): ArtifactVersionInfo => ({
+  id: 1000 + v,
+  version: v,
+  created_at: "2026-08-01T00:00:00",
+  size_bytes: sizeBytes,
+  sha256: `sha-${v}`,
+  python_type: "xgboost.core.Booster",
+  blob_exists: true,
+});
+
+describe("artifactRef", () => {
+  it("qualifies the name with the namespace path", () => {
+    expect(artifactRef("churn", ["General", "news-predictions"])).toBe(
+      "General.news-predictions::churn",
+    );
+  });
+
+  it("falls back to the bare name without a namespace path", () => {
+    expect(artifactRef("churn", [])).toBe("churn");
+  });
+});
+
+describe("totalPages", () => {
+  it("floors at 1 for an empty list", () => {
+    expect(totalPages(0)).toBe(1);
+  });
+
+  it("does not add an empty page on an exact multiple", () => {
+    expect(totalPages(50, 25)).toBe(2);
+  });
+
+  it("counts a partial last page", () => {
+    expect(totalPages(51, 25)).toBe(3);
+  });
+
+  it("floors at 1 for a nonsensical page size", () => {
+    expect(totalPages(42, 0)).toBe(1);
+  });
+});
+
+describe("pageAfterDelete", () => {
+  it("steps back when the current page no longer exists", () => {
+    expect(pageAfterDelete(3, 50, 25)).toBe(2);
+  });
+
+  it("stays put while the page still has rows", () => {
+    expect(pageAfterDelete(2, 51, 25)).toBe(2);
+  });
+
+  it("never returns page 0 for an emptied list", () => {
+    expect(pageAfterDelete(4, 0, 25)).toBe(1);
+  });
+});
+
+describe("latestVersionNumber / isLatest", () => {
+  it("takes the artifact's own version when the page holds only older rows", () => {
+    expect(latestVersionNumber(42, [version(3), version(2)])).toBe(42);
+  });
+
+  it("takes a higher version from the loaded page", () => {
+    expect(latestVersionNumber(3, [version(43), version(3)])).toBe(43);
+  });
+
+  it("flags only the max version as latest", () => {
+    const latest = latestVersionNumber(42, [version(42), version(41)]);
+    expect(isLatest(42, latest)).toBe(true);
+    expect(isLatest(41, latest)).toBe(false);
+  });
+});
+
+describe("pruneCandidates", () => {
+  const versions = [version(5, 10), version(4, 20), version(3, null), version(2, 40), version(1)];
+
+  it("deletes nothing when keep covers the whole history", () => {
+    expect(pruneCandidates(versions, 5).toDelete).toEqual([]);
+    expect(pruneCandidates(versions, 9).toDelete).toEqual([]);
+  });
+
+  it("keeps only the newest when keep is 1", () => {
+    const { toDelete } = pruneCandidates(versions, 1);
+    expect(toDelete.map((v) => v.version)).toEqual([4, 3, 2, 1]);
+  });
+
+  it("never deletes the newest version even for keep < 1", () => {
+    const { toDelete } = pruneCandidates(versions, 0);
+    expect(toDelete.map((v) => v.version)).toEqual([4, 3, 2, 1]);
+  });
+
+  it("sums freed bytes treating null as 0", () => {
+    const { freedBytes } = pruneCandidates(versions, 2);
+    expect(freedBytes).toBe(140);
+  });
+
+  it("sorts an out-of-order list before slicing", () => {
+    const { toDelete } = pruneCandidates([version(1), version(5), version(3)], 2);
+    expect(toDelete.map((v) => v.version)).toEqual([1]);
+  });
+});
+
+describe("page size", () => {
+  it("matches the house page size", () => {
+    expect(ARTIFACT_VERSIONS_PAGE_SIZE).toBe(25);
+  });
+});

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/artifactVersions.ts
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/artifactVersions.ts
@@ -1,0 +1,56 @@
+// Pure helpers for the artifact version table. Kept Vue-free so the paging,
+// latest-version and prune rules stay unit-testable (vitest runs in node env).
+import type { ArtifactVersionInfo } from "../../types";
+
+export const ARTIFACT_VERSIONS_PAGE_SIZE = 25;
+
+/**
+ * Namespace-qualified reference (`catalog.schema::name`) understood by the
+ * by-name artifact routes. Falls back to the bare name when the artifact has no
+ * namespace path, which the backend still accepts.
+ */
+export function artifactRef(name: string, namespacePath: string[]): string {
+  return namespacePath.length > 0 ? `${namespacePath.join(".")}::${name}` : name;
+}
+
+export function totalPages(total: number, pageSize = ARTIFACT_VERSIONS_PAGE_SIZE): number {
+  if (pageSize <= 0) return 1;
+  return Math.max(1, Math.ceil(total / pageSize));
+}
+
+/** Page to land on once rows have been removed — steps back when the current page is gone. */
+export function pageAfterDelete(
+  page: number,
+  total: number,
+  pageSize = ARTIFACT_VERSIONS_PAGE_SIZE,
+): number {
+  return Math.min(Math.max(1, page), totalPages(total, pageSize));
+}
+
+/**
+ * Highest known version: the artifact's own latest plus anything on the loaded
+ * page. Row-id equality is not usable — it goes stale the moment a promote mints
+ * a new max version.
+ */
+export function latestVersionNumber(
+  artifactVersion: number,
+  versions: { version: number }[],
+): number {
+  return versions.reduce((max, v) => Math.max(max, v.version), artifactVersion);
+}
+
+export function isLatest(version: number, latestVersion: number): boolean {
+  return version === latestVersion;
+}
+
+/** Versions a prune would remove, keeping the newest `keep` (never fewer than one). */
+export function pruneCandidates(
+  versions: ArtifactVersionInfo[],
+  keep: number,
+): { toDelete: ArtifactVersionInfo[]; freedBytes: number } {
+  const kept = Math.max(1, Math.floor(keep));
+  const sorted = [...versions].sort((a, b) => b.version - a.version);
+  const toDelete = sorted.slice(kept);
+  const freedBytes = toDelete.reduce((sum, v) => sum + (v.size_bytes ?? 0), 0);
+  return { toDelete, freedBytes };
+}

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/artifactVersions.ts
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/artifactVersions.ts
@@ -43,6 +43,21 @@ export function isLatest(version: number, latestVersion: number): boolean {
   return version === latestVersion;
 }
 
+/**
+ * Human-readable message from an axios error whose `detail` may be a plain
+ * string (403/404), an {error_code, message} object (the 409 guards), or a
+ * FastAPI validation list (422) — never render an object into a toast.
+ */
+export function apiErrorMessage(e: unknown, fallback: string): string {
+  const detail = (e as { response?: { data?: { detail?: unknown } } })?.response?.data?.detail;
+  if (typeof detail === "string") return detail;
+  if (detail && typeof detail === "object" && !Array.isArray(detail)) {
+    const message = (detail as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return fallback;
+}
+
 /** Versions a prune would remove, keeping the newest `keep` (never fewer than one). */
 export function pruneCandidates(
   versions: ArtifactVersionInfo[],

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/catalog-formatters.ts
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/catalog-formatters.ts
@@ -25,12 +25,18 @@ export function formatSize(bytes: number | null | undefined): string {
   return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
 }
 
+/** Last dotted segment of a python type, e.g. "xgboost.core.Booster" -> "Booster". */
+export function formatPythonType(
+  pythonType: string | null | undefined,
+  fallback = "unknown",
+): string {
+  if (!pythonType) return fallback;
+  const parts = pythonType.split(".");
+  return parts[parts.length - 1];
+}
+
 export function formatType(artifact: GlobalArtifact): string {
-  if (artifact.python_type) {
-    const parts = artifact.python_type.split(".");
-    return parts[parts.length - 1];
-  }
-  return artifact.serialization_format ?? "unknown";
+  return formatPythonType(artifact.python_type, artifact.serialization_format ?? "unknown");
 }
 
 export function formatNumber(n: number | null | undefined): string {

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/catalogTreeFilter.ts
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/catalogTreeFilter.ts
@@ -51,7 +51,13 @@ export function groupArtifacts(artifacts: GlobalArtifact[]): ArtifactGroup[] {
   }
   return [...byName.entries()].map(([name, versions]) => {
     const sorted = [...versions].sort((a, b) => b.version - a.version);
-    return { name, latest: sorted[0], versionCount: versions.length };
+    // The tree ships one row per artifact with a server-side version_count; the
+    // row count is only a fallback for payloads that predate it.
+    return {
+      name,
+      latest: sorted[0],
+      versionCount: sorted[0].version_count ?? versions.length,
+    };
   });
 }
 

--- a/flowfile_frontend/tests/catalog-artifact-versions.spec.ts
+++ b/flowfile_frontend/tests/catalog-artifact-versions.spec.ts
@@ -1,0 +1,291 @@
+// E2E coverage for the catalog artifact version manager: server-paginated version
+// history, latest-version protection, per-version delete, and namespace isolation
+// of same-named models.
+//
+// STATUS: written but NEVER EXECUTED — the selectors and the seeding ladder still
+// need a real run to shake out. Fix in the validation stage before wiring into CI.
+//
+// Prerequisites (same as web-flow.spec.ts — no webServer block in the config):
+// 1. Start backend: poetry run flowfile_core (worker not needed)
+// 2. Start frontend: npm run dev:web (from flowfile_frontend)
+// 3. Run: npx playwright test tests/catalog-artifact-versions.spec.ts
+// Seeding writes artifact blobs straight to the path core hands back from
+// /artifacts/prepare-upload, so core must run on this machine (not in Docker).
+import { test, expect, APIRequestContext, Page } from "@playwright/test";
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const BASE_URL = process.env.TEST_URL || "http://localhost:8080";
+const API_URL = process.env.API_URL || "http://localhost:63578";
+
+const MODEL_NAME = "e2e_versioned_model";
+const SCHEMA_A = "e2e-models-a";
+const SCHEMA_B = "e2e-models-b";
+const VERSIONS_IN_A = 45; // > 25 so the pager has two pages
+const VERSIONS_IN_B = 2;
+const PAGE_SIZE = 25;
+
+interface Seeded {
+  namespaceId: number;
+  registrationId: number;
+  latestArtifactId: number;
+}
+
+async function getAuthToken(request: APIRequestContext): Promise<string> {
+  const tokenResponse = await request.post(`${API_URL}/auth/token`);
+  if (!tokenResponse.ok()) {
+    throw new Error(`Failed to get auth token: ${tokenResponse.status()}`);
+  }
+  return (await tokenResponse.json()).access_token;
+}
+
+async function navigateWithAuth(page: Page, token: string, targetUrl: string) {
+  await page.goto(targetUrl);
+  await page.waitForLoadState("networkidle");
+  const expirationTime = Date.now() + 60 * 60 * 1000;
+  await page.evaluate(
+    ({ token, expiration }: { token: string; expiration: number }) => {
+      localStorage.setItem("auth_token", token);
+      localStorage.setItem("auth_token_expiration", expiration.toString());
+    },
+    { token, expiration: expirationTime },
+  );
+  await page.reload();
+  await page.waitForLoadState("networkidle");
+}
+
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+/** Create (or reuse) a schema under the "General" catalog. */
+async function ensureSchema(
+  request: APIRequestContext,
+  token: string,
+  name: string,
+): Promise<number> {
+  const listed = await request.get(`${API_URL}/catalog/namespaces`, {
+    headers: authHeaders(token),
+  });
+  const namespaces = await listed.json();
+  const general = namespaces.find((n: any) => n.name === "General" && n.parent_id === null);
+  if (!general) throw new Error('No "General" catalog to seed into');
+
+  const children = await request.get(`${API_URL}/catalog/namespaces`, {
+    headers: authHeaders(token),
+    params: { parent_id: general.id },
+  });
+  const existing = (await children.json()).find((n: any) => n.name === name);
+  if (existing) return existing.id;
+
+  const created = await request.post(`${API_URL}/catalog/namespaces`, {
+    headers: authHeaders(token),
+    data: { name, parent_id: general.id },
+  });
+  return (await created.json()).id;
+}
+
+async function registerFlow(
+  request: APIRequestContext,
+  token: string,
+  name: string,
+  namespaceId: number,
+): Promise<number> {
+  const response = await request.post(`${API_URL}/catalog/flows`, {
+    headers: authHeaders(token),
+    data: { name, flow_path: `/tmp/${name}.flowfile`, namespace_id: namespaceId },
+  });
+  return (await response.json()).id;
+}
+
+/** prepare-upload -> write the blob at the path core hands back -> finalize. */
+async function publishVersion(
+  request: APIRequestContext,
+  token: string,
+  registrationId: number,
+  namespaceId: number,
+  payload: string,
+): Promise<number> {
+  const prepared = await request.post(`${API_URL}/artifacts/prepare-upload`, {
+    headers: authHeaders(token),
+    data: {
+      name: MODEL_NAME,
+      source_registration_id: registrationId,
+      serialization_format: "pickle",
+      namespace_id: namespaceId,
+      python_type: "builtins.dict",
+      python_module: "builtins",
+    },
+  });
+  if (!prepared.ok()) throw new Error(`prepare-upload failed: ${prepared.status()}`);
+  const { artifact_id, storage_key, path } = await prepared.json();
+
+  const bytes = Buffer.from(payload, "utf-8");
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, bytes);
+
+  const finalized = await request.post(`${API_URL}/artifacts/finalize`, {
+    headers: authHeaders(token),
+    data: {
+      artifact_id,
+      storage_key,
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      size_bytes: bytes.length,
+    },
+  });
+  if (!finalized.ok()) throw new Error(`finalize failed: ${finalized.status()}`);
+  return artifact_id;
+}
+
+async function seedNamespace(
+  request: APIRequestContext,
+  token: string,
+  schemaName: string,
+  versionCount: number,
+): Promise<Seeded> {
+  const namespaceId = await ensureSchema(request, token, schemaName);
+  const registrationId = await registerFlow(request, token, `${schemaName}-producer`, namespaceId);
+  const artifactIds: number[] = [];
+  for (let i = 1; i <= versionCount; i++) {
+    artifactIds.push(await publishVersion(request, token, registrationId, namespaceId, `v${i}`));
+  }
+  return {
+    namespaceId,
+    registrationId,
+    latestArtifactId: artifactIds[artifactIds.length - 1],
+  };
+}
+
+/** Drop the artifacts a run published; safe to call before anything is seeded. */
+async function cleanupArtifacts(request: APIRequestContext, token: string, schemaName: string) {
+  const ref = `General.${schemaName}::${MODEL_NAME}`;
+  await request.delete(`${API_URL}/artifacts/by-name/${encodeURIComponent(ref)}`, {
+    headers: authHeaders(token),
+  });
+}
+
+/**
+ * Undo the whole seeding ladder in reverse: artifacts, then the flow registration
+ * that owns them, then the schema. Without this every run grows the catalog DB.
+ */
+async function cleanupSeeded(
+  request: APIRequestContext,
+  token: string,
+  schemaName: string,
+  seeded: Seeded | undefined,
+) {
+  await cleanupArtifacts(request, token, schemaName);
+  if (!seeded) return;
+  await request.delete(`${API_URL}/catalog/flows/${seeded.registrationId}`, {
+    headers: authHeaders(token),
+  });
+  await request.delete(`${API_URL}/catalog/namespaces/${seeded.namespaceId}`, {
+    headers: authHeaders(token),
+  });
+}
+
+/** Version numbers rendered in the versions table, in DOM order. */
+async function renderedVersions(page: Page): Promise<string[]> {
+  return page.locator(".versions-row .col-version").allInnerTexts();
+}
+
+test.describe("Catalog artifact versions", () => {
+  let authToken: string;
+  let seededA: Seeded;
+  let seededB: Seeded;
+
+  test.beforeAll(async ({ request }) => {
+    authToken = await getAuthToken(request);
+    await cleanupArtifacts(request, authToken, SCHEMA_A);
+    await cleanupArtifacts(request, authToken, SCHEMA_B);
+    seededA = await seedNamespace(request, authToken, SCHEMA_A, VERSIONS_IN_A);
+    seededB = await seedNamespace(request, authToken, SCHEMA_B, VERSIONS_IN_B);
+  });
+
+  test.afterAll(async ({ request }) => {
+    await cleanupSeeded(request, authToken, SCHEMA_A, seededA);
+    await cleanupSeeded(request, authToken, SCHEMA_B, seededB);
+  });
+
+  test("paginates version history and protects the latest version", async ({ page }) => {
+    await navigateWithAuth(
+      page,
+      authToken,
+      `${BASE_URL}/#/main/catalog?tab=catalog&artifactId=${seededA.latestArtifactId}`,
+    );
+
+    const panel = page.locator(".artifact-detail");
+    await expect(panel).toBeVisible();
+
+    // "Total Versions" is the server count, not the page length.
+    await expect(panel.locator(".meta-card", { hasText: "Total Versions" })).toContainText(
+      String(VERSIONS_IN_A),
+    );
+
+    // First page: newest first, exactly one page worth of rows.
+    await expect(page.locator(".versions-row")).toHaveCount(PAGE_SIZE);
+    const firstPage = await renderedVersions(page);
+    expect(firstPage[0]).toContain(`v${VERSIONS_IN_A}`);
+    expect(firstPage[0]).toContain("latest");
+
+    // The latest row offers neither restore nor delete.
+    await expect(page.locator(".versions-row").first().locator(".col-actions button")).toHaveCount(
+      0,
+    );
+    await expect(page.locator(".versions-row").nth(1).locator(".col-actions button")).toHaveCount(
+      2,
+    );
+
+    // Pager advances to a disjoint second page.
+    const pager = page.locator(".pagination-bar");
+    await expect(pager).toBeVisible();
+    await expect(pager.locator(".page-info")).toHaveText("Page 1 of 2");
+    await pager.locator(".page-btn").nth(3).click(); // next
+    await expect(pager.locator(".page-info")).toHaveText("Page 2 of 2");
+
+    const secondPage = await renderedVersions(page);
+    expect(secondPage).toHaveLength(VERSIONS_IN_A - PAGE_SIZE);
+    expect(secondPage.some((row) => firstPage.includes(row))).toBe(false);
+  });
+
+  test("deletes a single non-latest version", async ({ page }) => {
+    await navigateWithAuth(
+      page,
+      authToken,
+      `${BASE_URL}/#/main/catalog?tab=catalog&artifactId=${seededA.latestArtifactId}`,
+    );
+    await expect(page.locator(".artifact-detail")).toBeVisible();
+
+    const before = await renderedVersions(page);
+    const target = before[1]; // second row: newest deletable version
+
+    await page.locator(".versions-row").nth(1).locator(".col-actions button").last().click();
+    await page.locator(".el-message-box__btns button", { hasText: "Delete" }).click();
+
+    await expect(page.locator(".versions-row").first()).toContainText("latest");
+    await expect.poll(async () => (await renderedVersions(page)).includes(target)).toBe(false);
+    await expect(
+      page.locator(".artifact-detail .meta-card", { hasText: "Total Versions" }),
+    ).toContainText(String(VERSIONS_IN_A - 1));
+  });
+
+  test("keeps same-named models in different schemas apart", async ({ page }) => {
+    // Both artifacts share a name; the version list is fetched with a
+    // namespace-qualified ref, so neither may show the other's history.
+    await navigateWithAuth(
+      page,
+      authToken,
+      `${BASE_URL}/#/main/catalog?tab=catalog&artifactId=${seededB.latestArtifactId}`,
+    );
+    await expect(page.locator(".artifact-detail")).toBeVisible();
+    await expect(
+      page.locator(".artifact-detail .meta-card", { hasText: "Total Versions" }),
+    ).toContainText(String(VERSIONS_IN_B));
+    await expect(page.locator(".versions-row")).toHaveCount(VERSIONS_IN_B);
+
+    // The tree lists the two families as separate rows under their own schemas.
+    await page.locator(".search-input").first().fill(MODEL_NAME);
+    await expect(page.locator(".tree-artifact", { hasText: MODEL_NAME })).toHaveCount(2);
+  });
+});

--- a/shared/artifact_storage.py
+++ b/shared/artifact_storage.py
@@ -96,6 +96,22 @@ class ArtifactStorageBackend(ABC):
         pass
 
     @abstractmethod
+    def copy(self, src_key: str, dst_key: str) -> int:
+        """Copy a stored blob to a new key, backend-natively (Core never streams bytes).
+
+        Args:
+            src_key: Storage key of the blob to copy.
+            dst_key: Storage key to copy it to.
+
+        Returns:
+            Size in bytes of the copied blob.
+
+        Raises:
+            FileNotFoundError: If the source blob does not exist.
+        """
+        pass
+
+    @abstractmethod
     def delete(self, storage_key: str) -> None:
         """Remove blob from storage.
 
@@ -181,6 +197,16 @@ class SharedFilesystemStorage(ArtifactStorageBackend):
             method="file",
             path=str(self.permanent / storage_key),
         )
+
+    def copy(self, src_key: str, dst_key: str) -> int:
+        """Copy a permanent blob to another key on the same filesystem."""
+        src = self.permanent / src_key
+        if not src.is_file():
+            raise FileNotFoundError(f"Artifact blob not found: {src}")
+        dst = self.permanent / dst_key
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        return dst.stat().st_size
 
     def delete(self, storage_key: str) -> None:
         """Delete blob from permanent storage."""
@@ -301,6 +327,23 @@ class S3Storage(ArtifactStorageBackend):
             method="s3_presigned",
             path=presigned_url,
         )
+
+    def copy(self, src_key: str, dst_key: str) -> int:
+        """Server-side copy within the bucket; no bytes pass through Core."""
+        src_s3_key = f"{self.prefix}{src_key}"
+        dst_s3_key = f"{self.prefix}{dst_key}"
+        try:
+            self.client.copy_object(
+                Bucket=self.bucket,
+                CopySource={"Bucket": self.bucket, "Key": src_s3_key},
+                Key=dst_s3_key,
+            )
+            head = self.client.head_object(Bucket=self.bucket, Key=dst_s3_key)
+        except self.client.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] in ("404", "NoSuchKey"):
+                raise FileNotFoundError(f"S3 object not found: {src_s3_key}") from e
+            raise
+        return head["ContentLength"]
 
     def delete(self, storage_key: str) -> None:
         """Delete object from S3."""

--- a/shared/tests/test_artifact_storage.py
+++ b/shared/tests/test_artifact_storage.py
@@ -169,6 +169,30 @@ class TestPrepareDownload:
         assert Path(source.path).read_bytes() == sample_data
 
 
+# Copy Tests
+
+
+class TestCopy:
+    """Tests for the backend-native blob copy (used by version promote)."""
+
+    def test_copies_blob_to_a_new_key(self, storage, sample_data, sample_sha256):
+        """Should duplicate the bytes under the new key and leave the source intact."""
+        target = storage.prepare_upload(artifact_id=1, filename="model.pkl")
+        Path(target.path).write_bytes(sample_data)
+        storage.finalize_upload(target.storage_key, sample_sha256)
+
+        size = storage.copy(target.storage_key, "2/model.pkl")
+
+        assert size == len(sample_data)
+        assert storage.exists("2/model.pkl")
+        assert storage.exists(target.storage_key)
+        assert Path(storage.prepare_download("2/model.pkl").path).read_bytes() == sample_data
+
+    def test_copy_missing_source_raises(self, storage):
+        with pytest.raises(FileNotFoundError):
+            storage.copy("999/missing.pkl", "1000/missing.pkl")
+
+
 # Delete Tests
 
 


### PR DESCRIPTION
This pull request introduces comprehensive improvements to artifact version management in the catalog, both in the backend API and user documentation. Key changes include new API endpoints for promoting, pruning, and deleting artifact versions with safety checks, expanded error handling, and updated documentation to clarify artifact reference and versioning behavior.

**Artifact version management and API enhancements:**
- Added new API endpoints to:
  - Promote an older artifact version as the new latest (`/artifacts/{artifact_id}/promote`), prune old versions while keeping the newest (`/artifacts/by-name/{name}/prune`), and paginate artifact version listings. [[1]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cR286-R348) [[2]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cL196-R264)
  - Enforced safety checks on deletion: Prevents deleting the latest version unless `force=true`, and blocks deleting the last version (must delete the artifact instead). Internal service calls can bypass these guards.
  - Added a `latest_only` filter to list only the newest active artifact versions per name/namespace. [[1]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cR172) [[2]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cR183)
- Improved error handling and responses:
  - Introduced new exception classes for invalid artifact names, and for guarded version deletions (`CannotDeleteLatestVersionError`, `CannotDeleteLastVersionError`).
  - Standardized 409 conflict responses with machine-readable error codes for ambiguous or guarded operations. [[1]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cR51-R95) [[2]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cL187-R231)
  - Added error handling for invalid artifact names during upload.
- Updated dependency injection to pass user context and enforce access control using `AccessResolver`.

**Documentation updates:**
- Expanded catalog documentation to:
  - Explain artifact reference forms (bare name vs. qualified `catalog.schema::name`), how ambiguity is handled, and the effect of version pinning. [[1]](diffhunk://#diff-1efead2b97b882485d6bd3cf97c04073397be6834fe884cd935542841d9596caR219-R232) [[2]](diffhunk://#diff-1efead2b97b882485d6bd3cf97c04073397be6834fe884cd935542841d9596caL198-R203) [[3]](diffhunk://#diff-1efead2b97b882485d6bd3cf97c04073397be6834fe884cd935542841d9596caL325-R344)
  - Document version management actions (restore, delete version, prune versions), including safety guarantees and permanence of deletes.
  - Clarify how artifact selection works in custom node settings and the behavior of global artifact selectors.
- Updated API documentation to reflect new/changed endpoints and behaviors. [[1]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cL166-R210) [[2]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cL196-R264) [[3]](diffhunk://#diff-ed5f7ed69fd90e7277cb99ff100a7859a5d60991e723d890a52d4ac25ccaa01cR286-R348)

**Testing improvements:**
- Added a new Playwright end-to-end test for catalog artifact version management.

These changes provide robust, user-friendly artifact version management, clearer error reporting, and improved documentation for both API consumers and end users.