### PR TITLE
Fix objects not handled correctly in tables and in custom node designer

### DIFF
--- a/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
+++ b/flowfile_core/flowfile_core/flowfile/flow_data_engine/flow_data_engine.py
@@ -79,6 +79,18 @@ T = TypeVar("T", pl.DataFrame, pl.LazyFrame)
 CLOUD_PLACEHOLDER_RECORD_COUNT = 6_666_666
 
 
+def _minimal_field_dtype(field: input_schema.MinimalFieldInfo) -> pl.DataType | None:
+    """Polars dtype for a RawData column, or None (let polars infer) when it needs an inner type.
+
+    Nested types (List/Struct/Array) can't be instantiated from a bare name, so
+    nested data is inferred rather than rejected.
+    """
+    try:
+        return FlowfileColumn.create_from_minimal_field_info(field).get_polars_type().pl_datatype
+    except TypeError:
+        return None
+
+
 def _handle_duplication_join_keys(
     left_df: T, right_df: T, join_manager: transform_schemas.JoinInputManager
 ) -> tuple[T, T, dict[str, str]]:
@@ -377,13 +389,7 @@ class FlowDataEngine:
         Args:
             raw_data: An instance of `RawData` containing the data and schema.
         """
-        flowfile_schema = list(FlowfileColumn.create_from_minimal_field_info(c) for c in raw_data.columns)
-        polars_schema = pl.Schema(
-            [
-                (flowfile_column.column_name, flowfile_column.get_polars_type().pl_datatype)
-                for flowfile_column in flowfile_schema
-            ]
-        )
+        polars_schema = [(field.name, _minimal_field_dtype(field)) for field in raw_data.columns]
         try:
             df = pl.DataFrame(raw_data.data, polars_schema, strict=False)
         except TypeError as e:

--- a/flowfile_core/flowfile_core/flowfile/node_designer/parsing.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/parsing.py
@@ -997,16 +997,14 @@ class _SourceParser:
                 return _INVALID
             data: dict[str, list[Any]] = {}
             for column, values in entry.items():
-                if isinstance(values, tuple):
-                    values = list(values)
-                if not isinstance(values, list) or not all(isinstance(v, _SCALARS) for v in values):
+                if not isinstance(values, list | tuple) or not self._is_plain_json(values):
                     self.error(
                         ParseIssueCode.INVALID_EXAMPLE_INPUT,
-                        f"example values for column '{column}' must be a list of scalars",
+                        f"example values for column '{column}' must be a list of JSON-safe values",
                         node,
                     )
                     return _INVALID
-                data[column] = values
+                data[column] = self._jsonify(list(values))
             examples.append(ExampleInput(data=data))
         return examples
 

--- a/flowfile_core/flowfile_core/flowfile/node_designer/state.py
+++ b/flowfile_core/flowfile_core/flowfile/node_designer/state.py
@@ -142,7 +142,7 @@ class EnvironmentState(BaseModel):
 
 
 class ExampleInput(BaseModel):
-    data: dict[str, list[Any]]  # column -> JSON-scalar values
+    data: dict[str, list[Any]]  # column -> JSON values (scalars or nested lists/dicts)
 
 
 class ArtifactDecl(BaseModel):

--- a/flowfile_core/flowfile_core/schemas/input_schema.py
+++ b/flowfile_core/flowfile_core/schemas/input_schema.py
@@ -898,7 +898,13 @@ class RawData(BaseModel):
             return str(pl.String())
         if types == {int, float}:
             return str(pl.Float64())
-        return str(pl.DataType.from_python(next(iter(types))))
+        value_type = next(iter(types))
+        # Nested values have no flat dtype name; the inner type is inferred at construction.
+        if issubclass(value_type, list | tuple):
+            return "List"
+        if issubclass(value_type, dict):
+            return "Struct"
+        return str(pl.DataType.from_python(value_type))
 
     @classmethod
     def from_pylist(cls, pylist: list[dict]):

--- a/flowfile_core/flowfile_core/utils/utils.py
+++ b/flowfile_core/flowfile_core/utils/utils.py
@@ -37,8 +37,9 @@ def convert_to_string(v):
 
 
 def standardize_col_dtype(vals):
-    types = set(type(val) for val in vals)
-    if len(types) == 1:
+    """Stringify a genuinely mixed-type column; nulls don't count as a type, so [1, None] stays nullable Int."""
+    types = set(type(val) for val in vals if val is not None)
+    if len(types) <= 1:
         return vals
     elif int in types and float in types:
         return vals

--- a/flowfile_core/tests/flowfile/flowfile_table/test_flow_data_engine.py
+++ b/flowfile_core/tests/flowfile/flowfile_table/test_flow_data_engine.py
@@ -5,6 +5,7 @@ from pl_fuzzy_frame_match.models import FuzzyMapping
 from flowfile_core.flowfile.flow_data_engine.flow_data_engine import FlowDataEngine, execute_polars_code
 from flowfile_core.flowfile.flow_data_engine.polars_code_parser import PolarsCodeParser, remove_comments_and_docstrings
 from flowfile_core.schemas import transform_schema
+from flowfile_core.schemas.input_schema import RawData
 
 
 def create_sample_data():
@@ -939,6 +940,42 @@ class TestPolarsCodeParserSecurity:
         )
         result = func(pl.LazyFrame({"a": [1]}))
         assert result is not None
+
+
+class TestRawDataNestedTypes:
+    """RawData -> FlowDataEngine keeps List/Struct columns nested (with nulls) instead of stringifying."""
+
+    def test_nested_columns_materialise_as_list_and_struct(self):
+        raw = RawData.from_pydict(
+            {"id": [1, 2], "tags": [["a", "b"], ["c"]], "meta": [{"k": 1}, {"k": 2}]}
+        )
+        assert [c.data_type for c in raw.columns] == ["Int64", "List", "Struct"]
+        df = FlowDataEngine(raw).collect()
+        assert df.schema["tags"] == pl.List(pl.String)
+        assert df.schema["meta"] == pl.Struct({"k": pl.Int64})
+        assert df["tags"].to_list() == [["a", "b"], ["c"]]
+
+    def test_nested_columns_with_nulls_stay_nested(self):
+        raw = RawData.from_pydict({"id": [1, 2], "tags": [["a", "b"], None], "meta": [{"k": 1}, None]})
+        assert [c.data_type for c in raw.columns] == ["Int64", "List", "Struct"]
+        df = FlowDataEngine(raw).collect()
+        assert df.schema["tags"] == pl.List(pl.String)
+        assert df.schema["meta"] == pl.Struct({"k": pl.Int64})
+        assert df["tags"].to_list() == [["a", "b"], None]
+        assert df["meta"].to_list() == [{"k": 1}, None]
+
+    def test_scalar_column_with_null_stays_nullable(self):
+        raw = RawData.from_pydict({"id": [1, None], "name": ["x", None]})
+        df = FlowDataEngine(raw).collect()
+        assert df.schema["id"] == pl.Int64
+        assert df["id"].to_list() == [1, None]
+        assert df["name"].to_list() == ["x", None]
+
+    def test_from_pylist_nested_with_nulls(self):
+        raw = RawData.from_pylist([{"id": 1, "tags": ["a"]}, {"id": 2, "tags": None}])
+        df = FlowDataEngine(raw).collect()
+        assert df.schema["tags"] == pl.List(pl.String)
+        assert df["tags"].to_list() == [["a"], None]
 
 
 if __name__ == "__main__":

