### PR TITLE
Reconcile explore spec encodings with data model changes on schema migration

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/analytics/analytics_processor.py
+++ b/flowfile_core/flowfile_core/flowfile/analytics/analytics_processor.py
@@ -9,6 +9,8 @@ from flowfile_core.schemas.analysis_schemas.graphic_walker_schemas import (
 )
 from flowfile_core.schemas.input_schema import NodeExploreData
 
+GW_PSEUDO_FIDS = frozenset({"gw_count_fid", "gw_mea_key_fid", "gw_mea_val_fid"})
+
 
 class AnalyticsProcessor:
     @staticmethod
@@ -95,9 +97,59 @@ def add_field_to_spec_list(spec_list: dict, mut_field: MutField) -> None:
         spec_list["encodings"]["dimensions"].append(view_field.model_dump_dict())
 
 
+def is_data_column_field(spec_field: dict) -> bool:
+    """A spec entry backed by a real column, not a Graphic Walker pseudo or computed field."""
+    return not spec_field.get("computed") and spec_field.get("fid") not in GW_PSEUDO_FIDS
+
+
+def sync_spec_field_with_mut_field(spec_field: dict, mut_field: MutField) -> None:
+    """Retype a spec entry only when the column's dtype class changed.
+
+    Only ``semanticType`` is compared, because the analytic type and the shelf a field
+    sits on are the user's choice (Graphic Walker's "to dimension" / "to measure" move an
+    entry without touching its semantic type). ``ordinal`` is likewise always a manual
+    override — the backend only ever derives nominal, quantitative or temporal.
+    """
+    spec_semantic_type = spec_field.get("semanticType")
+    if spec_semantic_type == mut_field.semanticType or spec_semantic_type == "ordinal":
+        return
+    spec_field["semanticType"] = mut_field.semanticType
+    spec_field["analyticType"] = mut_field.analyticType
+    if mut_field.analyticType == "measure":
+        if not spec_field.get("aggName"):
+            spec_field["aggName"] = "sum"
+    else:
+        spec_field.pop("aggName", None)
+
+
+def reconcile_spec_list_with_data_model(spec_list: dict, data_model: DataModel) -> None:
+    """Make the saved encodings follow the data: retype what changed, drop what is gone."""
+    fields_by_fid = {field.fid: field for field in data_model.fields}
+    encodings = spec_list["encodings"]
+    for channel, spec_fields in encodings.items():
+        kept = []
+        for spec_field in spec_fields:
+            if not is_data_column_field(spec_field):
+                kept.append(spec_field)
+                continue
+            mut_field = fields_by_fid.get(spec_field.get("fid"))
+            if mut_field is None:
+                continue
+            sync_spec_field_with_mut_field(spec_field, mut_field)
+            kept.append(spec_field)
+        encodings[channel] = kept
+    shelved = encodings["dimensions"] + encodings["measures"]
+    encodings["dimensions"] = [f for f in shelved if f.get("analyticType") != "measure"]
+    encodings["measures"] = [f for f in shelved if f.get("analyticType") == "measure"]
+
+
 def validate_spec_list_with_data_model_types(spec_list: dict, data_model: DataModel) -> None:
     """
     Validate the spec_list with the data model types.
+
+    Existing entries are reconciled with the current fields (a retyped column updates
+    everywhere it appears and lands on the matching shelf, a dropped column is removed
+    from every encoding list) and new columns are appended.
 
     Args:
         spec_list (Dict): The spec list to validate.
@@ -106,8 +158,7 @@ def validate_spec_list_with_data_model_types(spec_list: dict, data_model: DataMo
     Returns:
         bool: True if the spec list is valid, False otherwise.
     """
-
-    # validate dimensions:
+    reconcile_spec_list_with_data_model(spec_list, data_model)
     existing_encoding_fields = get_existing_encoding_fields(spec_list)
     for field in data_model.fields:
         if field.fid not in existing_encoding_fields:

--- a/flowfile_core/flowfile_core/flowfile/analytics/analytics_processor.py
+++ b/flowfile_core/flowfile_core/flowfile/analytics/analytics_processor.py
@@ -97,11 +97,6 @@ def add_field_to_spec_list(spec_list: dict, mut_field: MutField) -> None:
         spec_list["encodings"]["dimensions"].append(view_field.model_dump_dict())
 
 
-def is_data_column_field(spec_field: dict) -> bool:
-    """A spec entry backed by a real column, not a Graphic Walker pseudo or computed field."""
-    return not spec_field.get("computed") and spec_field.get("fid") not in GW_PSEUDO_FIDS
-
-
 def sync_spec_field_with_mut_field(spec_field: dict, mut_field: MutField) -> None:
     """Retype a spec entry only when the column's dtype class changed.
 
@@ -110,14 +105,12 @@ def sync_spec_field_with_mut_field(spec_field: dict, mut_field: MutField) -> Non
     entry without touching its semantic type). ``ordinal`` is likewise always a manual
     override — the backend only ever derives nominal, quantitative or temporal.
     """
