### PR TITLE
fix: enhance context menu functionality for nodes and canvas functinos

### DIFF
--- a/flowfile_frontend/src/renderer/app/components/nodes/NodeWrapper.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/NodeWrapper.vue
@@ -1,12 +1,7 @@
 <!-- CustomNode.vue -->
 <template>
   <div v-bind="$attrs">
-    <div
-      class="custom-node-header"
-      data="description_display"
-      @contextmenu="onTitleClick"
-      @click.stop
-    >
+    <div class="custom-node-header" data="description_display" @dblclick="onTitleClick" @click.stop>
       <div>
         <div v-if="!editMode" class="description-display" :style="descriptionTextStyle" @click.stop>
           <div class="edit-icon" title="Edit description" @click.stop="toggleEditMode(true)">
@@ -48,7 +43,9 @@
         </div>
       </div>
     </div>
-    <div ref="nodeEl" class="custom-node" @contextmenu.prevent="showContextMenu">
+    <!-- Right-click bubbles to VueFlow's node handler → the canvas ContextMenu
+         (Canvas.vue @node-context-menu). This component no longer owns a menu. -->
+    <div ref="nodeEl" class="custom-node">
       <generic-node
         v-if="data.nodeTemplate"
         :node-id="data.id"
@@ -107,227 +104,29 @@
           {{ output.label }}
         </span>
       </div>
-
-      <!-- Teleport Context Menu to body -->
-      <Teleport v-if="showMenu" to="body">
-        <div ref="menuEl" class="context-menu" :style="contextMenuStyle">
-          <div class="context-menu-item" @click="openSettings">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <circle cx="12" cy="12" r="3"></circle>
-              <path
-                d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"
-              ></path>
-            </svg>
-            <span>Edit</span>
-          </div>
-          <div class="context-menu-item" @click="viewData">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-              <line x1="3" y1="9" x2="21" y2="9"></line>
-              <line x1="3" y1="15" x2="21" y2="15"></line>
-              <line x1="9" y1="3" x2="9" y2="21"></line>
-            </svg>
-            <span>View Data</span>
-          </div>
-          <div v-if="isRunFlowNode" class="context-menu-item" @click="openTargetFlow">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-              <polyline points="15 3 21 3 21 9"></polyline>
-              <line x1="10" y1="14" x2="21" y2="3"></line>
-            </svg>
-            <span>Go to Flow</span>
-          </div>
-          <div class="context-menu-item" @click="suggestNextNode">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M5 12h14"></path>
-              <path d="m12 5 7 7-7 7"></path>
-            </svg>
-            <span>Suggest next node…</span>
-          </div>
-          <div class="context-menu-item" @click="openNodeDocs">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-              <path d="M14 2v6h6"></path>
-              <line x1="16" y1="13" x2="8" y2="13"></line>
-              <line x1="16" y1="17" x2="8" y2="17"></line>
-              <line x1="10" y1="9" x2="8" y2="9"></line>
-            </svg>
-            <span>Read more</span>
-          </div>
-          <div class="context-menu-divider"></div>
-          <div class="context-menu-item" @click="runNode">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <polygon points="5 3 19 12 5 21 5 3"></polygon>
-            </svg>
-            <span>{{ isRunning ? "Running..." : "Run Now" }}</span>
-          </div>
-          <div class="context-menu-item" @click="toggleCache">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>
-              <path d="M3 3v5h5"></path>
-              <path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"></path>
-              <path d="M16 21h5v-5"></path>
-            </svg>
-            <span>{{ isCached ? "Disable Cache" : "Enable Cache" }}</span>
-          </div>
-          <div class="context-menu-divider"></div>
-          <div class="context-menu-item" @click="copyNode">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-            </svg>
-            <span>Copy</span>
-          </div>
-          <div class="context-menu-item context-menu-item-danger" @click="deleteNode">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M3 6h18"></path>
-              <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"></path>
-              <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-            </svg>
-            <span>Delete</span>
-          </div>
-        </div>
-      </Teleport>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// TODO(refactor): ~709 LOC. Plan to extract:
-//   - NodeContextMenu.vue (~lines 92-161, with positioning at ~263-283)
+// TODO(refactor): Plan to extract:
 //   - NodeDescriptionEditor.vue (~lines 11-48)
 //   - NodeHandles.vue: handle rendering loops (~lines 64-89)
-import { Handle, useNode } from "@vue-flow/core";
+// (The per-node context menu moved to the canvas ContextMenu —
+//  Canvas.vue @node-context-menu + composables/useContextMenu.)
+import { Handle } from "@vue-flow/core";
 import { computed, ref, onMounted, nextTick, watch, onUnmounted } from "vue";
-import { ElMessage } from "element-plus";
 import { useNodeStore } from "../../stores/column-store";
-import { useFlowStore } from "../../stores/flow-store";
-import { useEditorStore } from "../../stores/editor-store";
-import { useAiGhostNodeStore } from "../../stores/ai-ghost-node-store";
-import { VueFlowStore } from "@vue-flow/core";
-import {
-  copySingleNodeToBuffer,
-  writeSentinelToOsClipboard,
-} from "../../composables/useFlowClipboard";
-import { useFlowExecution } from "../../composables/useFlowExecution";
-import { CatalogApi } from "../../api/catalog.api";
-import { nodeDocsUrl } from "../../views/DesignerView/nodeDocsLinks";
-import { desktop } from "../../../lib/desktop";
 import GenericNode from "./GenericNode.vue";
 import ArtifactBadge from "./ArtifactBadge.vue";
-import type { NodeTemplate, NodeHandle, RunFlowReference } from "../../types";
+import type { NodeTemplate, NodeHandle } from "../../types";
 
 const nodeStore = useNodeStore();
-const flowStore = useFlowStore();
-const editorStore = useEditorStore();
-const ghostStore = useAiGhostNodeStore();
-// This component is the registered "custom-node", so VueFlow injects its node
-// context — read the node's own live position from it rather than a lookup.
-const currentVueFlowNode = useNode();
 const nodeEl = ref<HTMLElement | null>(null);
-const menuEl = ref<HTMLElement | null>(null);
-
-// Use the flow execution composable with persistent polling.
-// Getter form (not a snapshot number) so Save As doesn't leave the node
-// polling against the old flow id.
-const { triggerNodeFetch, isPollingActive } = useFlowExecution(
-  () => flowStore.flowId,
-  { interval: 2000, enabled: true },
-  {
-    persistPolling: true,
-    pollingKey: `node_wrapper_${flowStore.flowId}`,
-  },
-);
 
 const mouseX = ref<number>(0);
 const mouseY = ref<number>(0);
 const editMode = ref<boolean>(false);
-const showMenu = ref<boolean>(false);
-const contextMenuX = ref<number>(0);
-const contextMenuY = ref<number>(0);
-const isCached = ref<boolean>(false);
-const isRunning = ref<boolean>(false);
 
 const CHAR_LIMIT = 100;
 
@@ -368,218 +167,11 @@ const parameterInput = computed(() =>
   props.data.inputs.find((input) => input.kind === "parameter"),
 );
 
-const isRunFlowNode = computed(() => props.data.nodeTemplate?.item === "run_flow");
-
 const onTitleClick = (event: MouseEvent) => {
   toggleEditMode(true);
   mouseX.value = event.clientX;
   mouseY.value = event.clientY;
 };