--- a/flowfile_core/tests/flowfile/node_designer/corpus/insubset_nested_examples.py
+++ b/flowfile_core/tests/flowfile/node_designer/corpus/insubset_nested_examples.py
@@ -1,0 +1,33 @@
+import polars as pl
+
+from flowfile import node_designer as nd
+
+
+class UnpackSettings(nd.NodeSettings):
+    main: nd.Section = nd.Section(
+        title="Unpack",
+        column=nd.ColumnSelector(label="Column to unpack", data_types=nd.Types.Complex, required=True),
+    )
+
+
+class UnpackNode(nd.CustomNodeBase):
+    node_name: str = "Unpack Nested"
+    settings_schema: UnpackSettings = UnpackSettings()
+    example_inputs: list[dict[str, list]] = [
+        {
+            "station_id": ["a", "b"],
+            "num_docks_available": [10, 4],
+            "vehicle_types_available": [
+                [{"vehicle_type_id": "1", "count": 3}, {"vehicle_type_id": "2", "count": 1}],
+                [{"vehicle_type_id": "1", "count": 0}, {"vehicle_type_id": "2", "count": 2}],
+            ],
+            "meta": [{"region": "north", "tags": ["a", "b"]}, {"region": "south", "tags": []}],
+        },
+    ]
+    example_settings: dict[str, dict] = {
+        "main": {"column": "vehicle_types_available"},
+    }
+
+    def process(self, *inputs: pl.LazyFrame) -> pl.LazyFrame:
+        column = self.settings_schema.main.column.value
+        return inputs[0].explode(column)

--- a/flowfile_core/tests/flowfile/node_designer/test_codegen.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_codegen.py
@@ -463,3 +463,13 @@ def test_scaffolding_is_ruff_stable():
     if stable is None:
         pytest.skip("ruff not available")
     assert stable, f"generated scaffolding was not ruff-stable:\n{src}"
+
+
+def test_nested_example_data_is_ruff_stable():
+    """Nested example data (List(Struct)) renders as a ruff-stable exploded literal."""
+    state = _designer_state("insubset_nested_examples.py")
+    src = generate_source(state)
+    stable = _ruff_stable(src)
+    if stable is None:
+        pytest.skip("ruff not available")
+    assert stable, f"generated nested example data was not ruff-stable:\n{src}"

--- a/flowfile_core/tests/flowfile/node_designer/test_dry_run.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_dry_run.py
@@ -191,6 +191,19 @@ def test_dict_sample_input_mixed_int_float_promotes_to_float(monkeypatch):
     assert df["value"].to_list() == [21.0, 62.1, 1.2, 20.0]
 
 
+def test_nested_example_inputs_with_null_reach_worker_typed(monkeypatch):
+    """Parsed example_inputs with List/Struct cells and a null row stay nested, not repr() strings."""
+    code = CODE_WITH_EXAMPLES.replace(
+        '[{"a": [1, 2, 3]}]',
+        '[{"id": [1, 2], "tags": [["a", "b"], None], "meta": [{"k": 1}, None]}]',
+    )
+    df = _capture_first_input_frame(monkeypatch, DryRunRequest(code=code, sample_inputs=None))
+    assert df.schema["tags"] == pl.List(pl.String)
+    assert df.schema["meta"] == pl.Struct({"k": pl.Int64})
+    assert df["tags"].to_list() == [["a", "b"], None]
+    assert df["meta"].to_list() == [{"k": 1}, None]
+
+
 def test_example_inputs_lifted_from_code(monkeypatch):
     captured = {}
 

--- a/flowfile_core/tests/flowfile/node_designer/test_parsing.py
+++ b/flowfile_core/tests/flowfile/node_designer/test_parsing.py
@@ -438,6 +438,22 @@ def test_example_inputs_and_example_settings_round_trip():
     assert state.example_settings == {"main": {"name_column": "name", "greeting": "Hi"}}
 
 
+def test_nested_example_inputs_round_trip():
+    result = parse("insubset_nested_examples.py")
+    assert result.mode == "designer"
+    assert codes(result) == set()
+
+    (example,) = result.designer_state.example_inputs
+    assert example.data["vehicle_types_available"] == [
+        [{"vehicle_type_id": "1", "count": 3}, {"vehicle_type_id": "2", "count": 1}],
+        [{"vehicle_type_id": "1", "count": 0}, {"vehicle_type_id": "2", "count": 2}],
+    ]
+    assert example.data["meta"] == [
+        {"region": "north", "tags": ["a", "b"]},
+        {"region": "south", "tags": []},
+    ]
+
+
 def test_verbatim_escape_hatches_preserved_in_order():
     result = parse("insubset_verbatim.py")
     assert result.mode == "designer"

--- a/flowfile_core/tests/flowfile/test_core_utils.py
+++ b/flowfile_core/tests/flowfile/test_core_utils.py
@@ -71,6 +71,21 @@ class TestStandardizeColDtype:
         result = standardize_col_dtype(vals)
         assert all(isinstance(v, str) or v is None for v in result)
 
+    def test_none_does_not_count_as_a_type(self):
+        # a null next to one real type must stay a null, never the string "None"
+        assert standardize_col_dtype([1, None, 3]) == [1, None, 3]
+        assert standardize_col_dtype(["a", None]) == ["a", None]
+        assert standardize_col_dtype([None, None]) == [None, None]
+
+    def test_nested_values_with_none_preserved(self):
+        lists = [["a", "b"], None, ["c"]]
+        dicts = [{"k": 1}, None]
+        assert standardize_col_dtype(lists) == lists
+        assert standardize_col_dtype(dicts) == dicts
+
+    def test_none_still_stringified_when_genuinely_mixed(self):
+        assert standardize_col_dtype(["a", True, None]) == ["a", "True", "None"]
+
 
 class TestEnsureSimilarityDicts:
     """Test ensure_similarity_dicts function."""

--- a/flowfile_frontend/src/renderer/app/components/nodes/NodeWrapper.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/NodeWrapper.vue
@@ -2,45 +2,59 @@
 <template>
   <div v-bind="$attrs">
     <div class="custom-node-header" data="description_display" @dblclick="onTitleClick" @click.stop>
