### PR TITLE
fix: improve workbook locking mechanism to handle contention errors

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -364,6 +364,15 @@ jobs:
         shell: pwsh
         run: poetry run start_gcs
 
+      # Kafka tests need a broker; they run in test-kafka-integration.yml
+      - name: Run pytest for shared
+        if: |
+          needs.detect-changes.outputs.shared == 'true' ||
+          needs.detect-changes.outputs.test_workflow == 'true' ||
+          github.event.inputs.run_all_tests == 'true'
+        shell: pwsh
+        run: poetry run pytest shared/tests --ignore=shared/tests/kafka --disable-warnings
+
       - name: Run pytest for flowfile_frame
         if: |
           needs.detect-changes.outputs.backend_frame == 'true' ||

--- a/shared/excel_writer.py
+++ b/shared/excel_writer.py
@@ -20,9 +20,9 @@ unlocked last-writer-wins behavior.
 
 from __future__ import annotations
 
+import errno
 import os
 import shutil
-import tempfile
 import time
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Final
@@ -41,6 +41,10 @@ _NESTED_DTYPES: Final = (pl.List, pl.Array, pl.Struct, pl.Object)
 _LOCK_TIMEOUT_S: Final = 300.0
 _LOCK_POLL_S: Final = 0.05
 
+# Contention looks like EACCES/EAGAIN (msvcrt) or EWOULDBLOCK==EAGAIN (flock); anything else
+# (ENOLCK/EOPNOTSUPP on network filesystems, EBADF) means locking is broken and must fail fast.
+_CONTENTION_ERRNOS: Final = frozenset({errno.EACCES, errno.EAGAIN, errno.EDEADLK})
+
 if os.name == "nt":
     import msvcrt
 
@@ -48,8 +52,10 @@ if os.name == "nt":
         try:
             msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
             return True
-        except OSError:
-            return False
+        except OSError as exc:
+            if exc.errno in _CONTENTION_ERRNOS:
+                return False
+            raise
 
     def _unlock(fd: int) -> None:
         msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
@@ -61,8 +67,10 @@ else:
         try:
             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             return True
-        except OSError:
-            return False
+        except OSError as exc:
+            if exc.errno in _CONTENTION_ERRNOS:
+                return False
+            raise
 
     def _unlock(fd: int) -> None:
         fcntl.flock(fd, fcntl.LOCK_UN)
@@ -71,9 +79,9 @@ else:
 def _is_live_lockfile(fd: int, lock_path: str) -> bool:
     try:
         current = os.stat(lock_path)
+        held = os.fstat(fd)
     except OSError:
         return False
-    held = os.fstat(fd)
     return (current.st_dev, current.st_ino) == (held.st_dev, held.st_ino)
 
 
@@ -87,20 +95,26 @@ def _workbook_lock(path: str) -> Iterator[None]:
     open file cannot be unlinked, which makes the plain unlock-close-unlink order safe there.
     The OS releases the lock if the holder dies, so a killed write never wedges later runs.
     """
-    lock_path = os.path.abspath(path) + ".lock"
+    lock_path = os.path.realpath(path) + ".lock"
     deadline = time.monotonic() + _LOCK_TIMEOUT_S
     while True:
+        if time.monotonic() > deadline:
+            raise TimeoutError(f"Timed out waiting for the excel write lock on '{path}'.")
         fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
         try:
             while not _try_lock(fd):
                 if time.monotonic() > deadline:
                     raise TimeoutError(f"Timed out waiting for the excel write lock on '{path}'.")
                 time.sleep(_LOCK_POLL_S)
+            if _is_live_lockfile(fd, lock_path):
+                break
         except BaseException:
+            try:
+                _unlock(fd)
+            except OSError:
+                pass
             os.close(fd)
             raise
-        if _is_live_lockfile(fd, lock_path):
-            break
         _unlock(fd)
         os.close(fd)
     try:
@@ -160,10 +174,12 @@ def _next_table_name(wb: Workbook) -> str:
 
 
 def _save_atomically(wb: Workbook, path: str) -> None:
-    """Save *wb* over *path* via a same-directory temp file so a killed process cannot destroy it."""
-    directory = os.path.dirname(os.path.abspath(path)) or "."
-    fd, tmp_path = tempfile.mkstemp(dir=directory, suffix=".xlsx.tmp")
-    os.close(fd)
+    """Save *wb* over *path* via a temp file + ``os.replace`` so a killed process cannot destroy it.
+
+    The temp name is deterministic and only ever touched under the workbook lock, so an orphan
+    left by a killed writer is bounded to one per workbook and reclaimed by the next write.
+    """
+    tmp_path = path + ".tmp"
     try:
         wb.save(tmp_path)
         shutil.copymode(path, tmp_path)
@@ -174,15 +190,10 @@ def _save_atomically(wb: Workbook, path: str) -> None:
 
 
 def _write_fresh_atomically(df: pl.DataFrame, path: str, sheet: str) -> None:
-    """Write a brand-new workbook via a temp file + ``os.replace``, matching a direct write's perms."""
-    directory = os.path.dirname(os.path.abspath(path)) or "."
-    fd, tmp_path = tempfile.mkstemp(dir=directory, suffix=".xlsx.tmp")
-    os.close(fd)
+    """Write a brand-new workbook via a temp file + ``os.replace`` (same bounded temp-name scheme)."""
+    tmp_path = path + ".tmp"
     try:
         df.write_excel(tmp_path, worksheet=sheet)