-
-const showContextMenu = async (event: MouseEvent) => {
-  event.preventDefault();
-  event.stopPropagation();
-
-  if (editMode.value) {
-    toggleEditMode(false);
-  }
-
-  contextMenuX.value = event.clientX;
-  contextMenuY.value = event.clientY;
-  showMenu.value = true;
-
-  try {
-    const nodeData = await nodeStore.getNodeData(props.data.id, true);
-    if (nodeData && nodeData.setting_input) {
-      isCached.value = nodeData.setting_input.cache_results || false;
-    }
-  } catch (error) {
-    console.error("Error loading node data:", error);
-  }
-
-  setTimeout(() => {
-    window.addEventListener("click", handleClickOutsideMenu);
-  }, 0);
-
-  nextTick(() => {
-    updateMenuPosition();
-  });
-};
-
-const updateMenuPosition = () => {
-  if (!menuEl.value) return;
-
-  const menuRect = menuEl.value.getBoundingClientRect();
-  const viewportWidth = window.innerWidth;
-  const viewportHeight = window.innerHeight;
-
-  let left = contextMenuX.value;
-  let top = contextMenuY.value;
-
-  if (left + menuRect.width > viewportWidth - 10) {
-    left = viewportWidth - menuRect.width - 10;
-  }
-
-  if (top + menuRect.height > viewportHeight - 10) {
-    top = viewportHeight - menuRect.height - 10;
-  }
-
-  contextMenuX.value = left;
-  contextMenuY.value = top;
-};
-
-const handleClickOutsideMenu = (event: MouseEvent) => {
-  if (menuEl.value && !menuEl.value.contains(event.target as Node)) {
-    closeContextMenu();
-  }
-};
-
-const handleWindowResize = () => {
-  if (showMenu.value) {
-    updateMenuPosition();
-  }
-};
-
-const closeContextMenu = () => {
-  showMenu.value = false;
-  window.removeEventListener("click", handleClickOutsideMenu);
-};
-
-const openSettings = () => {
-  editorStore.requestNodeSettings(props.data.id);
-  closeContextMenu();
-};
-
-const viewData = () => {
-  editorStore.requestNodeData(props.data.id);
-  closeContextMenu();
-};
-
-const suggestNextNode = () => {
-  closeContextMenu();
-  const flowId = flowStore.flowId;
-  if (flowId === null) return;
-  // Popover anchors at the menu's screen position; the materialised node is
-  // placed relative to this node's own flow-coords position.
-  const pos = currentVueFlowNode.node.computedPosition ??
-    currentVueFlowNode.node.position ?? { x: 0, y: 0 };
-  ghostStore.beginIntent(
-    {
-      upstreamNodeId: props.data.id,
-      screenX: contextMenuX.value,
-      screenY: contextMenuY.value,
-      nodeX: pos.x,
-      nodeY: pos.y,
-    },
-    flowId,
-  );
-};
-
-// nodeTemplate is optional (a stale copy/paste blob can lack it); nodeDocsUrl
-// falls back to the node reference index rather than failing.
-const openNodeDocs = () => {
-  closeContextMenu();
-  void desktop.openExternal(nodeDocsUrl(props.data.nodeTemplate));
-};
-
-const openTargetFlow = async () => {
-  closeContextMenu();
-  try {
-    const nodeData = await nodeStore.getNodeData(props.data.id, false);
-    const flowRef = nodeData?.setting_input?.flow_reference as RunFlowReference | undefined;
-    const registrationId = flowRef?.registration_id ?? 0;
-    let flowPath = flowRef?.flow_path ?? null;
-    let name: string | undefined;
-    if (registrationId > 0) {
-      try {
-        const reg = await CatalogApi.getFlow(registrationId);
-        flowPath = reg?.flow_path ?? flowPath;
-        name = reg?.name;
-      } catch {
-        // Registration lookup failed (e.g. deleted) — fall back to stored path.
-      }
-    }
-    if (!flowPath) {
-      ElMessage.warning("No target flow is selected for this node.");
-      return;
-    }
-    editorStore.requestOpenFlow(flowPath, name);
-  } catch (error) {
-    console.error("Error opening target flow:", error);
-  }
-};
-
-const copyNode = () => {
-  // Shared writer with Canvas's copy path; this one knows the live description.
-  const sentinel = copySingleNodeToBuffer(props.data, nodeStore.flow_id, description.value);
-  void writeSentinelToOsClipboard(sentinel);
-  closeContextMenu();
-};
-
-const deleteNode = () => {
-  if (nodeStore.vueFlowInstance) {
-    const vueFlow: VueFlowStore = nodeStore.vueFlowInstance;
-    vueFlow.removeNodes(props.data.id.toLocaleString(), true);
-  }
-  closeContextMenu();
-};
-
-const runNode = async () => {
-  closeContextMenu();
-
-  if (isPollingActive(`node_${props.data.id}`)) {
-    return;
-  }
-
-  isRunning.value = true;
-  try {
-    await triggerNodeFetch(props.data.id);
-
-    const checkInterval = setInterval(() => {
-      if (!isPollingActive(`node_${props.data.id}`)) {
-        clearInterval(checkInterval);
-        isRunning.value = false;
-      }
-    }, 1000);
-
-    setTimeout(() => {
-      clearInterval(checkInterval);
-      isRunning.value = false;
-    }, 60000);
-  } catch (error) {
-    console.error("Error running node:", error);
-    isRunning.value = false;
-  }
-};
-
-const toggleCache = async () => {
-  try {
-    const nodeData = await nodeStore.getNodeData(props.data.id, false);
-    if (nodeData && nodeData.setting_input) {
-      const newCacheValue = !nodeData.setting_input.cache_results;
-      nodeData.setting_input.cache_results = newCacheValue;
-      isCached.value = newCacheValue;
-      await nodeStore.updateSettingsDirectly(nodeData.setting_input);
-    }
-  } catch (error) {
-    console.error("Error toggling cache:", error);
-  }
-  closeContextMenu();
-};
-
-onUnmounted(() => {
-  window.removeEventListener("click", handleClickOutsideMenu);
-  window.removeEventListener("resize", handleWindowResize);
-});
-
-const contextMenuStyle = computed(() => {
-  return {
-    position: "fixed" as const,
-    zIndex: 10000,
-    top: `${contextMenuY.value}px`,
-    left: `${contextMenuX.value}px`,
-  };
-});
 
 const descriptionTextStyle = computed(() => {
   const textLength = description.value.length;
@@ -609,14 +201,22 @@ const handleClickOutside = (event: MouseEvent) => {
   }
 };
 
+// Baseline captured on entering edit mode: leaving without a change must not
+// POST — an untouched auto-generated description would otherwise be pinned as
+// a user description and stop regenerating.
+let descriptionAtEditStart = "";
+
 const toggleEditMode = (state: boolean) => {
+  if (state === editMode.value) return;
   editMode.value = state;
   if (state) {
+    descriptionAtEditStart = description.value;
     window.addEventListener("click", handleClickOutside);
-  }
-  if (!state) {
+  } else {
     window.removeEventListener("click", handleClickOutside);
-    nodeStore.setNodeDescription(props.data.id, description.value);
+    if (description.value !== descriptionAtEditStart) {
+      nodeStore.setNodeDescription(props.data.id, description.value);
+    }
   }
 };
 
@@ -689,24 +289,28 @@ function getHandleStyle(index: number, total: number) {
   }
 }
 
+// Registered at setup level (not inside onMounted's async body) so Vue ties it
+// to the component's effect scope and stops it on unmount.
+watch(
+  () => {
+    const flowId = nodeStore.flow_id;
+    const nodeId = props.data.id;
+    return nodeStore.nodeDescriptions[flowId]?.[nodeId];
+  },
+  (newEntry) => {
+    if (newEntry !== undefined) {
+      description.value = newEntry.description;
+    }
+  },
+);
+
 onMounted(async () => {
   await nextTick();
   await getNodeDescription();
+});
 
-  window.addEventListener("resize", handleWindowResize);
-
-  watch(
-    () => {
-      const flowId = nodeStore.flow_id;
-      const nodeId = props.data.id;
-      return nodeStore.nodeDescriptions[flowId]?.[nodeId];
-    },
-    (newEntry) => {
-      if (newEntry !== undefined) {
-        description.value = newEntry.description;
-      }
-    },
-  );
+onUnmounted(() => {
+  window.removeEventListener("click", handleClickOutside);
 });
 </script>
 