-    spec_semantic_type = spec_field.get("semanticType")
-    if spec_semantic_type == mut_field.semanticType or spec_semantic_type == "ordinal":
+    if spec_field.get("semanticType") in (mut_field.semanticType, "ordinal"):
         return
     spec_field["semanticType"] = mut_field.semanticType
     spec_field["analyticType"] = mut_field.analyticType
     if mut_field.analyticType == "measure":
-        if not spec_field.get("aggName"):
-            spec_field["aggName"] = "sum"
+        spec_field["aggName"] = spec_field.get("aggName") or "sum"
     else:
         spec_field.pop("aggName", None)
 
@@ -129,10 +122,10 @@ def reconcile_spec_list_with_data_model(spec_list: dict, data_model: DataModel) 
     for channel, spec_fields in encodings.items():
         kept = []
         for spec_field in spec_fields:
-            if not is_data_column_field(spec_field):
+            if spec_field.get("computed") or spec_field["fid"] in GW_PSEUDO_FIDS:
                 kept.append(spec_field)
                 continue
-            mut_field = fields_by_fid.get(spec_field.get("fid"))
+            mut_field = fields_by_fid.get(spec_field["fid"])
             if mut_field is None:
                 continue
             sync_spec_field_with_mut_field(spec_field, mut_field)

--- a/flowfile_core/flowfile_core/flowfile/analytics/graphic_walker.py
+++ b/flowfile_core/flowfile_core/flowfile/analytics/graphic_walker.py
@@ -2,16 +2,19 @@ from flowfile_core.flowfile.flow_data_engine.flow_data_engine import FlowfileCol
 from flowfile_core.schemas.analysis_schemas import graphic_walker_schemas as gw_schema
 
 
-def get_semantic_type(data_type: str) -> str:
-    """Determine the semanticType based on the data_type."""
-    if data_type in ["Utf8", "VARCHAR", "CHAR", "NVARCHAR", "String"]:
-        return "nominal"
-    elif data_type in ["Int64", "Float64", "Int32", "Float32", "Int16", "Float16", "Decimal"]:
+def get_semantic_type(datatype_group: str) -> str:
+    """Map a readable dtype group onto a Graphic Walker semantic type.
+
+    Must agree with ``polars_gw.get_fields``, which owns the field schema the
+    browser actually charts against: numerics are quantitative, date-like
+    columns temporal, everything else nominal.
+    """
+    if datatype_group == "Numeric":
         return "quantitative"
-    elif data_type in ["Datetime", "Date"]:
+    elif datatype_group == "Date":
         return "temporal"
     else:
-        return "nominal"  # Default case; adjust as necessary
+        return "nominal"
 
 
 def get_analytic_type(semantic_type: str) -> gw_schema.AnalyticTypeLit:
@@ -29,7 +32,7 @@ def convert_ff_column_to_gw_field(flow_file_column: FlowfileColumn) -> gw_schema
     Returns:
     - A GraphicWalkerField instance with properties derived from the FlowfileColumn.
     """
-    semantic_type = get_semantic_type(flow_file_column.data_type)
+    semantic_type = get_semantic_type(flow_file_column.get_readable_datatype_group())
 
     analytic_type = get_analytic_type(semantic_type)
 

--- a/flowfile_core/tests/flowfile/analytics/test_analytics_processor.py
+++ b/flowfile_core/tests/flowfile/analytics/test_analytics_processor.py
@@ -1,7 +1,10 @@
+import datetime
+from copy import deepcopy
 from pathlib import Path
 from unittest.mock import patch
 
 import polars as pl
+import polars_gw
 import pytest
 
 from flowfile_core.flowfile.analytics.analytics_processor import (
@@ -751,3 +754,57 @@ def test_unchanged_data_leaves_the_users_own_choices_alone():
     assert _find_field(encodings, 'rows', 'year')['analyticType'] == 'dimension'
     assert 'aggName' not in _find_field(encodings, 'rows', 'year')
     assert _find_field(encodings, 'measures', 'score')['semanticType'] == 'ordinal', 'manual override must survive'
+
+
+_PARITY_FRAME = pl.DataFrame(
+    {
+        'text': ['a'],
+        'tiny_int': [1],
+        'unsigned_int': [1],
+        'big_int': [1],
+        'float': [1.0],
+        'decimal': [1.0],
+        'date': [datetime.date(2024, 1, 1)],
+        'datetime': [datetime.datetime(2024, 1, 1)],
+        'duration': [1],
+        'time': [1],
+        'boolean': [True],
+        'categorical': ['x'],
+        'list': [[1, 2]],
+    },
+    schema_overrides={
+        'tiny_int': pl.Int8,
+        'unsigned_int': pl.UInt32,
+        'float': pl.Float32,
+        'decimal': pl.Decimal(10, 2),
+        'duration': pl.Duration('us'),
+        'time': pl.Time,
+        'categorical': pl.Categorical,
+        'list': pl.List(pl.Int64),
+    },
+)
+
+
+def test_semantic_types_agree_with_polars_gw():
+    """The backend classifier must agree with polars_gw, which owns the browser's field schema.
+
+    Reconciliation compares a saved spec entry (built from polars_gw's fields) against a
+    backend-derived field, so any disagreement retypes columns on every drawer open.
+    """
+    core_fields = convert_ff_columns_to_gw_fields(FlowDataEngine(_PARITY_FRAME).schema)
+    gw_fields = polars_gw.get_fields(_PARITY_FRAME, classify_integers='measure')
+
+    assert [(f.fid, f.semanticType) for f in core_fields] == [(f['fid'], f['semanticType']) for f in gw_fields]
+
+    spec_fields = deepcopy(gw_fields)
+    spec_list = {
+        'encodings': {
+            'dimensions': [f for f in spec_fields if f['analyticType'] != 'measure'],
+            'measures': [f for f in spec_fields if f['analyticType'] == 'measure'],
+        }
+    }
+    untouched = deepcopy(spec_list)
+
+    validate_spec_list_with_data_model_types(spec_list, DataModel(data=[], fields=core_fields))
+
+    assert spec_list == untouched, 'a spec built from polars_gw fields must survive reconciliation unchanged'

--- a/flowfile_core/tests/flowfile/analytics/test_analytics_processor.py
+++ b/flowfile_core/tests/flowfile/analytics/test_analytics_processor.py
@@ -4,12 +4,17 @@ from unittest.mock import patch
 import polars as pl
 import pytest
 
-from flowfile_core.flowfile.analytics.analytics_processor import AnalyticsProcessor
+from flowfile_core.flowfile.analytics.analytics_processor import (
+    AnalyticsProcessor,
+    validate_spec_list_with_data_model_types,
+)
+from flowfile_core.flowfile.analytics.graphic_walker import convert_ff_columns_to_gw_fields
 from flowfile_core.flowfile.analytics.node_viz import has_result_to_visualize
 from flowfile_core.flowfile.flow_data_engine.flow_data_engine import FlowDataEngine
 from flowfile_core.flowfile.flow_graph import FlowGraph, add_connection, delete_connection
 from flowfile_core.flowfile.handler import FlowfileHandler
 from flowfile_core.schemas import input_schema, schemas
+from flowfile_core.schemas.analysis_schemas.graphic_walker_schemas import DataModel
 
 
 def find_parent_directory(target_dir_name, start_path=None):
@@ -635,3 +640,114 @@ def test_default_fetch_still_stores_for_the_preview_grid():
     attempts = _fetch_recording_stores(graph)
 
     assert attempts, 'the default fetch must still store the result for the preview grid'
+
+
+def _spec_field(fid: str, semantic_type: str = 'nominal', analytic_type: str = 'dimension') -> dict:
+    return {
+        'fid': fid,
+        'name': fid,
+        'basename': fid,
+        'semanticType': semantic_type,
+        'analyticType': analytic_type,
+        'offset': None,
+    }
+
+
+def _all_encoded_fids(encodings: dict) -> set[str]:
+    fids = set()
+    for channel in encodings.values():
+        for field in channel:
+            fids.add(field['fid'])
+    return fids
+
+
+def _find_field(encodings: dict, channel: str, fid: str) -> dict | None:
+    return next((f for f in encodings[channel] if f['fid'] == fid), None)
+
+
+def test_saved_spec_follows_a_changed_upstream_schema():
+    """A saved chart spec must track the data: retyped, dropped and added columns.
+
+    The explorer shows `currentVis.encodings`, not the fresh field list, so a
+    spec that keeps stale entries is exactly what the user ends up looking at.
+    """
+    graph = create_graph()
+    graph.flow_settings.execution_location = "local"
+    gw_node_settings = get_starting_gw_node_settings()
+    encodings = gw_node_settings.graphic_walker_input.specList[0]['encodings']
+    encodings['dimensions'].insert(1, _spec_field('Old'))
+    encodings['color'].append(_spec_field('Old'))
+
+    add_manual_input(
+        graph,
+        data=input_schema.RawData.from_pylist(
+            [{'Column 1': 'edward', 'Old': 'x'}, {'Column 1': 'eduward', 'Old': 'y'}]
+        ),
+    )
+    add_node_promise_on_type(graph, 'explore_data', 2)
+    add_connection(graph, input_schema.NodeConnection.create_from_simple_input(1, 2))
+    graph.add_explore_data(gw_node_settings)
+    node = graph.get_node(2)
+
+    graph.run_graph()
+    AnalyticsProcessor.process_graphic_walker_input(node)
+
+    graph.add_manual_input(
+        input_schema.NodeManualInput(
+            flow_id=1,
+            node_id=1,
+            raw_data_format=input_schema.RawData.from_pylist(
+                [{'Column 1': 1, 'New': 'a'}, {'Column 1': 2, 'New': 'b'}]
+            ),
+        )
+    )
+    graph.run_graph()
+    node_explore_data = AnalyticsProcessor.process_graphic_walker_input(node)
+    encodings = node_explore_data.graphic_walker_input.specList[0]['encodings']
+
+    retyped = _find_field(encodings, 'measures', 'Column 1')
+    assert retyped is not None, 'Column 1 became an integer, so it must live in measures'
+    assert retyped['semanticType'] == 'quantitative'
+    assert retyped['analyticType'] == 'measure'
+    assert _find_field(encodings, 'dimensions', 'Column 1') is None, 'the stale dimension entry must be gone'
+
+    row_field = _find_field(encodings, 'rows', 'Column 1')
+    assert row_field is not None, 'the placed field must survive the retype'
+    assert row_field['semanticType'] == 'quantitative'
+    assert row_field['analyticType'] == 'measure'
+
+    assert 'Old' not in _all_encoded_fids(encodings), 'a dropped column must vanish from every encoding list'
+    assert _find_field(encodings, 'dimensions', 'New') is not None, 'a new string column must show up as a dimension'
+
+    pseudo_fields = {'gw_count_fid', 'gw_mea_key_fid', 'gw_mea_val_fid'}
+    assert pseudo_fields <= _all_encoded_fids(encodings), 'GW pseudo-fields must survive reconciliation'
+
+
+def test_unchanged_data_leaves_the_users_own_choices_alone():
+    """Reconciliation runs on every drawer open, so it must not undo GW field-menu edits.
+
+    Moving a numeric field to Dimensions ('to_dim') rewrites only analyticType, and
+    setting a semantic type rewrites only semanticType — neither is a schema change.
+    """
+    spec_list = {
+        'encodings': {
+            'dimensions': [_spec_field('year', 'quantitative', 'dimension'), _spec_field('gw_mea_key_fid')],
+            'measures': [_spec_field('score', 'ordinal', 'measure')],
+            'rows': [_spec_field('year', 'quantitative', 'dimension')],
+        }
+    }
+    data_model = DataModel(
+        data=[],
+        fields=convert_ff_columns_to_gw_fields(
+            FlowDataEngine(pl.DataFrame({'year': [2024], 'score': [1]})).schema
+        ),
+    )
+
+    validate_spec_list_with_data_model_types(spec_list, data_model)
+
+    encodings = spec_list['encodings']
+    assert _find_field(encodings, 'dimensions', 'year') is not None, "the user's shelf choice must survive"
+    assert _find_field(encodings, 'measures', 'year') is None
+    assert _find_field(encodings, 'rows', 'year')['analyticType'] == 'dimension'
+    assert 'aggName' not in _find_field(encodings, 'rows', 'year')
+    assert _find_field(encodings, 'measures', 'score')['semanticType'] == 'ordinal', 'manual override must survive'


### PR DESCRIPTION
This pull request significantly improves how chart specifications stay in sync with upstream data model changes, ensuring that the visualized fields accurately reflect the current data. The main changes introduce a reconciliation process that updates, drops, or adds fields in the chart spec as the underlying data schema evolves. Comprehensive tests are also added to verify this behavior and to ensure that user-driven customizations are preserved when the data schema remains unchanged.

**Core reconciliation logic:**

* Added `reconcile_spec_list_with_data_model`, `sync_spec_field_with_mut_field`, and `is_data_column_field` functions to update chart spec encodings so that dropped columns are removed, retyped columns are updated, and new columns are appended, while preserving pseudo-fields and user overrides. [[1]](diffhunk://#diff-681eeca03ef91b44fee8e86a1800397cdb415776014645d70a975cad1ef7da4aR100-R161) [[2]](diffhunk://#diff-681eeca03ef91b44fee8e86a1800397cdb415776014645d70a975cad1ef7da4aR12-R13)

**Integration with validation:**

* Updated `validate_spec_list_with_data_model_types` to call the new reconciliation logic, ensuring that spec validation also synchronizes the spec with the data model.

**Testing improvements:**

* Added comprehensive tests (`test_saved_spec_follows_a_changed_upstream_schema` and `test_unchanged_data_leaves_the_users_own_choices_alone`) to verify that the spec updates correctly when the data model changes, and that user modifications are preserved when the data does not change. Helper functions for testing were also introduced.

**Test infrastructure updates:**

* Updated test imports to include the new validation and conversion functions needed for the new tests