-        umask = os.umask(0)
-        os.umask(umask)
-        os.chmod(tmp_path, 0o666 & ~umask)  # mkstemp creates 0600, unlike a plain write_excel
         os.replace(tmp_path, path)
     finally:
         if os.path.exists(tmp_path):
@@ -230,19 +241,23 @@ def write_excel_output(
     formulas and layout — intact. ``update`` against a missing file writes a fresh workbook.
 
     ``update`` and ``create`` hold the per-workbook lock, so parallel nodes filling different
-    sheets of one file merge sequentially and a concurrent ``create`` fails instead of racing.
+    sheets of one file merge sequentially and a concurrent ``create`` fails instead of racing;
+    both resolve symlinks first so every spelling of one workbook shares one lock and writes
+    through to the real file. Mixing an ``overwrite`` node with locked writers on one file is
+    unsupported — the unlocked overwrite can make a concurrent update fail loudly (BadZipFile).
     """
     sheet = sheet_name or "Sheet1"
     mode = resolve_excel_write_mode(write_mode)
     if mode == "overwrite":
         df.write_excel(path, worksheet=sheet)
         return
+    path = os.path.realpath(path)
     with _workbook_lock(path):
         exists = os.path.exists(path)
         if mode == "create":
             if exists:
                 raise FileExistsError(f"Cannot write '{path}': the file already exists (write mode 'create').")
-            df.write_excel(path, worksheet=sheet)
+            _write_fresh_atomically(df, path, sheet)
             return
         if exists:
             _update_sheet(df, path, sheet)

--- a/shared/tests/test_run_logs.py
+++ b/shared/tests/test_run_logs.py
@@ -54,7 +54,7 @@ def test_run_log_path_is_not_home_when_storage_dir_set(tmp_path, monkeypatch):
     monkeypatch.delenv("TESTING", raising=False)
     monkeypatch.setattr(storage, "_base_dir", tmp_path)
     resolved = run_log_path(7)
-    assert Path.home() not in resolved.parents
+    assert Path.home() / ".flowfile" not in resolved.parents
     assert Path.home() / ".flowfile" / "logs" != resolved.parent
 
 


### PR DESCRIPTION
This pull request improves the robustness and reliability of the Excel file writing logic in `shared/excel_writer.py`, particularly around file locking, atomic writes, and symlink handling. The changes ensure that concurrent access is handled more safely and that temporary files are managed deterministically, reducing the risk of data corruption or orphaned files. Additionally, the test workflow is updated to better isolate Kafka-related tests.

**Excel file locking and atomic write improvements:**

* Improved error handling in file locking: The `_try_lock` function now distinguishes between lock contention (which is handled gracefully) and other locking errors (which fail fast), using a defined set of contention error numbers (`_CONTENTION_ERRNOS`). [[1]](diffhunk://#diff-71c2ddc3009b6e4b287ace8fc5dca0db3bd538eb6a092fd2552292a4959549c0R44-R58) [[2]](diffhunk://#diff-71c2ddc3009b6e4b287ace8fc5dca0db3bd538eb6a092fd2552292a4959549c0L64-R73)
* Enhanced lock acquisition: The workbook lock now uses `os.path.realpath` to resolve symlinks, ensuring all references to a file share the same lock, and adds a timeout check before each lock attempt. [[1]](diffhunk://#diff-71c2ddc3009b6e4b287ace8fc5dca0db3bd538eb6a092fd2552292a4959549c0L90-L103) [[2]](diffhunk://#diff-71c2ddc3009b6e4b287ace8fc5dca0db3bd538eb6a092fd2552292a4959549c0L233-R260)
* Improved cleanup: The lockfile liveness check now ensures the lock is only considered valid if the lockfile matches the file descriptor, and unlock attempts are safely wrapped to avoid leaking file descriptors on exceptions. [[1]](diffhunk://#diff-71c2ddc3009b6e4b287ace8fc5dca0db3bd538eb6a092fd2552292a4959549c0R82-L76) [[2]](diffhunk://#diff-71c2ddc3009b6e4b287ace8fc5dca0db3bd538eb6a092fd2552292a4959549c0L90-L103)

**Atomic file write changes:**

* Deterministic temp file naming: Temporary files for atomic writes now use a fixed `.tmp` suffix instead of random names, making cleanup and orphan handling more predictable. [[1]](diffhunk://#diff-71c2ddc3009b6e4b287ace8fc5dca0db3bd538eb6a092fd2552292a4959549c0L163-R182) [[2]](diffhunk://#diff-71c2ddc3009b6e4b287ace8fc5dca0db3bd538eb6a092fd2552292a4959549c0L177-L185)
* Simplified permissions handling: The code for setting file permissions on new Excel files is removed, relying on the default behavior.

**Test workflow update:**

* The test workflow now runs shared tests (excluding Kafka integration tests) independently, clarifying test responsibilities and avoiding unnecessary Kafka broker setup.