@@ -860,59 +464,5 @@ onMounted(async () => {
 
 .handle-label--output {
   right: 13px;
-}
-
-.context-menu {
-  position: fixed;
-  z-index: var(--z-index-canvas-context-menu, 100002);
-  background-color: var(--color-background-primary);
-  border: 1px solid var(--color-border-primary);
-  border-radius: 4px;
-  box-shadow: var(--shadow-lg);
-  padding: 4px 0;
-  min-width: 120px;
-  font-family: var(--font-family-base);
-}
-
-.context-menu-item {
-  padding: 8px 12px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  font-size: 13px;
-  transition: background-color 0.2s;
-  font-family: var(--font-family-base);
-  color: var(--color-text-primary);
-}
-
-.context-menu-item:hover {
-  background-color: var(--color-background-hover);
-}
-
-.context-menu-item svg {
-  color: var(--color-text-secondary);
-}
-
-.context-menu-item span {
-  font-family: var(--font-family-base);
-}
-
-.context-menu-divider {
-  height: 1px;
-  background-color: var(--color-border-primary);
-  margin: 4px 0;
-}
-
-.context-menu-item-danger {
-  color: #dc3545;
-}
-
-.context-menu-item-danger:hover {
-  background-color: rgba(220, 53, 69, 0.1);
-}
-
-.context-menu-item-danger svg {
-  color: #dc3545;
 }
 </style>

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/groupBy/GroupBy.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/groupBy/GroupBy.vue
@@ -26,25 +26,13 @@
           </template>
         </ul>
       </div>
-      <div
-        v-if="showContextMenu"
-        ref="contextMenuRef"
-        class="context-menu"
-        :style="{
-          top: contextMenuPosition.y + 'px',
-          left: contextMenuPosition.x + 'px',
-        }"
-      >
-        <button @click="setAggregations('groupby', selectedColumns)">Group by</button>
-        <template v-for="option in singleColumnAggOptions" :key="option.value">
-          <button
-            v-if="singleColumnSelected"
-            @click="setAggregations(option.value, selectedColumns)"
-          >
-            {{ option.label }}
-          </button>
-        </template>
-      </div>
+      <context-menu
+        v-if="activeMenu"
+        :position="contextMenuPosition"
+        :options="menuOptions"
+        @select="onMenuSelect"
+        @close="activeMenu = null"
+      />
 
       <div class="listbox-subtitle">Settings</div>
 
@@ -59,7 +47,7 @@
           </thead>
           <tbody>
             <template v-for="(item, index) in groupByInput.agg_cols" :key="index">
-              <tr @contextmenu.prevent="openRowContextMenu($event, index)">
+              <tr @contextmenu="openRowContextMenu($event, index)">
                 <td>{{ item.old_name }}</td>
                 <td>
                   <el-select v-model="item.agg" size="small">
@@ -84,23 +72,13 @@
           </tbody>
         </table>
       </div>
-      <div
-        v-if="showContextMenuRemove"
-        class="context-menu"
-        :style="{
-          top: contextMenuPosition.y + 'px',
-          left: contextMenuPosition.x + 'px',
-        }"
-      >
-        <button @click="removeRow">Remove</button>
-      </div>
     </generic-node-settings>
   </div>
   <CodeLoader v-else />
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, onUnmounted, computed, nextTick } from "vue";
+import { ref, computed } from "vue";
 import { GroupByInput, NodeGroupBy, AggOption, GroupByOption } from "../../../baseNode/nodeInput";
 import { CodeLoader } from "vue-content-loader";
 import { NodeData } from "../../../baseNode/nodeInterfaces";
@@ -108,6 +86,8 @@ import { useNodeStore } from "../../../../../stores/node-store";
 import { useNodeSettings } from "../../../../../composables/useNodeSettings";
 import { NO_AUTOFILL } from "../../../../../utils/noAutofill";
 import GenericNodeSettings from "../../../baseNode/genericNodeSettings.vue";
+import { ContextMenu } from "../../../../common";
+import type { ContextMenuOption } from "../../../../common";
 
 const nodeStore = useNodeStore();
 const nodeGroupBy = ref<null | NodeGroupBy>(null);
@@ -118,12 +98,11 @@ const { saveSettings, pushNodeData, handleGenericSettingsUpdate } = useNodeSetti
     validateConfig();
   },
 });
-const showContextMenu = ref(false);
-const showContextMenuRemove = ref(false);
+// One menu at a time: the column menu and the agg-row menu are mutually
+// exclusive by construction (a single enum instead of two booleans).
+const activeMenu = ref<"column" | "row" | null>(null);
 const dataLoaded = ref(false);
 const contextMenuPosition = ref({ x: 0, y: 0 });
-const contextMenuColumn = ref<string | null>(null);
-const contextMenuRef = ref<HTMLElement | null>(null);
 const selectedColumns = ref<string[]>([]);
 const nodeData = ref<null | NodeData>(null);
 const aggOptions: (AggOption | GroupByOption)[] = [
@@ -182,17 +161,19 @@ const onDropInTable = () => {
 };
 
 const openRowContextMenu = (event: MouseEvent, index: number) => {
+  // Right-clicks on the row's editable fields keep the native menu (paste).
+  const el = event.target as HTMLElement | null;
+  if (el?.closest?.("input, textarea")) return;
   event.preventDefault();
   contextMenuPosition.value = { x: event.clientX, y: event.clientY };
   contextMenuRowIndex.value = index;
-  showContextMenuRemove.value = true;
+  activeMenu.value = "row";
 };
 
 const removeRow = () => {
   if (contextMenuRowIndex.value !== null) {
     groupByInput.value.agg_cols.splice(contextMenuRowIndex.value, 1);
   }
-  showContextMenuRemove.value = false;
   contextMenuRowIndex.value = null;
 };
 
@@ -207,7 +188,27 @@ const openContextMenu = (clickedIndex: number, columnName: string, event: MouseE
     selectedColumns.value = [columnName];
   }
   contextMenuPosition.value = { x: event.clientX, y: event.clientY };
-  showContextMenu.value = true;
+  activeMenu.value = "column";
+};
+
+const menuOptions = computed<ContextMenuOption[]>(() => {
+  if (activeMenu.value === "row") {
+    return [{ label: "Remove", action: "remove", danger: true }];
+  }
+  return [
+    { label: "Group by", action: "groupby" },
+    ...(singleColumnSelected.value
+      ? singleColumnAggOptions.map((option) => ({ label: option.label, action: option.value }))
+      : []),
+  ];
+});
+
+const onMenuSelect = (action: string) => {
+  if (activeMenu.value === "row") {
+    if (action === "remove") removeRow();
+    return;
+  }
+  setAggregations(action as AggOption | GroupByOption, selectedColumns.value);
 };
 
 const setAggregations = (aggType: AggOption | GroupByOption, columns: string[] | null) => {
@@ -222,8 +223,6 @@ const setAggregations = (aggType: AggOption | GroupByOption, columns: string[] |
       });
     });
   }
-  showContextMenu.value = false;
-  contextMenuColumn.value = null;
 };
 
 const handleItemMouseDown = (event: MouseEvent) => {
@@ -294,14 +293,6 @@ const loadNodeData = async (nodeId: number) => {
   dataLoaded.value = true;
 };
 
-const handleClickOutside = (event: MouseEvent) => {
-  if (!contextMenuRef.value?.contains(event.target as Node)) {
-    showContextMenu.value = false;
-    contextMenuColumn.value = null;
-    showContextMenuRemove.value = false;
-  }
-};
-
 // Missing-column warnings come from the backend settings validation; this only
 // covers configuration completeness the backend does not check.
 const validateConfig = () => {
@@ -323,15 +314,6 @@ defineExpose({
   loadNodeData,
   pushNodeData,
   saveSettings,
-});
-
-onMounted(async () => {
-  await nextTick();
-  window.addEventListener("click", handleClickOutside);
-});
-
-onUnmounted(() => {
-  window.removeEventListener("click", handleClickOutside);
 });
 </script>
 

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/sort/Sort.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/sort/Sort.vue
@@ -20,25 +20,13 @@
           </li>
         </ul>
       </div>
-      <div
-        v-if="showContextMenu"
-        ref="contextMenuRef"
-        class="context-menu"
-        :style="{
-          top: contextMenuPosition.y + 'px',
-          left: contextMenuPosition.x + 'px',
-        }"
-      >
-        <button v-if="!singleColumnSelected" @click="setSortSettings('Ascending', selectedColumns)">
-          Ascending
-        </button>
-        <button v-if="singleColumnSelected" @click="setSortSettings('Ascending', selectedColumns)">
-          Ascending
-        </button>
-        <button v-if="singleColumnSelected" @click="setSortSettings('Descending', selectedColumns)">
-          Descending
-        </button>
-      </div>
+      <context-menu
+        v-if="activeMenu"
+        :position="contextMenuPosition"
+        :options="menuOptions"
+        @select="onMenuSelect"
+        @close="activeMenu = null"
+      />
 
       <div class="listbox-wrapper">
         <div class="listbox-subtitle">Settings</div>
@@ -55,7 +43,7 @@
               <tr
                 v-for="(item, index) in nodeSort.sort_input"
                 :key="index"
-                @contextmenu.prevent="openRowContextMenu($event, index)"
+                @contextmenu="openRowContextMenu($event, index)"
               >
                 <td>{{ item.column }}</td>
                 <td>
@@ -72,16 +60,6 @@
             </tbody>
           </table>
         </div>
-        <div
-          v-if="showContextMenuRemove"
-          class="context-menu"
-          :style="{
-            top: contextMenuPosition.y + 'px',
-            left: contextMenuPosition.x + 'px',
-          }"
-        >
-          <button @click="removeRow">Remove</button>
-        </div>
       </div>
     </generic-node-settings>
   </div>