-      <div>
-        <div v-if="!editMode" class="description-display" :style="descriptionTextStyle" @click.stop>
-          <div class="edit-icon" title="Edit description" @click.stop="toggleEditMode(true)">
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-              <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-            </svg>
-          </div>
-          <pre class="description-text">{{ descriptionSummary }}</pre>
-          <span v-if="isTruncated" class="truncated-indicator" title="Click to see full description"
-            >...</span
-          >
-        </div>
-        <div
-          v-else
-          :id="props.data.id.toLocaleString()"
-          class="custom-node-header"
-          :style="overlayStyle"
-          data="description_input"
-          @click.stop
+      <div
+        v-if="!editMode"
+        class="description-display"
+        :class="{ 'description-display--placeholder': !description }"
+        @click.stop
+      >
+        <pre
+          ref="descriptionTextEl"
+          class="description-text"
+        ><template v-for="(segment, index) in displaySegments" :key="index">{{ segment }}<wbr v-if="index < displaySegments.length - 1" /></template></pre>
+        <button
+          type="button"
+          class="edit-icon"
+          aria-label="Edit description"
+          title="Edit description"
+          @click.stop="toggleEditMode(true)"
         >
-          <textarea
-            :id="props.data.id.toLocaleString()"
-            v-model="description"
-            class="description-input"
-            data="description_input"
-            @blur="toggleEditMode(false)"
-            @click.stop
-          ></textarea>
-        </div>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+          </svg>
+        </button>
+        <div v-if="isTruncated" class="description-tooltip" role="tooltip">{{ description }}</div>
+      </div>
+      <div
+        v-else
+        :id="props.data.id.toLocaleString()"
+        class="description-editor"
+        data="description_input"
+        @click.stop
+      >
+        <textarea
+          :id="props.data.id.toLocaleString()"
+          ref="descriptionInputEl"
+          v-model="description"
+          class="description-input"
+          data="description_input"
+          rows="3"
+          placeholder="Describe what this node does"
+          @blur="toggleEditMode(false)"
+          @keydown.esc.prevent="cancelEdit"
+          @click.stop
+        ></textarea>
       </div>
     </div>
     <!-- Right-click bubbles to VueFlow's node handler → the canvas ContextMenu
@@ -124,11 +138,9 @@ import type { NodeTemplate, NodeHandle } from "../../types";
 const nodeStore = useNodeStore();
 const nodeEl = ref<HTMLElement | null>(null);
 
-const mouseX = ref<number>(0);
-const mouseY = ref<number>(0);
 const editMode = ref<boolean>(false);