@@ -96,6 +74,8 @@ import { useNodeStore } from "../../../../../stores/node-store";
 import { useNodeSettings } from "../../../../../composables/useNodeSettings";
 import { CodeLoader } from "vue-content-loader";
 import GenericNodeSettings from "../../../baseNode/genericNodeSettings.vue";
+import { ContextMenu } from "../../../../common";
+import type { ContextMenuOption } from "../../../../common";
 
 const nodeStore = useNodeStore();
 const nodeSort = ref<null | NodeSort>(null);
@@ -103,29 +83,30 @@ const nodeSort = ref<null | NodeSort>(null);
 const { saveSettings, pushNodeData, handleGenericSettingsUpdate } = useNodeSettings({
   nodeRef: nodeSort,
 });
-const showContextMenu = ref(false);
-const showContextMenuRemove = ref(false);
+// One menu at a time: the column menu and the sort-row menu are mutually
+// exclusive by construction (a single enum instead of two booleans).
+const activeMenu = ref<"column" | "row" | null>(null);
 const dataLoaded = ref(false);
 const contextMenuPosition = ref({ x: 0, y: 0 });
-const contextMenuColumn = ref<string | null>(null);
-const contextMenuRef = ref<HTMLElement | null>(null);
 const selectedColumns = ref<string[]>([]);
 const nodeData = ref<null | NodeData>(null);
 const sortOptions = ["Ascending", "Descending"];
 const firstSelectedIndex = ref<number | null>(null);
 
 const openRowContextMenu = (event: MouseEvent, index: number) => {
+  // Right-clicks on the row's editable fields keep the native menu (paste).
+  const el = event.target as HTMLElement | null;
+  if (el?.closest?.("input, textarea")) return;
   event.preventDefault();
   contextMenuPosition.value = { x: event.clientX, y: event.clientY };
   contextMenuRowIndex.value = index;
-  showContextMenuRemove.value = true;
+  activeMenu.value = "row";
 };
 
 const removeRow = () => {
   if (contextMenuRowIndex.value !== null) {
     nodeSort.value?.sort_input.splice(contextMenuRowIndex.value, 1);
   }
-  showContextMenuRemove.value = false;
   contextMenuRowIndex.value = null;
 };
 
@@ -140,7 +121,25 @@ const openContextMenu = (clickedIndex: number, columnName: string, event: MouseE
     selectedColumns.value = [columnName];
   }
   contextMenuPosition.value = { x: event.clientX, y: event.clientY };
-  showContextMenu.value = true;
+  activeMenu.value = "column";
+};
+
+const menuOptions = computed<ContextMenuOption[]>(() => {
+  if (activeMenu.value === "row") {
+    return [{ label: "Remove", action: "remove", danger: true }];
+  }
+  return [
+    { label: "Ascending", action: "Ascending" },
+    ...(singleColumnSelected.value ? [{ label: "Descending", action: "Descending" }] : []),
+  ];
+});
+
+const onMenuSelect = (action: string) => {
+  if (activeMenu.value === "row") {
+    if (action === "remove") removeRow();
+    return;
+  }
+  setSortSettings(action, selectedColumns.value);
 };
 
 const setSortSettings = (sortType: string, columns: string[] | null) => {
@@ -149,8 +148,6 @@ const setSortSettings = (sortType: string, columns: string[] | null) => {
       nodeSort.value?.sort_input.push({ column: column, how: sortType });
     });
   }
-  showContextMenu.value = false;
-  contextMenuColumn.value = null;
 };
 
 const handleItemMouseDown = (event: MouseEvent) => {

--- a/flowfile_frontend/src/renderer/app/composables/useContextMenu.ts
+++ b/flowfile_frontend/src/renderer/app/composables/useContextMenu.ts
@@ -1,0 +1,140 @@
+import { ref } from "vue";
+
+import type { GraphNode, NodeMouseEvent } from "@vue-flow/core";
+
+import { NodeApi } from "../api";
+import { useFlowStore } from "../stores/flow-store";
+import type { NodeTemplate } from "../types/flow.types";
+import { isNodeBufferArmed } from "./useFlowClipboard";
+
+export type ContextMenuTargetType = "node" | "edge" | "pane" | "selection";
+
+export interface ContextMenuTarget {
+  type: ContextMenuTargetType;
+  id: string;
+}
+
+/**
+ * Canvas context-menu state and open/close handling, extracted from Canvas.vue
+ * per its TODO(refactor) plan.
+ *
+ * Owns which target the menu is open for, where it opens, and the lazily
+ * hydrated per-node facts the menu renders (cache flag, run_flow-ness,
+ * running state). Action dispatch stays in Canvas.vue, which holds the
+ * VueFlow instance and the flow-level composables.
+ *
+ * Hydration is deliberately slot-free: it calls NodeApi.getNodeData with
+ * include_inputs=false and never writes nodeStore.nodeData. The store's
+ * single cache slot belongs to the node whose settings drawer is open — a
+ * right-click must not clobber it, nor trigger the expensive
+ * include_inputs=true path, which resolves upstream schemas and can execute
+ * un-run upstream nodes.
+ */
+export function useContextMenu(options: {
+  /** Called when a node target opens, so the node can join the selection. */
+  onNodeTargeted?: (node: GraphNode) => void;
+  /** Whether the node is currently executing (drives the Run Now label). */
+  isNodeRunning?: (nodeId: number) => boolean;
+}) {
+  const flowStore = useFlowStore();
+
+  const showContextMenu = ref(false);
+  const menuPosition = ref({ x: 0, y: 0 });
+  const target = ref<ContextMenuTarget>({ type: "pane", id: "" });
+  const targetInGroup = ref(false);
+  // Snapshot of the node-copy buffer at open time, so the template doesn't hit
+  // localStorage on every re-render.
+  const canPasteNode = ref(false);
+  const targetIsRunFlow = ref(false);
+  const targetIsRunning = ref(false);
+  // null = hydration in flight; the menu shows a neutral, disabled label.
+  const targetCacheResults = ref<boolean | null>(null);
+
+  // Bumped on every open/close so a stale hydration response can't write into
+  // a menu that has since closed or re-opened for another node.
+  let hydrateToken = 0;
+
+  const isEditableTarget = (event: Event): boolean => {
+    const el = event.target as HTMLElement | null;
+    return Boolean(
+      el?.closest?.('input, textarea, .cm-editor, [contenteditable]:not([contenteditable="false"])'),
+    );
+  };
+
+  const openMenu = (t: ContextMenuTarget, x: number, y: number) => {
+    hydrateToken++;
+    canPasteNode.value = isNodeBufferArmed();
+    menuPosition.value = { x, y };
+    target.value = t;
+    showContextMenu.value = true;
+  };
+
+  const openForPane = (event: Event) => {
+    event.preventDefault();
+    const pointerEvent = event as PointerEvent;
+    targetInGroup.value = false;
+    openMenu({ type: "pane", id: "" }, pointerEvent.x, pointerEvent.y);
+  };
+
+  const openForNode = ({ event, node }: NodeMouseEvent) => {
+    // Editable fields inside a node (the description textarea) keep the
+    // native menu so right-click paste still works there.
+    if (isEditableTarget(event)) return;
+    event.preventDefault();
+    if (node.type === "group") return;
+    options.onNodeTargeted?.(node);
+    const mouseEvent = event as MouseEvent;
+    const nodeId = Number(node.id);
+    targetInGroup.value = Boolean(node.parentNode);
+    targetIsRunFlow.value =
+      (node.data as { nodeTemplate?: NodeTemplate } | undefined)?.nodeTemplate?.item === "run_flow";
+    targetIsRunning.value = options.isNodeRunning?.(nodeId) ?? false;
+    openMenu({ type: "node", id: node.id }, mouseEvent.clientX, mouseEvent.clientY);
+    hydrateNodeFacts(nodeId);
+  };
+
+  const openForSelection = ({ event }: { event: MouseEvent }) => {
+    event.preventDefault();
+    targetInGroup.value = false;
+    openMenu({ type: "selection", id: "" }, event.clientX, event.clientY);
+  };
+
+  const closeMenu = () => {
+    hydrateToken++;
+    showContextMenu.value = false;
+  };
+
+  /** Slot-free settings snapshot; see the hydration note above. */
+  const fetchNodeSettingsSnapshot = (nodeId: number) =>
+    NodeApi.getNodeData(flowStore.flowId, nodeId, false, false);
+
+  const hydrateNodeFacts = (nodeId: number) => {
+    targetCacheResults.value = null;
+    if (!Number.isFinite(nodeId)) return;
+    const myToken = hydrateToken;
+    fetchNodeSettingsSnapshot(nodeId)
+      .then((data) => {
+        if (myToken !== hydrateToken) return;
+        targetCacheResults.value = Boolean(data?.setting_input?.cache_results);
+      })
+      .catch(() => {
+        // Menu keeps the neutral label; the toggle stays disabled.
+      });
+  };
+
+  return {
+    showContextMenu,
+    menuPosition,
+    target,
+    targetInGroup,
+    canPasteNode,
+    targetIsRunFlow,
+    targetIsRunning,
+    targetCacheResults,
+    openForPane,
+    openForNode,
+    openForSelection,
+    closeMenu,
+    fetchNodeSettingsSnapshot,
+  };
+}

--- a/flowfile_frontend/src/renderer/app/stores/node-store.test.ts
+++ b/flowfile_frontend/src/renderer/app/stores/node-store.test.ts
@@ -84,6 +84,44 @@ describe("node-store getNodeData flow-aware cache", () => {
     expect(refetched?.setting_input?.description).toBe("flow-2");
   });
 
+  it("keys the cache on the stored payload's node id, not the selected node", async () => {
+    const store = useNodeStore();
+    mocks.getNodeData.mockImplementation((flowId: number, id: number) =>
+      Promise.resolve(nodeData(id, `node-${id}`)),
+    );
+
+    // Node 3 is selected (its drawer is open) and cached.
+    store.nodeId = 3;
+    await store.getNodeData(3, true);
+    expect(mocks.getNodeData).toHaveBeenCalledTimes(1);
+
+    // A fetch for node 4 (selection unchanged) misses the cache and
+    // overwrites the slot with node 4's payload.
+    const other = await store.getNodeData(4, true);
+    expect(mocks.getNodeData).toHaveBeenCalledTimes(2);
+    expect(other?.node_id).toBe(4);
+
+    // Node 3 is still the *selected* node, but the slot now holds node 4 —
+    // a cached read for node 3 must refetch, never hand back node 4's blob.
+    const refetched = await store.getNodeData(3, true);
+    expect(mocks.getNodeData).toHaveBeenCalledTimes(3);
+    expect(refetched?.node_id).toBe(3);
+    expect(refetched?.setting_input?.description).toBe("node-3");
+  });
+
+  it("serves the cache regardless of which node is selected", async () => {
+    const store = useNodeStore();
+    mocks.getNodeData.mockImplementation((flowId: number, id: number) =>
+      Promise.resolve(nodeData(id, `node-${id}`)),
+    );
+
+    // Nothing selected: the cache must still work for repeat reads.
+    store.nodeId = -1;
+    await store.getNodeData(3, true);
+    await store.getNodeData(3, true);
+    expect(mocks.getNodeData).toHaveBeenCalledTimes(1);
+  });
+
   it("resets the flow stamp when a fetch fails", async () => {
     const store = useNodeStore();
     mocks.getNodeData.mockRejectedValueOnce(new Error("boom"));

--- a/flowfile_frontend/src/renderer/app/stores/node-store.ts
+++ b/flowfile_frontend/src/renderer/app/stores/node-store.ts
@@ -102,6 +102,16 @@ export const useNodeStore = defineStore("node", {
 
   actions: {
     // ========== Node Data Management ==========
+    /**
+     * Fetch a node's data, serving the single-slot cache when it already holds
+     * this exact node's payload for the current flow.
+     *
+     * The cache is keyed on the payload actually stored (`nodeData.node_id` +
+     * `nodeDataFlowId`), never on `this.nodeId` — that field tracks the
+     * *selected* node (the open settings drawer) and says nothing about what
+     * the slot holds. Gating on the selection used to let a fetch for node B
+     * poison later cached reads for node A while A stayed selected.
+     */
     async getNodeData(
       nodeId: number,
       useCache = true,
@@ -110,11 +120,14 @@ export const useNodeStore = defineStore("node", {
       const flowStore = useFlowStore();
       const flowId = flowStore.flowId;
 
-      if (this.nodeId === nodeId && this.nodeDataFlowId === flowId && useCache) {
-        if (this.nodeData) {
-          this.isLoaded = true;
-          return this.nodeData;
-        }
+      if (
+        useCache &&
+        this.nodeData &&
+        Number(this.nodeData.node_id) === nodeId &&
+        this.nodeDataFlowId === flowId
+      ) {
+        this.isLoaded = true;
+        return this.nodeData;
       }
 
       try {

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/Canvas.vue
@@ -22,7 +22,6 @@ import {
   NodeComponent,
   EdgeComponent,
   Node,
-  NodeMouseEvent,
   useVueFlow,
   ConnectionMode,
 } from "@vue-flow/core";
@@ -62,14 +61,16 @@ import {
 import { FlowApi } from "../../api";
 import {
   copyNodesToBuffer,
+  copySingleNodeToBuffer,
   hasTextSelection,
   isCanvasClipboardTarget,
-  isNodeBufferArmed,
   readNodeClipboardBuffer,
   resolvePasteIntent,
   writeSentinelToOsClipboard,
 } from "../../composables/useFlowClipboard";
-import type { PasteIntent } from "../../composables/useFlowClipboard";
+import type { CopyableNodeData, PasteIntent } from "../../composables/useFlowClipboard";
+import { useContextMenu } from "../../composables/useContextMenu";
+import { useFlowExecution } from "../../composables/useFlowExecution";
 import { useFlowHotkeys } from "../../composables/useFlowHotkeys";
 import { desktop, isDesktop } from "../../../lib/desktop";
 import DraggableItem from "../../components/common/DraggableItem/DraggableItem.vue";
@@ -85,8 +86,12 @@ import { useFileDropImport } from "../../composables/useFileDropImport";
 import AiCommandPalette from "../../features/ai/AiCommandPalette.vue";
 import AiGhostNode from "../../features/ai/AiGhostNode.vue";
 import { useGhostNodeSuggestions } from "../../features/ai/useGhostNodeSuggestions";
+import { useAiGhostNodeStore } from "../../stores/ai-ghost-node-store";
+import { CatalogApi } from "../../api/catalog.api";
+import { nodeDocsUrl } from "./nodeDocsLinks";
 import { NodeCopyInput, ContextMenuAction, CursorPosition } from "./types";
 import type { NodeHandle, NodeTemplate } from "../../types/flow.types";
+import type { RunFlowReference } from "../../types/node.types";
 import type { Connection } from "@vue-flow/core";
 import { applyStandardLayout } from "./editorLayoutInterface";
 import { ElMessage, ElMessageBox } from "element-plus";
@@ -281,12 +286,39 @@ const dataActionsWidth = computed(() => {
 });
 const drawerLeftOverride = (d: DrawerDef): number | undefined =>
   d.id === "bottomDock" ? dataActionsWidth.value : undefined;
-const showContextMenu = ref(false);
-const clickedPosition = ref<CursorPosition>({ x: 0, y: 0 });
-const contextMenuTarget = ref({ type: "pane", id: "" });
-// Whether the right-clicked node is currently inside a group (drives Group vs
-// Remove-from-group in the node context menu).
-const contextMenuTargetInGroup = ref(false);
+// Node-level "Run Now" from the context menu. No custom pollingKey: Canvas
+// mounts once and outlives flow switches, so a key baked at setup would stop
+// tracking the active flow — the default key derives from the live flow id
+// per call, keeping run bookkeeping namespaced per flow.
+const { triggerNodeFetch, isPollingActive } = useFlowExecution(
+  () => flowStore.flowId,
+  { interval: 2000, enabled: true },
+  { persistPolling: true },
+);
+
+const ghostStore = useAiGhostNodeStore();
+
+const {
+  showContextMenu,
+  menuPosition: contextMenuPosition,
+  target: contextMenuTarget,
+  targetInGroup: contextMenuTargetInGroup,
+  canPasteNode,
+  targetIsRunFlow,
+  targetIsRunning,
+  targetCacheResults,
+  openForPane: handleContextMenu,
+  openForNode: handleNodeContextMenu,
+  openForSelection: handleSelectionContextMenu,
+  closeMenu,
+  fetchNodeSettingsSnapshot,
+} = useContextMenu({
+  onNodeTargeted: (node) => {
+    // Ensure the right-clicked node participates in the selection-based group action.
+    if (!node.selected) addSelectedNodes([node]);
+  },
+  isNodeRunning: (nodeId) => isPollingActive(`node_${nodeId}`),
+});
 const emit = defineEmits<{
   (e: "save", flowId: number): void;
   (e: "run", flowId: number): void;
@@ -341,16 +373,12 @@ interface EdgeChange {
   type: "remove" | "add" | "update";
 }
 
-const handleCanvasClick = (event: any | PointerEvent) => {
+const handleCanvasClick = () => {
   drawerStore.clearPreview();
   nodeStore.nodeId = -1;
   editorStore.activeDrawerComponent = null;
   nodeStore.hideLogViewer();
   ghostNode.onViewportClick();
-  clickedPosition.value = {
-    x: event.x,
-    y: event.y,
-  };
   window.getSelection()?.removeAllRanges();
 };
 
@@ -928,6 +956,118 @@ const handleContextMenuAction = async (actionData: ContextMenuAction) => {
     await groupSelectedNodes();
   } else if (actionId === "remove-from-group") {
     await removeSelectedFromGroup();
+  } else if (actionId === "open-node-settings") {
+    await openNodeSettings(Number(targetId));
+  } else if (actionId === "view-node-data") {
+    openNodeData(Number(targetId));
+  } else if (actionId === "run-node") {
+    await runNodeFromMenu(Number(targetId));
+  } else if (actionId === "toggle-cache") {
+    await toggleNodeCache(Number(targetId));
+  } else if (actionId === "copy-node") {
+    copyNodeFromMenu(targetId);
+  } else if (actionId === "delete-node") {
+    instance.removeNodes(targetId, true);
+  } else if (actionId === "open-node-docs") {
+    const node = instance.findNode(targetId);
+    const template = (node?.data as { nodeTemplate?: NodeTemplate } | undefined)?.nodeTemplate;
+    void desktop.openExternal(nodeDocsUrl(template));
+  } else if (actionId === "suggest-next-node") {
+    suggestNextNodeFromMenu(targetId, position);
+  } else if (actionId === "open-target-flow") {
+    await openTargetFlow(Number(targetId));
+  }
+};
+
+// ---- node-target context-menu actions (the per-node menu lives here now) ----
+
+const runNodeFromMenu = async (nodeId: number) => {
+  if (!Number.isFinite(nodeId) || isPollingActive(`node_${nodeId}`)) return;
+  try {
+    await triggerNodeFetch(nodeId);
+  } catch (error) {
+    console.error("Error running node:", error);
+  }
+};
+
+// Optimistic: the menu is already closed when this runs — reconcile in the
+// background, surface and revert on failure.
+const toggleNodeCache = async (nodeId: number) => {
+  if (!Number.isFinite(nodeId)) return;
+  const next = !(targetCacheResults.value ?? false);
+  targetCacheResults.value = next;
+  try {
+    const nodeData = await fetchNodeSettingsSnapshot(nodeId);
+    if (!nodeData?.setting_input) throw new Error("node settings unavailable");
+    nodeData.setting_input.cache_results = next;
+    await nodeStore.updateSettingsDirectly(nodeData.setting_input);
+  } catch (error) {
+    console.error("Error toggling cache:", error);
+    // Revert only if the menu still targets this node — a menu re-opened for
+    // another node owns targetCacheResults by then (and re-hydrates anyway).
+    if (contextMenuTarget.value.id === String(nodeId)) {
+      targetCacheResults.value = !next;
+    }
+    ElMessage.error("Could not update the node's cache setting.");
+  }
+};
+
+const copyNodeFromMenu = (targetId: string) => {
+  const node = instance.findNode(targetId);
+  if (!node) return;
+  const description =
+    nodeStore.nodeDescriptions[flowStore.flowId]?.[Number(targetId)]?.description ?? "";
+  const sentinel = copySingleNodeToBuffer(
+    node.data as CopyableNodeData,
+    flowStore.flowId,
+    description,
+  );
+  void writeSentinelToOsClipboard(sentinel);
+};
+
+const suggestNextNodeFromMenu = (targetId: string, position: CursorPosition) => {
+  const flowId = flowStore.flowId;
+  if (!flowId || flowId <= 0) return;
+  const node = instance.findNode(targetId);
+  if (!node) return;
+  // Popover anchors at the menu's screen position; the materialised node is
+  // placed relative to the source node's own flow-coords position.
+  const pos = node.computedPosition ?? node.position ?? { x: 0, y: 0 };
+  ghostStore.beginIntent(
+    {
+      upstreamNodeId: Number(targetId),
+      screenX: position.x,
+      screenY: position.y,
+      nodeX: pos.x,
+      nodeY: pos.y,
+    },
+    flowId,
+  );
+};
+
+const openTargetFlow = async (nodeId: number) => {
+  try {
+    const nodeData = await fetchNodeSettingsSnapshot(nodeId);
+    const flowRef = nodeData?.setting_input?.flow_reference as RunFlowReference | undefined;
+    const registrationId = flowRef?.registration_id ?? 0;
+    let flowPath = flowRef?.flow_path ?? null;
+    let name: string | undefined;
+    if (registrationId > 0) {
+      try {
+        const reg = await CatalogApi.getFlow(registrationId);
+        flowPath = reg?.flow_path ?? flowPath;
+        name = reg?.name;
+      } catch {
+        // Registration lookup failed (e.g. deleted) — fall back to stored path.
+      }
+    }
+    if (!flowPath) {
+      ElMessage.warning("No target flow is selected for this node.");
+      return;
+    }
+    editorStore.requestOpenFlow(flowPath, name);
+  } catch (error) {
+    console.error("Error opening target flow:", error);
   }
 };
 
@@ -1003,47 +1143,8 @@ const handlePasteEvent = (event: ClipboardEvent) => {
   void handleCanvasPaste(position.x, position.y, intent);
 };
 
-const handleContextMenu = (event: Event) => {
-  event.preventDefault();
-  let pointerEvent = event as PointerEvent;
-
-  contextMenuTarget.value = { type: "pane", id: "" };
-  contextMenuTargetInGroup.value = false;
-  clickedPosition.value = {
-    x: pointerEvent.x,
-    y: pointerEvent.y,
-  };
-  showContextMenu.value = true;
-};
-
-// Right-click on a node opens the context menu with node-target actions (incl.
-// grouping). The container "group" node has its own affordances, so skip it here.
-const handleNodeContextMenu = ({ event, node }: NodeMouseEvent) => {
-  event.preventDefault();
-  if (node.type === "group") return;
-  // Ensure the right-clicked node participates in the selection-based group action.
-  if (!node.selected) {
-    addSelectedNodes([node]);
-  }
-  const mouseEvent = event as MouseEvent;
-  contextMenuTarget.value = { type: "node", id: node.id };
-  contextMenuTargetInGroup.value = Boolean(node.parentNode);
-  clickedPosition.value = { x: mouseEvent.clientX, y: mouseEvent.clientY };
-  showContextMenu.value = true;
-};
-
-// Right-click on the multi-selection rectangle (the highlighted box around several
-// selected nodes) — VueFlow routes this here rather than to pane/node menus.
-const handleSelectionContextMenu = ({ event }: { event: MouseEvent }) => {
-  event.preventDefault();
-  contextMenuTarget.value = { type: "selection", id: "" };
-  contextMenuTargetInGroup.value = false;
-  clickedPosition.value = { x: event.clientX, y: event.clientY };
-  showContextMenu.value = true;
-};
-
 const closeContextMenu = () => {
-  showContextMenu.value = false;
+  closeMenu();
   nodeStore.setCodeGeneratorVisibility(false);
 };
 
@@ -1271,12 +1372,15 @@ defineExpose({
       <FileDropUploadDialog :controller="fileDrop" />
       <context-menu
         v-if="showContextMenu"
-        :x="clickedPosition.x"
-        :y="clickedPosition.y"
+        :x="contextMenuPosition.x"
+        :y="contextMenuPosition.y"
         :target-type="contextMenuTarget.type"
         :target-id="contextMenuTarget.id"
         :target-in-group="contextMenuTargetInGroup"
-        :can-paste-node="isNodeBufferArmed()"
+        :can-paste-node="canPasteNode"
+        :is-run-flow-node="targetIsRunFlow"
+        :is-running="targetIsRunning"
+        :cache-results="targetCacheResults"
         :on-close="closeContextMenu"
         @action="handleContextMenuAction"
       />

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/ContextMenu.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/ContextMenu.vue
@@ -1,39 +1,34 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+
 import { ContextMenuAction } from "./types";
 
-const props = defineProps({
-  x: {
-    type: Number,
-    required: true,
+const props = withDefaults(
+  defineProps<{
+    x: number;
+    y: number;
+    targetType: "node" | "edge" | "pane" | "selection";
+    targetId?: string;
+    targetInGroup?: boolean;
+    /** Whether the node-copy buffer is armed; "Paste Node" is hidden otherwise. */
+    canPasteNode?: boolean;
+    /** Node target only: the node is a run_flow node ("Go to Flow" entry). */
+    isRunFlowNode?: boolean;
+    /** Node target only: the node is currently executing. */
+    isRunning?: boolean;
+    /** Node target only: cache_results flag; null while hydration is in flight. */
+    cacheResults?: boolean | null;
+    onClose: () => void;
+  }>(),
+  {
+    targetId: "",
+    targetInGroup: false,
+    canPasteNode: false,
+    isRunFlowNode: false,
+    isRunning: false,
+    cacheResults: null,
   },
-  y: {
-    type: Number,
-    required: true,
-  },
-  targetType: {
-    type: String,
-    required: true,
-    validator: (value: string) => ["node", "edge", "pane", "selection"].includes(value),
-  },
-  targetId: {
-    type: String,
-    default: "",
-  },
-  targetInGroup: {
-    type: Boolean,
-    default: false,
-  },
-  // Whether the node-copy buffer is armed; "Paste Node" is hidden otherwise.
-  canPasteNode: {
-    type: Boolean,
-    default: false,
-  },
-  onClose: {
-    type: Function,
-    required: true,
-  },
-});
+);
 
 const emit = defineEmits(["action"]);
 
@@ -59,88 +54,141 @@ const ICONS: Record<string, string> = {
     '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/>',
   lineage:
     '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>',
+  settings:
+    '<circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>',
+  table:
+    '<rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="9" y1="3" x2="9" y2="21"/>',
+  externalLink:
+    '<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>',
+  arrowRight: '<path d="M5 12h14"/><path d="m12 5 7 7-7 7"/>',
+  play: '<polygon points="5 3 19 12 5 21 5 3"/>',
+  refresh:
+    '<path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 21h5v-5"/>',
+  copy: '<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>',
+  trash:
+    '<path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>',
 };
 
-// Define menu actions based on the target type. Pane-only entries pick up
-// the "Generate documentation" affordance and the new "Ask about
-// lineage" affordance; the per-node "Ask about this node's lineage"
-// joins the node-target entries. The four pre-existing canvas actions
-// still render against node/edge targets — that's a known pre-existing
-// inconsistency, fixing it is out of scope for.
-const getMenuActions = () => {
-  const baseActions = [
+interface MenuEntry {
+  id: string;
+  label: string;
+  icon: string;
+  danger?: boolean;
+  disabled?: boolean;
+  divider?: boolean;
+}
+
+const divider = (id: string): MenuEntry => ({ id, label: "", icon: "", divider: true });
+
+// A node target renders the full per-node action set (this menu is the only
+// right-click surface for nodes — NodeWrapper no longer has its own menu).
+// Pane/selection targets keep the canvas-level actions.
+const menuEntries = computed<MenuEntry[]>(() => {
+  if (props.targetType === "node") {
+    const entries: MenuEntry[] = [
+      { id: "open-node-settings", label: "Edit", icon: "settings" },
+      { id: "view-node-data", label: "View Data", icon: "table" },
+    ];
+    if (props.isRunFlowNode) {
+      entries.push({ id: "open-target-flow", label: "Go to Flow", icon: "externalLink" });
+    }
+    entries.push(
+      { id: "suggest-next-node", label: "Suggest next node…", icon: "arrowRight" },
+      { id: "open-node-docs", label: "Read more", icon: "document" },
+      divider("d1"),
+      {
+        id: "run-node",
+        label: props.isRunning ? "Running…" : "Run Now",
+        icon: "play",
+        disabled: props.isRunning,
+      },
+      {
+        id: "toggle-cache",
+        label:
+          props.cacheResults === null
+            ? "Cache results…"
+            : props.cacheResults
+              ? "Disable Cache"
+              : "Enable Cache",
+        icon: "refresh",
+        disabled: props.cacheResults === null,
+      },
+      divider("d2"),
+      props.targetInGroup
+        ? { id: "remove-from-group", label: "Remove from group", icon: "ungroup" }
+        : { id: "group-selection", label: "Group selected nodes", icon: "group" },
+      { id: "ask-lineage-node", label: "Ask about this node's lineage…", icon: "lineage" },
+      divider("d3"),
+      { id: "copy-node", label: "Copy", icon: "copy" },
+      { id: "delete-node", label: "Delete", icon: "trash", danger: true },
+    );
+    return entries;
+  }
+
+  const entries: MenuEntry[] = [
     { id: "fit-view", label: "Fit View", icon: "fitView" },
     { id: "zoom-in", label: "Zoom In", icon: "zoomIn" },
     { id: "zoom-out", label: "Zoom Out", icon: "zoomOut" },
   ];
   if (props.canPasteNode) {
-    baseActions.push({ id: "paste-node", label: "Paste Node", icon: "paste" });
+    entries.push({ id: "paste-node", label: "Paste Node", icon: "paste" });
+  }
+  if (props.targetType === "pane" || props.targetType === "selection") {
+    entries.push({ id: "group-selection", label: "Group selected nodes", icon: "group" });
   }
   if (props.targetType === "pane") {
-    baseActions.push({
-      id: "group-selection",
-      label: "Group selected nodes",
-      icon: "group",
-    });
-    baseActions.push({
-      id: "generate-documentation",
-      label: "Generate documentation",
-      icon: "document",
-    });
-    baseActions.push({
-      id: "add-descriptions-all",
-      label: "Add description to all nodes",
-      icon: "sparkles",
-    });
-    baseActions.push({
-      id: "ask-lineage",
-      label: "Ask about lineage…",
-      icon: "lineage",
-    });
+    entries.push(
+      { id: "generate-documentation", label: "Generate documentation", icon: "document" },
+      { id: "add-descriptions-all", label: "Add description to all nodes", icon: "sparkles" },
+      { id: "ask-lineage", label: "Ask about lineage…", icon: "lineage" },
+    );
   }
-  if (props.targetType === "selection") {
-    baseActions.push({
-      id: "group-selection",
-      label: "Group selected nodes",
-      icon: "group",
-    });
-  }
-  if (props.targetType === "node") {
-    if (props.targetInGroup) {
-      baseActions.push({
-        id: "remove-from-group",
-        label: "Remove from group",
-        icon: "ungroup",
-      });
-    } else {
-      baseActions.push({
-        id: "group-selection",
-        label: "Group selected nodes",
-        icon: "group",
-      });
-    }
-    baseActions.push({
-      id: "ask-lineage-node",
-      label: "Ask about this node's lineage…",
-      icon: "lineage",
-    });
-  }
-  return baseActions;
-};
+  return entries;
+});
 
-const handleAction = (actionId: string): void => {
+const handleAction = (entry: MenuEntry): void => {
+  if (entry.divider || entry.disabled) return;
   emit("action", {
-    actionId,
-    targetType: props.targetType as "node" | "edge" | "pane" | "selection",
+    actionId: entry.id,
+    targetType: props.targetType,
     targetId: props.targetId,
+    // Raw coords, not the clamped ones — paste-node projects them into flow
+    // space, so they must stay where the user actually clicked.
     position: { x: props.x, y: props.y },
   } as ContextMenuAction);
   props.onClose();
 };
 
+// The page never scrolls (html/body/#app are overflow:hidden), so a menu
+// opened near an edge would be unreachable rather than scrolled into view —
+// clamp it fully inside the viewport. Runs pre-paint (nextTick), so there is
+// no visible jump.
+const coords = ref({ x: props.x, y: props.y });
+
+const clampToViewport = () => {
+  const el = menuRef.value;
+  if (!el) return;
+  const { width, height } = el.getBoundingClientRect();
+  coords.value = {
+    x: Math.max(10, Math.min(props.x, window.innerWidth - width - 10)),
+    y: Math.max(10, Math.min(props.y, window.innerHeight - height - 10)),
+  };
+};
+
+// Re-clamp whenever the anchor or the rendered entry set changes — the menu
+// may stay mounted across two consecutive right-clicks on different targets.
+watch(
+  () => [props.x, props.y, props.targetType, props.targetId],
+  () => {
+    coords.value = { x: props.x, y: props.y };
+    void nextTick(clampToViewport);
+  },
+);
+
 // Capture-phase pointerdown: VueFlow's pane preventDefaults pointerdown, which
 // suppresses the compatibility mousedown — a bubble mousedown listener never
-// fires for canvas clicks, leaving the menu stuck open.
+// fires for canvas clicks, leaving the menu stuck open. pointerdown also fires
+// for right-clicks (click does not), so a right-click elsewhere dismisses too.
 const handlePointerDownOutside = (event: PointerEvent) => {
   if (menuRef.value && !menuRef.value.contains(event.target as Node)) {
     props.onClose();
@@ -154,6 +202,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
 };
 
 onMounted(() => {
+  void nextTick(clampToViewport);
   document.addEventListener("pointerdown", handlePointerDownOutside, true);
   document.addEventListener("keydown", handleKeyDown);
 });
@@ -169,8 +218,8 @@ onUnmounted(() => {
     ref="menuRef"
     class="context-menu"
     :style="{
-      left: `${x}px`,
-      top: `${y}px`,
+      left: `${coords.x}px`,
+      top: `${coords.y}px`,
     }"
   >
     <div class="context-menu-header">
@@ -183,29 +232,32 @@ onUnmounted(() => {
       }}</span>
     </div>
     <div class="context-menu-items">
-      <div
-        v-for="action in getMenuActions()"
-        :key="action.id"
-        class="context-menu-item"
-        @click="handleAction(action.id)"
-      >
-        <!-- eslint-disable vue/no-v-html -- ICONS is a trusted internal constant of static SVG paths -->
-        <span class="context-menu-icon" aria-hidden="true">
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            v-html="ICONS[action.icon]"
-          ></svg>
-        </span>
-        <!-- eslint-enable vue/no-v-html -->
-        <span>{{ action.label }}</span>
-      </div>
+      <template v-for="entry in menuEntries" :key="entry.id">
+        <div v-if="entry.divider" class="context-menu-divider"></div>
+        <div
+          v-else
+          class="context-menu-item"
+          :class="{ disabled: entry.disabled, 'context-menu-item-danger': entry.danger }"
+          @click="handleAction(entry)"
+        >
+          <!-- eslint-disable vue/no-v-html -- ICONS is a trusted internal constant of static SVG paths -->
+          <span class="context-menu-icon" aria-hidden="true">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              v-html="ICONS[entry.icon]"
+            ></svg>
+          </span>
+          <!-- eslint-enable vue/no-v-html -->
+          <span>{{ entry.label }}</span>
+        </div>
+      </template>
     </div>
   </div>
 </template>
@@ -217,10 +269,24 @@ onUnmounted(() => {
   min-width: 200px;
 }
 
+/* The node-target menu is taller than the shared 300px cap; viewport clamping
+   already keeps it on-screen, so let it grow instead of scrolling. */
+.context-menu-items {
+  max-height: min(80vh, 560px);
+}
+
 .context-menu-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+}
+
+.context-menu-item-danger {
+  color: var(--color-danger);
+}
+
+.context-menu-item-danger:hover {
+  background-color: var(--color-danger-light);
 }
 </style>


### PR DESCRIPTION
This pull request refactors context menu handling in the GroupBy and Sort node components to use a new, reusable `ContextMenu` component and composable logic. The update simplifies context menu state management, ensures only one menu is open at a time, and improves UX by preserving native context menus for editable fields. Additionally, it introduces a new `useContextMenu` composable for canvas-level menus and clarifies the cache keying logic in the node data store, with new tests to verify correct behavior.

**Context menu refactoring and improvements:**

- Replaced ad-hoc context menu implementations in `GroupBy.vue` and `Sort.vue` with a shared `ContextMenu` component, using a single `activeMenu` state instead of multiple booleans, and moved menu option logic into computed properties. This ensures only one menu is open at a time and improves maintainability. [[1]](diffhunk://#diff-68b6015763e62e15e67a44c5bb7c8fa9b03342e875acef717c8fa62936746589L29-R35) [[2]](diffhunk://#diff-68b6015763e62e15e67a44c5bb7c8fa9b03342e875acef717c8fa62936746589L121-L126) [[3]](diffhunk://#diff-b3f20e2c4725125f1303ca765024fe4700c883f5cad0d209f1a035a3f941304cL23-R29) [[4]](diffhunk://#diff-b3f20e2c4725125f1303ca765024fe4700c883f5cad0d209f1a035a3f941304cR77-L128)
- Context menus now preserve native browser behavior for right-clicks on editable fields (inputs, textareas), allowing users to use standard actions like paste. [[1]](diffhunk://#diff-68b6015763e62e15e67a44c5bb7c8fa9b03342e875acef717c8fa62936746589R164-L195) [[2]](diffhunk://#diff-b3f20e2c4725125f1303ca765024fe4700c883f5cad0d209f1a035a3f941304cR77-L128)

**Composables and code reuse:**

- Added a new `useContextMenu` composable that manages canvas-level context menu state, target identification, and node data hydration, as planned in the Canvas.vue refactor.

**Node data store cache logic:**

- Clarified and documented that the node data cache is keyed on the payload's node id and flow id, not the currently selected node, and added tests to verify correct cache behavior when fetching data for different nodes. [[1]](diffhunk://#diff-954143b391ececc777d6adf4d9579c5141c0d0e68ab00ae9d7238056aa6a8764R105-R114) [[2]](diffhunk://#diff-06b2bbf6c0ac57d088441576ef45fcfdeb2c67c99d832c05867e652f3cd47b16R87-R124)

**Other cleanups:**

- Removed now-unneeded event listeners and context menu DOM refs from the affected components. [[1]](diffhunk://#diff-68b6015763e62e15e67a44c5bb7c8fa9b03342e875acef717c8fa62936746589L327-L335) [[2]](diffhunk://#diff-b3f20e2c4725125f1303ca765024fe4700c883f5cad0d209f1a035a3f941304cR77-L128)

These changes improve code clarity, reduce duplication, and make context menu behavior more consistent and user-friendly across the app.