-
-const CHAR_LIMIT = 100;
+const descriptionTextEl = ref<HTMLElement | null>(null);
+const descriptionInputEl = ref<HTMLTextAreaElement | null>(null);
 
 interface NodeData {
   id: number;
@@ -167,25 +179,9 @@ const parameterInput = computed(() =>
   props.data.inputs.find((input) => input.kind === "parameter"),
 );
 
-const onTitleClick = (event: MouseEvent) => {
+const onTitleClick = () => {
   toggleEditMode(true);
-  mouseX.value = event.clientX;
-  mouseY.value = event.clientY;
 };
-
-const descriptionTextStyle = computed(() => {
-  const textLength = description.value.length;
-  let minWidth = "200px";
-
-  if (textLength < 20) {
-    minWidth = "100px";
-  } else if (textLength < 30) {
-    minWidth = "150px";
-  }
-  return {
-    minWidth: minWidth,
-  };
-});
 
 const handleClickOutside = (event: MouseEvent) => {
   const target = event.target as HTMLElement;
@@ -212,6 +208,7 @@ const toggleEditMode = (state: boolean) => {
   if (state) {
     descriptionAtEditStart = description.value;
     window.addEventListener("click", handleClickOutside);
+    nextTick(() => descriptionInputEl.value?.focus());
   } else {
     window.removeEventListener("click", handleClickOutside);
     if (description.value !== descriptionAtEditStart) {
@@ -220,58 +217,36 @@ const toggleEditMode = (state: boolean) => {
   }
 };
 
+const cancelEdit = () => {
+  description.value = descriptionAtEditStart;
+  toggleEditMode(false);
+};
+
 const description = ref<string>("");
 
 const getNodeDescription = async () => {
   description.value = await nodeStore.getNodeDescription(props.data.id);
 };
 
-const overlayStyle = computed(() => {
-  const overlayWidth = 400;
-  const overlayHeight = 200;
-  const buffer = 100;
+const displayText = computed(() => description.value || `${props.data.id}: ${props.data.label}`);
 
-  let left = mouseX.value + buffer;
-  let top = mouseY.value + buffer;
-
-  if (left + overlayWidth > window.innerWidth) {
-    left -= overlayWidth + 2 * buffer;
-  }
-
-  if (top + overlayHeight > window.innerHeight) {
-    top -= overlayHeight + 2 * buffer;
-  }
-
-  left = Math.max(left, buffer);
-  top = Math.max(top, buffer);
-
-  return {
-    top: `${top}px`,
-    left: `${left}px`,
-  };
+// A <wbr> follows every dot so dotted identifiers (schema.table) wrap at the
+// dot instead of overflowing the bubble or breaking mid-token.
+const displaySegments = computed(() => {
+  const parts = displayText.value.split(".");
+  return parts.map((part, index) => (index < parts.length - 1 ? `${part}.` : part));
 });
 
-const isTruncated = computed(() => {
-  try {
-    return description.value.length > CHAR_LIMIT;
-  } catch (error) {
-    return false;
-  }
-});
+// The text is CSS line-clamped; measure whether the clamp actually cut
+// anything so the full-text tooltip only appears when there is more to see.
+const isTruncated = ref(false);
+const measureTruncation = async () => {
+  await nextTick();
+  const el = descriptionTextEl.value;
+  isTruncated.value = el !== null && el.scrollHeight > el.clientHeight + 1;
+};
 
-const descriptionSummary = computed(() => {
-  if (!description.value) {
-    return `${props.data.id}: ${props.data.label}`;
-  }
-
-  if (isTruncated.value) {
-    const truncatePoint = description.value.lastIndexOf(" ", CHAR_LIMIT);
-    const endPoint = truncatePoint > 0 ? truncatePoint : CHAR_LIMIT;
-    return description.value.substring(0, endPoint);
-  }
-
-  return description.value;
-});
+watch([displayText, editMode], measureTruncation);
 
 function getHandleStyle(index: number, total: number) {
   const topMargin = 30;
@@ -307,6 +282,7 @@ watch(
 onMounted(async () => {
   await nextTick();
   await getNodeDescription();
+  await measureTruncation();
 });
 
 onUnmounted(() => {
@@ -329,78 +305,131 @@ onUnmounted(() => {
   border: 2px solid #409eff;
 }
 
+/* Kept narrow so the bubble never widens the node box VueFlow measures;
+   the bubble overflows the header on purpose. */
 .custom-node-header {
-  font-weight: 100;
-  font-size: small;
   width: 20px;
-  white-space: nowrap;
   overflow: visible;
-  text-overflow: ellipsis;
   font-family: var(--font-family-base);
 }
 
 .description-display {
   position: relative;
-  white-space: normal;
-  min-width: 100px;
-  max-width: 300px;
-  width: auto;
-  padding: 2px 4px;
-  cursor: pointer;
-  background-color: var(--color-background-secondary);
-  font-family: var(--font-family-base);
   display: flex;
   align-items: flex-start;
-  gap: 4px;
-  border-radius: 4px;
+  gap: 2px;
+  width: max-content;
+  min-width: 0;
+  max-width: 240px;
+  padding: 2px 2px 2px 6px;
+  border-radius: var(--border-radius-md);
+  background-color: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.description-display:hover {
+  background-color: var(--color-background-tertiary);
   color: var(--color-text-primary);
 }
 
-.edit-icon {
-  opacity: 0;
-  transition: opacity 0.2s;
-  color: var(--color-accent);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  padding: 2px;
+.description-display--placeholder .description-text {
+  color: var(--color-text-tertiary);
 }
 
-.description-display:hover .edit-icon {
+.description-text {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  line-height: 1.35;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.edit-icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--border-radius-sm);
+  background: transparent;
+  color: var(--color-text-tertiary);
+  opacity: 0;
+  cursor: pointer;
+  transition:
+    opacity 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.description-display:hover .edit-icon,
+.edit-icon:focus-visible {
   opacity: 1;
 }
 
 .edit-icon:hover {
-  color: var(--color-accent-hover);
+  color: var(--color-accent);
 }
 
-.description-text {
-  margin: 0;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  font-family: var(--font-family-base);
+.description-tooltip {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 6px);
+  z-index: 10;
+  width: max-content;
+  max-width: 320px;
+  padding: 6px 10px;
+  border-radius: var(--border-radius-md);
+  background-color: var(--color-background-primary);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-md);
   font-size: var(--font-size-xs);
+  line-height: 1.4;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.15s ease;
 }
 
-.edit-overlay {
-  position: fixed;
-  z-index: 1000;
-  background: var(--color-background-primary);
-  border-radius: 4px;
-  box-shadow: var(--shadow-lg);
+.description-display:hover .description-tooltip {
+  visibility: visible;
+  opacity: 1;
 }
 
 .description-input {
-  width: 200px;
-  height: 75px;
+  display: block;
+  width: 240px;
+  min-height: 64px;
+  padding: 6px 8px;
   resize: both;
-  padding: 4px;
   border: 1px solid var(--color-accent);
-  border-radius: 4px;
-  font-size: small;
-  font-family: var(--font-family-base);
+  border-radius: var(--border-radius-md);
   background-color: var(--color-background-primary);
   color: var(--color-text-primary);
+  box-shadow: var(--shadow-sm);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+  outline: none;
+}
+
+.description-input:focus {
+  box-shadow: 0 0 0 3px var(--color-focus-ring-accent);
 }
 
 .handle-input {

--- a/flowfile_frontend/src/renderer/app/components/nodes/baseNode/selectComponents/nodeSelectLogic.test.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/baseNode/selectComponents/nodeSelectLogic.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { applySelectPositions, createSelectInput } from "./nodeSelectLogic";
+import {
+  applySelectPositions,
+  createSelectInput,
+  restoreSourceType,
+  sourceTypesFromSchema,
+} from "./nodeSelectLogic";
 import type { FileColumn, SelectInput } from "../../../../types/node.types";
 
 const column = (name: string, data_type: string): FileColumn => ({ name, data_type }) as FileColumn;
@@ -106,5 +111,45 @@ describe("applySelectPositions", () => {
     expect(result).toBe(inputs);
     expect(result[0]).toBe(second);
     expect(result[1]).toBe(first);
+  });
+});
+
+describe("sourceTypesFromSchema", () => {
+  it("maps upstream column names to their data types", () => {
+    expect(sourceTypesFromSchema([column("a", "Int64"), column("b", "String")])).toEqual({
+      a: "Int64",
+      b: "String",
+    });
+  });
+
+  it("is empty when the upstream schema is unknown", () => {
+    expect(sourceTypesFromSchema(undefined)).toEqual({});
+  });
+});
+
+describe("restoreSourceType", () => {
+  it("puts the source type back and clears the type-change flags in place", () => {
+    const selectInput = input("a", "String", 0);
+    selectInput.data_type_change = true;
+    selectInput.is_altered = true;
+
+    const result = restoreSourceType(selectInput, "Int64");
+
+    expect(result).toBe(selectInput);
+    expect(selectInput.data_type).toBe("Int64");
+    expect(selectInput.data_type_change).toBe(false);
+    expect(selectInput.is_altered).toBe(false);
+  });
+
+  it("keeps is_altered when the column is also renamed", () => {
+    const selectInput = input("a", "String", 0);
+    selectInput.new_name = "renamed";
+    selectInput.data_type_change = true;
+    selectInput.is_altered = true;
+
+    restoreSourceType(selectInput, "Int64");
+
+    expect(selectInput.data_type_change).toBe(false);
+    expect(selectInput.is_altered).toBe(true);
   });
 });

--- a/flowfile_frontend/src/renderer/app/components/nodes/baseNode/selectComponents/nodeSelectLogic.ts
+++ b/flowfile_frontend/src/renderer/app/components/nodes/baseNode/selectComponents/nodeSelectLogic.ts
@@ -82,6 +82,20 @@ export const applySelectPositions = (
   return selectInputs;
 };
 
+/** old_name → upstream data type, so a picker can offer "restore the source type". */
+export const sourceTypesFromSchema = (
+  tableSchema: FileColumn[] | undefined,
+): Record<string, string> =>
+  Object.fromEntries((tableSchema ?? []).map((column) => [column.name, column.data_type]));
+
+/** Undo a data-type edit in place, keeping the same flag contract as applySelectPositions. */
+export const restoreSourceType = (selectInput: SelectInput, sourceType: string): SelectInput => {
+  selectInput.data_type = sourceType;
+  selectInput.data_type_change = false;
+  selectInput.is_altered = selectInput.old_name !== selectInput.new_name;
+  return selectInput;
+};
+
 export const createNodeSelect = (
   flowId = -1,
   nodeId = -1,

--- a/flowfile_frontend/src/renderer/app/components/nodes/baseNode/selectComponents/selectDynamic.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/baseNode/selectComponents/selectDynamic.vue
@@ -56,6 +56,16 @@
             />
           </div>
           <div class="column-list-actions">
+            <button
+              v-if="props.showDataType && revertableColumns.length > 0"
+              class="btn btn-sm btn-ghost"
+              type="button"
+              :title="`Revert all ${revertableColumns.length} data type changes to the source types`"
+              @mousedown.prevent
+              @click="revertAllTypes()"
+            >
+              Revert types
+            </button>
             <template v-if="props.showKeepOption">
               <button
                 class="btn btn-sm btn-ghost"
@@ -149,7 +159,7 @@
                   />
                 </td>
 
-                <td v-if="props.showDataType" :class="{ 'is-changed': isTypeChanged(column) }">
+                <td v-if="props.showDataType">
                   <div class="cell-with-marker">
                     <el-select v-model="column.data_type" size="small">
                       <el-option
@@ -159,13 +169,17 @@
                         :value="dataType"
                       />
                     </el-select>
-                    <span
+                    <button
                       v-if="isTypeChanged(column)"
+                      type="button"
                       class="change-marker"
-                      :title="`Data type changed from ${originalTypeOf(column) ?? 'the source type'}`"
-                      aria-label="Data type changed"
-                      >●</span
+                      :aria-label="markerLabel(column)"
+                      @mouseenter="showTypeCard(column, $event)"
+                      @mouseleave="scheduleHideTypeCard"
+                      @click.stop="revertColumnType(column)"
                     >
+                      ●
+                    </button>
                   </div>
                 </td>
 
@@ -194,6 +208,33 @@
       <button :disabled="!canMove('down')" @click="moveSelectedTo('down')">Move down</button>
       <button :disabled="!canMove('bottom')" @click="moveSelectedTo('bottom')">
         Move to bottom
+      </button>
+    </div>
+
+    <div
+      v-if="typeCard"
+      class="context-menu type-card"
+      :style="{ top: typeCard.y + 'px', right: typeCard.right + 'px' }"
+      @mouseenter="cancelHideTypeCard"
+      @mouseleave="scheduleHideTypeCard"
+    >
+      <div class="type-card-title">{{ typeCard.column.old_name }}</div>
+      <dl class="type-card-detail">
+        <dt>From</dt>
+        <dd>{{ originalTypeOf(typeCard.column) ?? "unknown source type" }}</dd>
+        <dt>To</dt>
+        <dd>{{ typeCard.column.data_type }}</dd>
+      </dl>
+      <div v-if="originalTypeOf(typeCard.column) === undefined" class="type-card-hint">
+        Source type unknown until this node's input has a schema
+      </div>
+      <button
+        v-else
+        type="button"
+        class="type-card-revert"
+        @click="revertColumnType(typeCard.column)"
+      >
+        Click to revert
       </button>
     </div>
   </div>
@@ -225,6 +266,7 @@ import {
   type SelectionState,
   type SortDirection,
 } from "./columnSelection";
+import { restoreSourceType } from "./nodeSelectLogic";
 
 const props = withDefaults(
   defineProps<{
@@ -237,6 +279,8 @@ const props = withDefaults(
     showHeaders?: boolean;
     showTitle?: boolean;
     originalColumnHeader?: string;
+    /** old_name → upstream data type; lets the change marker restore it. */
+    sourceTypes?: Record<string, string>;
   }>(),
   {
     selectInputs: () => [],
@@ -248,6 +292,7 @@ const props = withDefaults(
     showHeaders: true,
     showTitle: true,
     originalColumnHeader: "Original column name",
+    sourceTypes: () => ({}),
   },
 );
 
@@ -291,7 +336,8 @@ const toggleSort = () => {
  * an unsaved edit shows up immediately. A column that arrives already carrying a
  * saved type change has no recoverable source type here — `data_type_change` is
  * the persisted signal for those. (`is_altered` is not: the backend also sets it
- * for a plain rename.)
+ * for a plain rename.) A parent that knows the upstream schema passes
+ * `sourceTypes` instead, which also makes saved changes restorable.
  */
 const sourceDataTypes = new Map<string, string | undefined>();
 
@@ -303,11 +349,70 @@ const rememberSourceTypes = (inputs: readonly SelectInput[]) => {
   });
 };
 
-const originalTypeOf = (column: SelectInput) => sourceDataTypes.get(column.old_name);
+const originalTypeOf = (column: SelectInput) =>
+  props.sourceTypes[column.old_name] ?? sourceDataTypes.get(column.old_name);
 
 const isTypeChanged = (column: SelectInput) => {
-  const source = sourceDataTypes.get(column.old_name);
+  const source = originalTypeOf(column);
   return source === undefined ? Boolean(column.data_type_change) : source !== column.data_type;
+};
+
+const markerLabel = (column: SelectInput) => {
+  const source = originalTypeOf(column);
+  return source === undefined
+    ? `Data type changed from the source type to ${column.data_type}`
+    : `Data type changed from ${source} to ${column.data_type}. Click to revert.`;
+};
+
+/**
+ * Hover card under the change marker. Hiding is delayed so the pointer can
+ * travel from the marker into the card (or past it) without it vanishing.
+ */
+const typeCard = ref<{ column: SelectInput; right: number; y: number } | null>(null);
+let hideTypeCardTimer: ReturnType<typeof setTimeout> | null = null;
+
+const cancelHideTypeCard = () => {
+  if (hideTypeCardTimer) clearTimeout(hideTypeCardTimer);
+  hideTypeCardTimer = null;
+};
+
+const showTypeCard = (column: SelectInput, event: MouseEvent) => {
+  cancelHideTypeCard();
+  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+  // Right-anchored to the marker: long type names grow leftwards, never off-screen.
+  typeCard.value = {
+    column,
+    right: Math.max(8, window.innerWidth - rect.right),
+    y: rect.bottom + 4,
+  };
+};
+
+const hideTypeCard = () => {
+  cancelHideTypeCard();
+  typeCard.value = null;
+};
+
+const scheduleHideTypeCard = () => {
+  cancelHideTypeCard();
+  hideTypeCardTimer = setTimeout(hideTypeCard, 400);
+};
+
+const revertableColumns = computed(() =>
+  localSelectInputs.value.filter(
+    (column) => isTypeChanged(column) && originalTypeOf(column) !== undefined,
+  ),
+);
+
+const revertColumnType = (column: SelectInput) => {
+  const source = originalTypeOf(column);
+  if (source !== undefined) restoreSourceType(column, source);
+  hideTypeCard();
+};
+
+const revertAllTypes = () => {
+  revertableColumns.value.forEach((column) => {
+    restoreSourceType(column, originalTypeOf(column) as string);
+  });
 };
 
 // State and Store
@@ -535,6 +640,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener("click", handleClickOutside);
+  cancelHideTypeCard();
 });
 
 // Emit and Expose
@@ -578,6 +684,58 @@ const removeMissingFields = () => {
 
 .context-menu button:hover {
   background-color: var(--color-background-hover);
+}
+
+.type-card {
+  min-width: 200px;
+  max-width: 320px;
+}
+
+.type-card-title {
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.type-card-detail {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 8px;
+  row-gap: 2px;
+  margin: 0;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
+.type-card-detail dt {
+  color: var(--color-text-secondary);
+}
+
+.type-card-detail dd {
+  margin: 0;
+  color: var(--color-text-primary);
+  overflow-wrap: anywhere;
+}
+
+.type-card-hint {
+  padding: 4px 8px 2px;
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.type-card-revert {
+  display: block;
+  padding: 4px 8px 2px;
+  border: none;
+  background: none;
+  font-size: 11px;
+  color: var(--color-accent);
+  cursor: pointer;
+}
+
+.type-card-revert:hover {
+  text-decoration: underline;
 }
 
 /* Overrides only — shadow/radius/margin come from the shared .table-wrapper */

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/NotebookDataTable.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/pythonScript/NotebookDataTable.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 // Read-only AG Grid table for flowfile_ctx.display(df), mirroring dataPreview.vue.
 import { computed } from "vue";
+import { cellValueFormatter } from "../../../../../utils/cellFormat";
 import { AgGridVue } from "@ag-grid-community/vue3";
 import { ModuleRegistry } from "@ag-grid-community/core";
 import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
@@ -27,11 +28,7 @@ const columnDefs = computed(() =>
   (props.columns ?? []).map((name) => ({
     field: name,
     headerName: name,
-    // Render List/Struct cells as JSON, not "[object Object]".
-    valueFormatter: (p: { value: unknown }) =>
-      p.value !== null && typeof p.value === "object"
-        ? JSON.stringify(p.value)
-        : (p.value as string),
+    valueFormatter: cellValueFormatter,
   })),
 );
 </script>

--- a/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/select/Select.vue
+++ b/flowfile_frontend/src/renderer/app/components/nodes/node-types/elements/select/Select.vue
@@ -12,6 +12,7 @@
         :show-data-type="true"
         :show-new-columns="true"
         :show-old-columns="true"
+        :source-types="sourceTypes"
         :show-headers="true"
         :show-title="false"
         title="Select data"
@@ -27,6 +28,7 @@ import { ref } from "vue";
 import {
   applySelectPositions,
   createNodeSelect,
+  sourceTypesFromSchema,
   updateNodeSelect,
 } from "../../../baseNode/selectComponents/nodeSelectLogic";
 import { NodeSelect } from "../../../baseNode/nodeInput";
@@ -41,6 +43,7 @@ const keepMissing = ref(false);
 const nodeStore = useNodeStore();
 const nodeSelect = ref<NodeSelect>(createNodeSelect().value);
 const dataLoaded = ref(false);
+const sourceTypes = ref<Record<string, string>>({});
 
 const { saveSettings, pushNodeData, handleGenericSettingsUpdate } = useNodeSettings({
   nodeRef: nodeSelect,
@@ -58,6 +61,7 @@ const loadNodeData = async (nodeId: number) => {
   const result = await nodeStore.getNodeData(nodeId, false);
   if (result) {
     const main_input = result.main_input;
+    sourceTypes.value = sourceTypesFromSchema(main_input?.table_schema);
     try {
       if (result.setting_input && main_input && result.setting_input.is_setup) {
         nodeSelect.value = result.setting_input;

--- a/flowfile_frontend/src/renderer/app/features/designer/dataPreview.vue
+++ b/flowfile_frontend/src/renderer/app/features/designer/dataPreview.vue
@@ -133,6 +133,7 @@ import ArtifactsPanel from "./ArtifactsPanel.vue";
 import debounce from "lodash/debounce";
 import { TableExample, FileColumn } from "../../components/nodes/baseNode/nodeInterfaces";
 import { NodeApi } from "../../api/node.api";
+import { cellValueFormatter, formatCellValue } from "../../utils/cellFormat";
 import { useNodeStore } from "../../stores/column-store";
 import { useFlowStore } from "../../stores/flow-store";
 import { useFlowExecution } from "./composables/useFlowExecution";
@@ -275,8 +276,7 @@ const defaultColDef = {
 // a newline becomes a row break). Wrap in double-quotes and double any existing
 // quotes — matches what Excel and Google Sheets emit when copying.
 const serializeCell = (v: unknown): string => {
-  if (v === null || v === undefined) return "";
-  const raw = typeof v === "object" ? JSON.stringify(v) : String(v);
+  const raw = formatCellValue(v);
   if (/[\t\n\r"]/.test(raw)) {
     return `"${raw.replace(/"/g, '""')}"`;
   }
@@ -475,6 +475,7 @@ async function downloadData(nodeId: number) {
         headerName: item.name,
         resizable: true,
         headerComponentParams: { dataType: item.data_type },
+        valueFormatter: cellValueFormatter,
       }));
 
       if (resp.has_example_data === false) {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/WorkspaceTabs.vue
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/designer/WorkspaceTabs.vue
@@ -25,7 +25,7 @@
       </el-tab-pane>
 
       <el-tab-pane label="Code" name="code">
-        <div class="code-tab-layout">
+        <div class="code-tab-layout" :class="{ 'code-only': store.codeOnly }">
           <FormFieldsOverview v-if="!store.codeOnly" @insert="handleInsertVariable" />
           <div class="code-editor-column">
             <div v-if="store.codeOnly" class="code-only-banner">
@@ -314,6 +314,11 @@ function handleInsertVariable(code: string) {
   height: 100%;
   min-height: 0;
   padding-bottom: 0.75rem;
+}
+
+/* Code-only mode drops the field overview, so the editor takes the full width. */
+.code-tab-layout.code-only {
+  grid-template-columns: 1fr;
 }
 
 .code-editor-column {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/sampleData.test.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/sampleData.test.ts
@@ -98,6 +98,43 @@ describe("columnDataToTable", () => {
     const original = { a: [1, 2, 3], b: ["x", "y", "z"] };
     expect(tableToColumnData(columnDataToTable(original))).toEqual(original);
   });
+
+  it("round trips nested list/struct example values without flattening them", () => {
+    const original = {
+      station_id: ["a", "b"],
+      vehicle_types_available: [
+        [
+          { vehicle_type_id: "1", count: 3 },
+          { vehicle_type_id: "2", count: 1 },
+        ],
+        [{ vehicle_type_id: "1", count: 0 }],
+      ],
+      meta: [
+        { region: "north", tags: ["a", "b"] },
+        { region: "south", tags: [] },
+      ],
+    };
+    const table = columnDataToTable(original);
+    expect(table.columns).toEqual([
+      { name: "station_id", dtype: "str" },
+      { name: "vehicle_types_available", dtype: "list" },
+      { name: "meta", dtype: "struct" },
+    ]);
+    expect(tableToColumnData(table)).toEqual(original);
+    expect(tableToRawData(table).columns).toEqual([
+      { name: "station_id", data_type: "String" },
+      { name: "vehicle_types_available", data_type: "List" },
+      { name: "meta", data_type: "Struct" },
+    ]);
+  });
+
+  it("coerces an unparseable nested cell to null instead of a string", () => {
+    const table: SampleTable = {
+      columns: [{ name: "items", dtype: "list" }],
+      rows: [{ items: "[1, 2]" }, { items: "not json" }],
+    };
+    expect(tableToColumnData(table)).toEqual({ items: [[1, 2], null] });
+  });
 });
 
 describe("sampleColumnsToFileColumns", () => {

--- a/flowfile_frontend/src/renderer/app/pages/nodeDesigner/sampleData.ts
+++ b/flowfile_frontend/src/renderer/app/pages/nodeDesigner/sampleData.ts
@@ -5,9 +5,26 @@
 
 import type { FileColumn } from "@/types";
 
-export type SampleDtype = "str" | "int" | "float" | "bool" | "date" | "datetime";
+export type SampleDtype =
+  | "str"
+  | "int"
+  | "float"
+  | "bool"
+  | "date"
+  | "datetime"
+  | "list"
+  | "struct";
 
-export const SAMPLE_DTYPES: SampleDtype[] = ["str", "int", "float", "bool", "date", "datetime"];
+export const SAMPLE_DTYPES: SampleDtype[] = [
+  "str",
+  "int",
+  "float",
+  "bool",
+  "date",
+  "datetime",
+  "list",
+  "struct",
+];
 
 export const MAX_SAMPLE_ROWS = 100;
 export const MAX_SAMPLE_COLS = 25;
@@ -41,6 +58,15 @@ export function coerceCell(raw: string, dtype: SampleDtype): unknown {
       if (["true", "1", "yes", "y"].includes(lowered)) return true;
       if (["false", "0", "no", "n"].includes(lowered)) return false;
       return null;
+    }
+    case "list":
+    case "struct": {
+      // Nested cells are edited as JSON text; unparseable text becomes a null cell.
+      try {
+        return JSON.parse(value);
+      } catch {
+        return null;
+      }
     }
     case "str":
     case "date":
@@ -84,6 +110,8 @@ function inferDtype(values: unknown[]): SampleDtype {
   if (nonNull.every((v) => typeof v === "boolean")) return "bool";
   if (nonNull.every((v) => typeof v === "number" && Number.isInteger(v))) return "int";
   if (nonNull.every((v) => typeof v === "number")) return "float";
+  if (nonNull.every((v) => Array.isArray(v))) return "list";
+  if (nonNull.every((v) => typeof v === "object")) return "struct";
   return "str";
 }
 
@@ -97,11 +125,17 @@ export function columnDataToTable(data: Record<string, unknown[]>): SampleTable 
     const row: Record<string, string> = {};
     for (const name of names) {
       const cell = data[name][r];
-      row[name] = cell === null || cell === undefined ? "" : String(cell);
+      row[name] = formatCell(cell);
     }
     rows.push(row);
   }
   return { columns, rows };
+}
+
+function formatCell(cell: unknown): string {
+  if (cell === null || cell === undefined) return "";
+  if (typeof cell === "object") return JSON.stringify(cell);
+  return String(cell);
 }
 
 /** Parse CSV/TSV text into a grid table (first row = header). Auto-sniffs delimiter. */
@@ -168,6 +202,8 @@ const SAMPLE_DTYPE_TO_POLARS: Record<SampleDtype, string> = {
   bool: "Boolean",
   date: "Date",
   datetime: "Datetime",
+  list: "List",
+  struct: "Struct",
 };
 
 // The grid's coarse dtype -> its readable data_type_group, mirroring the backend
@@ -179,6 +215,8 @@ const SAMPLE_DTYPE_TO_GROUP: Record<SampleDtype, string> = {
   bool: "Boolean",
   date: "Date",
   datetime: "Date",
+  list: "Complex",
+  struct: "Complex",
 };
 
 /** SampleColumns -> typed FileColumns for column-driven controls (ColumnSelector, …). */

--- a/flowfile_frontend/src/renderer/app/utils/cellFormat.test.ts
+++ b/flowfile_frontend/src/renderer/app/utils/cellFormat.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { cellValueFormatter, formatCellValue } from "./cellFormat";
+
+describe("formatCellValue", () => {
+  it("renders nested lists of structs as JSON instead of [object Object]", () => {
+    const cell = [[{ vehicle_type_id: "1", count: 3 }], [{ vehicle_type_id: "2", count: 0 }]];
+    const expected = '[[{"vehicle_type_id":"1","count":3}],[{"vehicle_type_id":"2","count":0}]]';
+    expect(formatCellValue(cell)).toBe(expected);
+    expect(formatCellValue({ a: 1 })).toBe('{"a":1}');
+  });
+
+  it("keeps primitive lists unambiguous", () => {
+    expect(formatCellValue(["a", "b"])).toBe('["a","b"]');
+    expect(formatCellValue([10, 4])).toBe("[10,4]");
+  });
+
+  it("leaves scalars and nulls as AG Grid would show them", () => {
+    expect(formatCellValue(10)).toBe("10");
+    expect(formatCellValue(false)).toBe("false");
+    expect(formatCellValue("x")).toBe("x");
+    expect(formatCellValue(null)).toBe("");
+    expect(formatCellValue(undefined)).toBe("");
+  });
+});
+
+describe("cellValueFormatter", () => {
+  it("adapts formatCellValue to AG Grid's valueFormatter signature", () => {
+    expect(cellValueFormatter({ value: [{ k: 1 }] })).toBe('[{"k":1}]');
+    expect(cellValueFormatter({ value: null })).toBe("");
+  });
+});

--- a/flowfile_frontend/src/renderer/app/utils/cellFormat.ts
+++ b/flowfile_frontend/src/renderer/app/utils/cellFormat.ts
@@ -1,0 +1,9 @@
+// AG Grid renders cells with String(value), so a List/Struct cell that arrives
+// as a JSON array/object would show as "[object Object]". Format those as JSON.
+export const formatCellValue = (value: unknown): string => {
+  if (value === null || value === undefined) return "";
+  return typeof value === "object" ? JSON.stringify(value) : String(value);
+};
+
+export const cellValueFormatter = (params: { value: unknown }): string =>
+  formatCellValue(params.value);

--- a/flowfile_frontend/src/renderer/app/views/CatalogView/TableEditorDialog.vue
+++ b/flowfile_frontend/src/renderer/app/views/CatalogView/TableEditorDialog.vue
@@ -182,6 +182,7 @@ import "@ag-grid-community/styles/ag-theme-balham.css";
 import type { CatalogTable, NewColumnDtype, NewColumnSpec } from "../../types";
 import { CatalogApi } from "../../api/catalog.api";
 import { catalogSaveErrorMessage } from "../../composables/saveError";
+import { cellValueFormatter } from "../../utils/cellFormat";
 import TableLabelingMode from "./TableLabelingMode.vue";
 import {
   applyCellEdit,
@@ -284,6 +285,7 @@ const columnDefs = computed<ColDef[]>(() => {
     field: col.name,
     headerName: col.name,
     headerTooltip: col.dtype,
+    valueFormatter: cellValueFormatter,
     checkboxSelection: index === 0,
     headerCheckboxSelection: index === 0,
     cellClass: session.keyColumns.includes(col.name) ? "editor-key-cell" : undefined,

--- a/flowfile_frontend/src/renderer/app/views/DesignerView/NodeSettingsDrawer.vue
+++ b/flowfile_frontend/src/renderer/app/views/DesignerView/NodeSettingsDrawer.vue
@@ -8,7 +8,7 @@
     <div class="node-settings-body">
       <component
         :is="nodeStore.activeDrawerComponent"
-        v-bind="nodeStore.drawerProps"
+        v-bind="componentProps"
         ref="drawerComponentInstance"
         :node-id="nodeStore.node_id"
       />
@@ -36,6 +36,16 @@ interface DrawerComponentInstance {
 }
 
 const nodeStore = useNodeStore();
+
+// Header-only keys must not reach the node component: they would fall through
+// as DOM attributes, and a native `title` tooltip then follows the pointer
+// anywhere inside the drawer.
+const HEADER_ONLY_KEYS = new Set(["title", "intro", "docsUrl"]);
+const componentProps = computed(() =>
+  Object.fromEntries(
+    Object.entries(nodeStore.drawerProps).filter(([key]) => !HEADER_ONLY_KEYS.has(key)),
+  ),
+);
 const editorStore = useEditorStore();
 const drawerComponentInstance = ref<DrawerComponentInstance | null>(null);
 

--- a/flowfile_frontend/src/renderer/styles/components/_column-list.css
+++ b/flowfile_frontend/src/renderer/styles/components/_column-list.css
@@ -246,7 +246,8 @@
 
 /* ===== Edited-cell marker =====
  * A column whose data type differs from the source is worth spotting at a
- * glance — otherwise a one-cell edit is invisible in a 20-row table. */
+ * glance — otherwise a one-cell edit is invisible in a 20-row table. Hovering
+ * the marker shows the change; clicking it reverts to the source type. */
 .column-list .cell-with-marker {
   display: flex;
   align-items: center;
@@ -261,14 +262,17 @@
 
 .column-list .change-marker {
   flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: none;
   font-size: var(--font-size-2xs);
   line-height: 1;
   color: var(--color-accent);
-  cursor: default;
+  cursor: pointer;
 }
 
-.column-list td.is-changed {
-  box-shadow: inset 0 -2px 0 0 var(--color-accent);
+.column-list .change-marker:hover {
+  opacity: 0.6;
 }
 
 /* ===== Drop indicator =====

--- a/flowfile_worker/flowfile_worker/create/utils.py
+++ b/flowfile_worker/flowfile_worker/create/utils.py
@@ -61,8 +61,9 @@ def convert_to_string(v):
 
 
 def standardize_col_dtype(vals):
-    types = set(type(val) for val in vals)
-    if len(types) == 1:
+    """Stringify a genuinely mixed-type column; nulls don't count as a type, so [1, None] stays nullable Int."""
+    types = set(type(val) for val in vals if val is not None)
+    if len(types) <= 1:
         return vals
     elif int in types and float in types:
         return vals

--- a/flowfile_worker/tests/test_create_utils.py
+++ b/flowfile_worker/tests/test_create_utils.py
@@ -61,6 +61,11 @@ class TestStandardizeColDtype:
         result = standardize_col_dtype(vals)
         assert all(isinstance(v, str) or v is None for v in result)
 
+    def test_none_does_not_count_as_a_type(self):
+        assert standardize_col_dtype([1, None, 3]) == [1, None, 3]
+        assert standardize_col_dtype([["a"], None]) == [["a"], None]
+        assert standardize_col_dtype([{"k": 1}, None]) == [{"k": 1}, None]
+
 
 class TestCreatePlDfTypeSave:
     """Test create_pl_df_type_save function."""


### PR DESCRIPTION
This pull request introduces improvements for handling nested and complex data types in both the backend (Python core) and frontend (Vue UI), as well as enhanced test coverage for these changes. The most significant updates are improved support for nested example data in node designer parsing and round-tripping, more robust schema inference for complex types, and a better user experience for editing and displaying node descriptions.

**Backend: Nested Data and Schema Handling**
- Improved support for nested (list/dict) example input data in the node designer parsing logic, ensuring proper validation and JSON serialization. Now, example inputs can include complex, JSON-safe values, not just scalars. [[1]](diffhunk://#diff-5dde26e5cb6b9660b90e23c0d60e2d6c107ad774d626b9a869970efb350bf2beL1000-R1007) [[2]](diffhunk://#diff-5b7edafc85db151ef8f328e1d905953ace45a9266dd63bee680baefbda663ea8L145-R145)
- Updated schema inference to recognize nested Python types: lists/tuples are treated as "List", dicts as "Struct", and only flat types are passed to Polars directly. This prevents errors and allows for more flexible data modeling.
- Added `_minimal_field_dtype` to ensure Polars schema construction works with nested types by allowing type inference for complex fields. [[1]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aR82-R93) [[2]](diffhunk://#diff-d057aec936c633f864e65130a2af5c272131ea3fe5c3687d83599c81723d019aL380-R392)

**Backend: Tests for Nested Example Data**
- Added a new test node (`insubset_nested_examples.py`) and corresponding round-trip and codegen tests to verify that nested example data is correctly parsed, rendered, and remains stable under code formatting tools. [[1]](diffhunk://#diff-67db2695fd15f3b78b569f8cee0e8d2be8045933f639fded336ed4d5243403daR1-R33) [[2]](diffhunk://#diff-47dab521b98afbc3fa6f4c78afe38a9f0a39640e81d56a216f086cc070939d76R441-R456) [[3]](diffhunk://#diff-21dd5f30dd6e002c711c80579c5a8967a4ac21f0f8d562f585df4f8f34699d78R466-R475)

**Frontend: Node Description Editing and Display**
- Refactored the node description editor to improve accessibility, UX, and presentation: the description is now line-clamped, with a tooltip for truncated content, and the edit icon is more discoverable. Editing is more robust, including focus management, placeholder text, and escape-to-cancel. [[1]](diffhunk://#diff-f43b8b8ba0651b383a8a052064dbe946a2738bed9fc7ba917a14c6cf89eced12L5-R21) [[2]](diffhunk://#diff-f43b8b8ba0651b383a8a052064dbe946a2738bed9fc7ba917a14c6cf89eced12R31-L45) [[3]](diffhunk://#diff-f43b8b8ba0651b383a8a052064dbe946a2738bed9fc7ba917a14c6cf89eced12L127-R143) [[4]](diffhunk://#diff-f43b8b8ba0651b383a8a052064dbe946a2738bed9fc7ba917a14c6cf89eced12L170-L188) [[5]](diffhunk://#diff-f43b8b8ba0651b383a8a052064dbe946a2738bed9fc7ba917a14c6cf89eced12R211) [[6]](diffhunk://#diff-f43b8b8ba0651b383a8a052064dbe946a2738bed9fc7ba917a14c6cf89eced12R220-R249) [[7]](diffhunk://#diff-f43b8b8ba0651b383a8a052064dbe946a2738bed9fc7ba917a14c6cf89eced12R308-R432) [[8]](diffhunk://#diff-f43b8b8ba0651b383a8a052064dbe946a2738bed9fc7ba917a14c6cf89eced12R285)

**Frontend: Select Input Logic Tests**
- Added tests for new utility functions handling select input types, ensuring correct mapping and restoration of data types from upstream schemas. [[1]](diffhunk://#diff-74a2079eae18b14e9001fee0d9350ef60f6a8cff2a9724c73b2b908af1df9ca2L2-R7) [[2]](diffhunk://#diff-74a2079eae18b14e9001fee0d9350ef60f6a8cff2a9724c73b2b908af1df9ca2R116-R155)

These changes collectively improve support for complex data structures, robustness of schema handling, and user interaction with node metadata in the UI.